### PR TITLE
Change itemgen to take an alpha value directly for the background layer

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/command/InfoGenCommand.java
+++ b/src/main/java/net/hypixel/nerdbot/command/InfoGenCommand.java
@@ -49,6 +49,7 @@ public class InfoGenCommand extends ApplicationCommand {
         builder.append("`description:` Parses a description, including color codes, bold, italics, and newlines.\n");
         builder.append("`type:` The type of the item, such as a Sword or Wand. Can be left blank.\n");
         builder.append("`handle_line_breaks- (true/false)`: To be used if you're manually handling line breaks between the description and rarity.\n\n");
+        builder.append("`alpha- (0-255)`: To be used to change the transparency of the background layer. 0 for transparent, 255 for opaque. 245 for overlay.\n\n");
         builder.append("The Item Generator bot also accepts color codes. You can use these with either manual Minecraft codes, such as `&1`, or `%%DARK_BLUE%%`.\n");
         builder.append("You can use this same format for stats, such as `%%PRISTINE%%`. \nThis format can also have numbers, where `%%PRISTINE:1%%` will become \"1 ✧ Pristine\"\n");
         builder.append("Finally, you can move your text to a newline by using \\n. This format can be forced with the handle_line_breaks argument.\n\n");

--- a/src/main/java/net/hypixel/nerdbot/command/ItemGenCommand.java
+++ b/src/main/java/net/hypixel/nerdbot/command/ItemGenCommand.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -41,7 +42,7 @@ public class ItemGenCommand extends ApplicationCommand {
             @AppOption(description = "The description of the item") String description,
             @Optional @AppOption(description = "The type of the item") String type,
             @Optional @AppOption(description = "If you will handle line breaks at the end of the item's description") Boolean handleLineBreaks,
-            @Optional @AppOption(description = "If you want the image to be semitransparent") Boolean transparent
+            @Optional @AppOption(description = "Sets the background transparency level, 0 for transparent, 255 for opaque") Integer alpha
     ) throws IOException {
         String senderChannelId = event.getChannel().getId();
         String[] itemGenChannelIds = NerdBotApp.getBot().getConfig().getItemGenChannel();
@@ -114,12 +115,11 @@ public class ItemGenCommand extends ApplicationCommand {
             return;
         }
 
-        // checks if the image transparency was set
-        if (transparent == null) {
-            transparent = false;
-        }
+        // alpha value validation
+        alpha = Objects.requireNonNullElse(alpha, 255); // checks if the image transparency was set
+        alpha = Math.min(255, Math.max(alpha, 0)); // ensure range between 0-254
 
-        MinecraftImage minecraftImage = new MinecraftImage(500, colorParser.getRequiredLines(), MCColor.GRAY, transparent);
+        MinecraftImage minecraftImage = new MinecraftImage(500, colorParser.getRequiredLines(), MCColor.GRAY, alpha);
         minecraftImage.drawStrings(colorParser.getParsedDescription());
         minecraftImage.cropImage();
         minecraftImage.createImageBorder();

--- a/src/main/java/net/hypixel/nerdbot/generator/MinecraftImage.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/MinecraftImage.java
@@ -27,9 +27,9 @@ public class MinecraftImage {
     private int locationX = START_XY;
     private int locationY = START_XY + PIXEL_SIZE * 2 + Y_INCREMENT / 2;
     private int largestWidth = 0;
-    private int alphaValue = 255;
+    private final int alphaValue;
 
-    public MinecraftImage(int imageWidth, int linesToPrint, MCColor defaultColor, boolean transparent) {
+    public MinecraftImage(int imageWidth, int linesToPrint, MCColor defaultColor, int alpha) {
         this.ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
 
         // registers the static fonts
@@ -37,11 +37,8 @@ public class MinecraftImage {
             ge.registerFont(font);
         }
 
-        if (transparent) {
-            this.alphaValue = 245;
-        }
-
-        this.g2d = initG2D(imageWidth, linesToPrint * Y_INCREMENT + START_XY + PIXEL_SIZE * 4, transparent);
+        this.alphaValue = alpha;
+        this.g2d = initG2D(imageWidth, linesToPrint * Y_INCREMENT + START_XY + PIXEL_SIZE * 4);
         this.currentColor = defaultColor;
     }
 
@@ -54,7 +51,7 @@ public class MinecraftImage {
      *
      * @return G2D object
      */
-    private Graphics2D initG2D(int width, int height, boolean transparent) {
+    private Graphics2D initG2D(int width, int height) {
         this.image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
 
         Graphics2D graphics = image.createGraphics();


### PR DESCRIPTION
This replaces the transparent parameter in /itemgen with alpha and allows the user to enter a value between 0 and 255, 0 looking like an in-game chat message, 255 being the item lore black/default background.