### PR TITLE
Allows using & before stats to only display the icon with its color

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/generator/StringColorParser.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/StringColorParser.java
@@ -111,11 +111,17 @@ public class StringColorParser {
                         extraData = selectedCommand.substring(specialFlagIndex + 1);
                         selectedCommand = selectedCommand.substring(0, specialFlagIndex);
                     }
+                    // checking if the command is supposed to be the icon
+                    boolean isIcon = selectedCommand.indexOf('&') == 0;
+                    if (isIcon) {
+                        selectedCommand = selectedCommand.substring(1);
+                    }
+
                     // checking if the command is a stat
                     Stat stat = (Stat) findValue(stats, selectedCommand);
                     if (stat != null) {
                         // replacing the selected space with the stat's text
-                        String replacementText = stat.getParsedStat(extraData) + "%%GRAY%%";
+                        String replacementText = stat.getParsedStat(isIcon, extraData) + "%%GRAY%%";
                         description.replace(charIndex, closingIndex + 2, replacementText);
                         continue;
                     }
@@ -300,7 +306,7 @@ public class StringColorParser {
     }
 
     private static String stripString(String normalString) {
-        return normalString.replaceAll("[^a-zA-Z0-9_ ]", "");
+        return normalString.replaceAll("[^a-zA-Z0-9_ &]", "");
     }
 
 }

--- a/src/main/java/net/hypixel/nerdbot/generator/StringColorParser.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/StringColorParser.java
@@ -306,7 +306,7 @@ public class StringColorParser {
     }
 
     private static String stripString(String normalString) {
-        return normalString.replaceAll("[^a-zA-Z0-9_ &]", "");
+        return normalString.replaceAll("[^a-zA-Z0-9_ ]", "");
     }
 
 }

--- a/src/main/java/net/hypixel/nerdbot/util/skyblock/Stat.java
+++ b/src/main/java/net/hypixel/nerdbot/util/skyblock/Stat.java
@@ -5,60 +5,64 @@ import net.hypixel.nerdbot.generator.StatColorParser;
 import java.util.function.BiFunction;
 
 public enum Stat {
-    STRENGTH("❁ Strength", MCColor.RED),
-    DAMAGE("❁ Damage", MCColor.RED),
-    HEALTH("❤ Health", MCColor.RED, MCColor.GREEN, StatColorParser::normalStatColorParser),
-    DEFENSE("❈ Defense", MCColor.GREEN),
-    TRUE_DEFENSE("❂ True Defense", MCColor.WHITE),
-    SPEED("✦ Speed", MCColor.WHITE, MCColor.GREEN, StatColorParser::normalStatColorParser),
-    INTELLIGENCE("✎ Intelligence", MCColor.AQUA),
-    CRIT_CHANCE("☣ Critical Chance", MCColor.BLUE),
-    CRIT_DAMAGE("☠ Critical Damage", MCColor.BLUE),
-    ATTACK_SPEED("⚔ Bonus Attack Speed", MCColor.YELLOW, MCColor.GREEN, StatColorParser::normalStatColorParser),
-    FEROCITY("⫽ Ferocity", MCColor.RED),
-    MAGIC_FIND("✯ Magic Find", MCColor.AQUA),
-    PET_LUCK("♣ Pet Luck", MCColor.LIGHT_PURPLE, MCColor.WHITE, StatColorParser::normalStatColorParser),
-    SEA_CREATURE_CHANCE("α Sea Creature Chance", MCColor.DARK_AQUA),
-    ABILITY_DAMAGE("๑ Ability Damage", MCColor.RED),
-    MINING_SPEED("⸕ Mining Speed", MCColor.GOLD),
-    PRISTINE("✧ Pristine", MCColor.DARK_PURPLE),
-    MINING_FORTUNE("☘ Mining Fortune", MCColor.GOLD),
-    FARMING_FORTUNE("☘ Farming Fortune", MCColor.GOLD),
-    FORAGING_FORTUNE("☘ Foraging Fortune", MCColor.GOLD),
-    SOULFLOW("⸎ Soulflow", MCColor.DARK_AQUA),
-    RECIPE("Right-click to view recipes!", MCColor.YELLOW),
-    REQUIRE("❣ Requires", MCColor.RED, StatColorParser::postStatColorParser),
-    REFORGABLE("This item can be reforged!", MCColor.DARK_GRAY),
-    ITEM_STAT_RED("ITEM_STAT_RED", MCColor.GRAY, MCColor.RED, StatColorParser::itemStatColorParser),
-    ITEM_STAT_GREEN("ITEM_STAT_GREEN", MCColor.GRAY, MCColor.GREEN, StatColorParser::itemStatColorParser),
-    ITEM_STAT_PURPLE("ITEM_STAT_PINK", MCColor.GRAY, MCColor.LIGHT_PURPLE, StatColorParser::itemStatColorParser);
+    STRENGTH("❁", "Strength", MCColor.RED),
+    DAMAGE("❁", "Damage", MCColor.RED),
+    HEALTH("❤", "Health", MCColor.RED, MCColor.GREEN, StatColorParser::normalStatColorParser),
+    DEFENSE("❈", "Defense", MCColor.GREEN),
+    TRUE_DEFENSE("❂", "True Defense", MCColor.WHITE),
+    SPEED("✦", "Speed", MCColor.WHITE, MCColor.GREEN, StatColorParser::normalStatColorParser),
+    INTELLIGENCE("✎", "Intelligence", MCColor.AQUA),
+    CRIT_CHANCE("☣", "Critical Chance", MCColor.BLUE),
+    CRIT_DAMAGE("☠", "Critical Damage", MCColor.BLUE),
+    ATTACK_SPEED("⚔", "Bonus Attack Speed", MCColor.YELLOW, MCColor.GREEN, StatColorParser::normalStatColorParser),
+    FEROCITY("⫽", "Ferocity", MCColor.RED),
+    MAGIC_FIND("✯", "Magic Find", MCColor.AQUA),
+    PET_LUCK("♣", "Pet Luck", MCColor.LIGHT_PURPLE, MCColor.WHITE, StatColorParser::normalStatColorParser),
+    SEA_CREATURE_CHANCE("α", "Sea Creature Chance", MCColor.DARK_AQUA),
+    ABILITY_DAMAGE("๑", "Ability Damage", MCColor.RED),
+    MINING_SPEED("⸕", "Mining Speed", MCColor.GOLD),
+    PRISTINE("✧", "Pristine", MCColor.DARK_PURPLE),
+    MINING_FORTUNE("☘", "Mining Fortune", MCColor.GOLD),
+    FARMING_FORTUNE("☘", "Farming Fortune", MCColor.GOLD),
+    FORAGING_FORTUNE("☘", "Foraging Fortune", MCColor.GOLD),
+    SOULFLOW("⸎", "Soulflow", MCColor.DARK_AQUA),
+    RECIPE("", "Right-click to view recipes!", MCColor.YELLOW),
+    REQUIRE("❣",  "Requires", MCColor.RED, StatColorParser::postStatColorParser),
+    REFORGABLE("", "This item can be reforged!", MCColor.DARK_GRAY),
+    ITEM_STAT_RED("", "ITEM_STAT_RED", MCColor.GRAY, MCColor.RED, StatColorParser::itemStatColorParser),
+    ITEM_STAT_GREEN("", "ITEM_STAT_GREEN", MCColor.GRAY, MCColor.GREEN, StatColorParser::itemStatColorParser),
+    ITEM_STAT_PURPLE("", "ITEM_STAT_PINK", MCColor.GRAY, MCColor.LIGHT_PURPLE, StatColorParser::itemStatColorParser);
 
     public static final Stat[] VALUES = values();
 
+    private final String icon;
     private final String stat;
     private final MCColor color;
     private final BiFunction<Stat, String, String> statColorParser;
     // Some stats have special colors which are used in conjunction to the normal color.
     private final MCColor subColor;
 
-    Stat(String stat, MCColor color, MCColor subColor, BiFunction<Stat, String, String> statColorParser) {
-        this.stat = stat;
+    Stat(String icon, String stat, MCColor color, MCColor subColor, BiFunction<Stat, String, String> statColorParser) {
+        this.icon = icon;
+        this.stat = icon + " " + stat;
         this.color = color;
         this.subColor = subColor;
         this.statColorParser = statColorParser;
     }
 
-    Stat(String stat, MCColor color) {
-        this(stat, color, null, StatColorParser::normalStatColorParser);
+    Stat(String icon, String stat, MCColor color) {
+        this(icon, stat, color, null, StatColorParser::normalStatColorParser);
     }
 
-    Stat(String stat, MCColor color, BiFunction<Stat, String, String> statColorParser) {
-        this(stat, color, null, statColorParser);
+    Stat(String icon, String stat, MCColor color, BiFunction<Stat, String, String> statColorParser) {
+        this(icon, stat, color, null, statColorParser);
     }
 
-    Stat(String stat, MCColor color, MCColor subColor) {
-        this(stat, color, subColor, StatColorParser::dualStatColorParser);
+    Stat(String icon, String stat, MCColor color, MCColor subColor) {
+        this(icon, stat, color, subColor, StatColorParser::dualStatColorParser);
     }
+
+    public String getIcon() { return icon; }
 
     public String getId() {
         return stat;
@@ -70,10 +74,15 @@ public enum Stat {
 
     /**
      * Parses the string into its color and id components
+     * @param isIcon specifying if the stat's icon is meant to be displayed
      * @param extraData extra arguments provided in the section
      * @return returns a color parsed replacement string
      */
-    public String getParsedStat(String extraData) {
+    public String getParsedStat(boolean isIcon, String extraData) {
+        if (isIcon) {
+            return "%%" + getColor() + "%%" + getIcon();
+        }
+
         return statColorParser.apply(this, extraData);
     }
 


### PR DESCRIPTION
Users can use `%%&<StatName>%%` to display the stat's icon at the required location.
| i.e. `%%&speed%%` turns into `%%white%%✦`