### PR TITLE
Separate Suggestion and Alpha User Activity

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/api/database/greenlit/GreenlitMessage.java
+++ b/src/main/java/net/hypixel/nerdbot/api/database/greenlit/GreenlitMessage.java
@@ -28,6 +28,7 @@ public class GreenlitMessage {
     private List<String> tags;
     private long suggestionTimestamp;
     private int agrees, disagrees, neutrals;
+    private boolean alpha;
 
     public GreenlitMessage() {
     }

--- a/src/main/java/net/hypixel/nerdbot/api/database/user/LastActivity.java
+++ b/src/main/java/net/hypixel/nerdbot/api/database/user/LastActivity.java
@@ -11,21 +11,21 @@ import java.util.function.Function;
 public class LastActivity {
 
     // Global Activity
-    private long lastGlobalActivity = -1L; // TODO: Migrate to globalMostRecent
-    private long lastVoiceChannelJoinDate = -1L; // TODO: Migrate to globalVoiceJoinDate
-    private long lastItemGenUsage = -1L; // TODO: Migrate to itemGenUsage
+    private long lastGlobalActivity = -1L;
+    private long lastVoiceChannelJoinDate = -1L;
+    private long lastItemGenUsage = -1L;
 
     // Suggestion Activity
-    private long lastSuggestionDate = -1L; // TODO: Migrate to suggestionCreationDate
+    private long lastSuggestionDate = -1L;
     private long suggestionVoteDate = -1L;
     private long suggestionCommentDate = -1L;
 
     // Alpha Activity
-    private long lastAlphaActivity = -1L; // TODO: Migrate to alphaMostRecent
+    private long lastAlphaActivity = -1L;
     private long alphaVoiceJoinDate = -1L;
 
     // Alpha Suggestion Activity
-    private long lastAlphaSuggestionDate = -1L; // TODO: Migrate to alphaSuggestionCreationDate
+    private long lastAlphaSuggestionDate = -1L;
     private long alphaSuggestionVoteDate = -1L;
     private long alphaSuggestionCommentDate = -1L;
 

--- a/src/main/java/net/hypixel/nerdbot/api/database/user/LastActivity.java
+++ b/src/main/java/net/hypixel/nerdbot/api/database/user/LastActivity.java
@@ -2,18 +2,41 @@ package net.hypixel.nerdbot.api.database.user;
 
 import lombok.Getter;
 import lombok.Setter;
+import net.hypixel.nerdbot.util.discord.DiscordTimestamp;
+
+import java.util.function.Function;
 
 @Getter
 @Setter
 public class LastActivity {
 
-    private long lastGlobalActivity = -1L;
-    private long lastVoiceChannelJoinDate = -1L;
-    private long lastSuggestionDate = -1L;
-    private long lastAlphaSuggestionDate = -1L;
-    private long lastAlphaActivity = -1L;
-    private long lastItemGenUsage = -1L;
+    // Global Activity
+    private long lastGlobalActivity = -1L; // TODO: Migrate to globalMostRecent
+    private long lastVoiceChannelJoinDate = -1L; // TODO: Migrate to globalVoiceJoinDate
+    private long lastItemGenUsage = -1L; // TODO: Migrate to itemGenUsage
+
+    // Suggestion Activity
+    private long lastSuggestionDate = -1L; // TODO: Migrate to suggestionCreationDate
+    private long suggestionVoteDate = -1L;
+    private long suggestionCommentDate = -1L;
+
+    // Alpha Activity
+    private long lastAlphaActivity = -1L; // TODO: Migrate to alphaMostRecent
+    private long alphaVoiceJoinDate = -1L;
+
+    // Alpha Suggestion Activity
+    private long lastAlphaSuggestionDate = -1L; // TODO: Migrate to alphaSuggestionCreationDate
+    private long alphaSuggestionVoteDate = -1L;
+    private long alphaSuggestionCommentDate = -1L;
 
     public LastActivity() {
+    }
+
+    public DiscordTimestamp toTimestamp(Function<LastActivity, Long> function) {
+        return new DiscordTimestamp(function.apply(this));
+    }
+
+    public String toRelativeTimestamp(Function<LastActivity, Long> function) {
+        return this.toTimestamp(function).toRelativeTimestamp();
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/api/feature/BotFeature.java
+++ b/src/main/java/net/hypixel/nerdbot/api/feature/BotFeature.java
@@ -1,6 +1,10 @@
 package net.hypixel.nerdbot.api.feature;
 
+import java.util.Timer;
+
 public abstract class BotFeature {
+
+    protected final Timer timer = new Timer();
 
     public abstract void onStart();
 

--- a/src/main/java/net/hypixel/nerdbot/bot/config/BotConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/BotConfig.java
@@ -32,9 +32,14 @@ public class BotConfig {
     private String botManagerRoleId;
 
     /**
-     * The {@link TextChannel} ID for the suggestion forum
+     * The {@link TextChannel} IDs for the suggestion forums
      */
-    private String suggestionForumId;
+    private String[] suggestionForumIds;
+
+    /**
+     * The {@link TextChannel} IDs for the alpha suggestion forums
+     */
+    private String[] alphaSuggestionForumIds;
 
     /**
      * The {@link TextChannel} ID for the itemgen channel

--- a/src/main/java/net/hypixel/nerdbot/bot/config/EmojiConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/EmojiConfig.java
@@ -35,8 +35,9 @@ public class EmojiConfig {
     private String greenlitEmojiId;
 
     public boolean isEquals(MessageReaction reaction, Function<EmojiConfig, String> function) {
-        if (reaction.getEmoji().getType() != Emoji.Type.CUSTOM)
+        if (reaction.getEmoji().getType() != Emoji.Type.CUSTOM) {
             return false;
+        }
 
         return Objects.equals(reaction.getEmoji().asCustom().getId(), function.apply(this));
     }

--- a/src/main/java/net/hypixel/nerdbot/bot/config/EmojiConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/EmojiConfig.java
@@ -3,6 +3,11 @@ package net.hypixel.nerdbot.bot.config;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import net.dv8tion.jda.api.entities.MessageReaction;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
+
+import java.util.Objects;
+import java.util.function.Function;
 
 @Getter
 @Setter
@@ -28,4 +33,11 @@ public class EmojiConfig {
      * The ID of the reaction for the greenlit emoji
      */
     private String greenlitEmojiId;
+
+    public boolean isEquals(MessageReaction reaction, Function<EmojiConfig, String> function) {
+        if (reaction.getEmoji().getType() != Emoji.Type.CUSTOM)
+            return false;
+
+        return Objects.equals(reaction.getEmoji().asCustom().getId(), function.apply(this));
+    }
 }

--- a/src/main/java/net/hypixel/nerdbot/curator/ForumChannelCurator.java
+++ b/src/main/java/net/hypixel/nerdbot/curator/ForumChannelCurator.java
@@ -127,6 +127,7 @@ public class ForumChannelCurator extends Curator<ForumChannel> {
                         .disagrees(disagree)
                         .messageId(message.getId())
                         .userId(message.getAuthor().getId())
+                        .alpha(forumChannel.getName().toLowerCase().contains("alpha"))
                         .suggestionUrl(message.getJumpUrl())
                         .suggestionTitle(thread.getName())
                         .suggestionTimestamp(thread.getTimeCreated().toInstant().toEpochMilli())

--- a/src/main/java/net/hypixel/nerdbot/curator/ForumChannelCurator.java
+++ b/src/main/java/net/hypixel/nerdbot/curator/ForumChannelCurator.java
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.forums.BaseForumTag;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
+import net.dv8tion.jda.internal.utils.tuple.Pair;
 import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.curator.Curator;
 import net.hypixel.nerdbot.api.database.Database;
@@ -16,11 +17,15 @@ import net.hypixel.nerdbot.api.database.greenlit.GreenlitMessage;
 import net.hypixel.nerdbot.bot.config.BotConfig;
 import net.hypixel.nerdbot.bot.config.EmojiConfig;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Log4j2
 public class ForumChannelCurator extends Curator<ForumChannel> {
+
+    private final static List<String> greenlitTags = Arrays.asList("greenlit", "docced");
 
     public ForumChannelCurator(boolean readOnly) {
         super(readOnly);
@@ -56,7 +61,10 @@ public class ForumChannelCurator extends Curator<ForumChannel> {
 
         List<ThreadChannel> threads = forumChannel.getThreadChannels()
                 .stream()
-                .filter(threadChannel -> threadChannel.getAppliedTags().stream().noneMatch(tag -> tag.getName().equalsIgnoreCase("greenlit") || tag.getName().equalsIgnoreCase("docced")))
+                .filter(threadChannel -> threadChannel.getAppliedTags()
+                        .stream()
+                        .noneMatch(tag -> greenlitTags.contains(tag.getName().toLowerCase()))
+                )
                 .toList();
 
         log.info("Found " + threads.size() + " non-greenlit forum post(s)!");
@@ -84,21 +92,29 @@ public class ForumChannelCurator extends Curator<ForumChannel> {
                         .stream()
                         .filter(reaction -> reaction.getEmoji().getType() == Emoji.Type.CUSTOM)
                         .toList();
-                int agree = reactions.stream()
-                        .filter(reaction -> reaction.getEmoji().asCustom().getId().equalsIgnoreCase(emojiConfig.getAgreeEmojiId()))
-                        .mapToInt(MessageReaction::getCount)
-                        .findFirst()
-                        .orElse(0);
-                int disagree = reactions.stream()
-                        .filter(reaction -> reaction.getEmoji().asCustom().getId().equalsIgnoreCase(emojiConfig.getDisagreeEmojiId()))
-                        .mapToInt(MessageReaction::getCount)
-                        .findFirst()
-                        .orElse(0);
-                int neutral = reactions.stream()
-                        .filter(reaction -> reaction.getEmoji().asCustom().getId().equalsIgnoreCase(emojiConfig.getNeutralEmojiId()))
-                        .mapToInt(MessageReaction::getCount)
-                        .findFirst()
-                        .orElse(0);
+
+                Map<String, Integer> votes = Stream.of(
+                                emojiConfig.getAgreeEmojiId(),
+                                emojiConfig.getNeutralEmojiId(),
+                                emojiConfig.getDisagreeEmojiId()
+                        )
+                        .map(emojiId -> Pair.of(
+                                emojiId,
+                                reactions.stream()
+                                        .filter(reaction -> reaction.getEmoji()
+                                                .asCustom()
+                                                .getId()
+                                                .equalsIgnoreCase(emojiId)
+                                        )
+                                        .mapToInt(MessageReaction::getCount)
+                                        .findFirst()
+                                        .orElse(0)
+                        ))
+                        .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+
+                int agree = votes.get(emojiConfig.getAgreeEmojiId());
+                int neutral = votes.get(emojiConfig.getNeutralEmojiId());
+                int disagree = votes.get(emojiConfig.getDisagreeEmojiId());
                 double ratio = getRatio(agree, disagree);
 
                 log.info("Thread '" + thread.getName() + "' (ID: " + thread.getId() + ") has " + agree + " agree reactions, " + neutral + " neutral reactions, and " + disagree + " disagree reactions with a ratio of " + ratio + "%");

--- a/src/main/java/net/hypixel/nerdbot/feature/CurateFeature.java
+++ b/src/main/java/net/hypixel/nerdbot/feature/CurateFeature.java
@@ -16,8 +16,6 @@ import java.util.stream.Stream;
 @Log4j2
 public class CurateFeature extends BotFeature {
 
-    private final Timer timer = new Timer();
-
     @Override
     public void onStart() {
         if (NerdBotApp.getBot().getConfig().getSuggestionForumIds() == null) {

--- a/src/main/java/net/hypixel/nerdbot/feature/CurateFeature.java
+++ b/src/main/java/net/hypixel/nerdbot/feature/CurateFeature.java
@@ -2,6 +2,7 @@ package net.hypixel.nerdbot.feature;
 
 import lombok.extern.log4j.Log4j2;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
+import net.dv8tion.jda.internal.utils.tuple.Pair;
 import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.curator.Curator;
 import net.hypixel.nerdbot.api.database.Database;
@@ -9,52 +10,68 @@ import net.hypixel.nerdbot.api.database.greenlit.GreenlitMessage;
 import net.hypixel.nerdbot.api.feature.BotFeature;
 import net.hypixel.nerdbot.curator.ForumChannelCurator;
 
-import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.*;
+import java.util.stream.Stream;
 
 @Log4j2
 public class CurateFeature extends BotFeature {
 
+    private final Timer timer = new Timer();
+
     @Override
     public void onStart() {
-        if (NerdBotApp.getBot().getConfig().getSuggestionForumId() == null) {
-            log.info("Not starting CurateFeature as 'suggestionForumId' could not be found in the configuration file!");
+        if (NerdBotApp.getBot().getConfig().getSuggestionForumIds() == null) {
+            log.info("Not starting CurateFeature as 'suggestionForumIds' could not be found in the configuration file!");
             return;
         }
 
-        Database database = NerdBotApp.getBot().getDatabase();
-        TimerTask timerTask = new TimerTask() {
+        this.timer.scheduleAtFixedRate(new TimerTask() {
             @Override
             public void run() {
-                Curator<ForumChannel> forumChannelCurator = new ForumChannelCurator(NerdBotApp.getBot().isReadOnly());
-                ForumChannel forumChannel = NerdBotApp.getBot().getJDA().getForumChannelById(NerdBotApp.getBot().getConfig().getSuggestionForumId());
-                if (forumChannel == null) {
-                    log.error("Couldn't find the suggestion forum channel from the bot config!");
-                    return;
-                }
-
                 NerdBotApp.EXECUTOR_SERVICE.execute(() -> {
-                    List<GreenlitMessage> result = forumChannelCurator.curate(forumChannel);
-                    if (result.isEmpty()) {
-                        log.info("No new suggestions were greenlit this time!");
-                    } else {
-                        log.info("Greenlit " + result.size() + " new suggestions in " + (forumChannelCurator.getEndTime() - forumChannelCurator.getStartTime()) + "ms!");
-                    }
-                    result.forEach(greenlitMessage -> {
-                        database.upsertDocument(database.getCollection("greenlit_messages", GreenlitMessage.class), "messageId", greenlitMessage.getMessageId(), greenlitMessage);
+                    Database database = NerdBotApp.getBot().getDatabase();
+                    final Curator<ForumChannel> forumChannelCurator = new ForumChannelCurator(NerdBotApp.getBot().isReadOnly());
+
+                    Stream.concat(
+                            Arrays.stream(NerdBotApp.getBot().getConfig().getSuggestionForumIds()).map(forumId -> Pair.of(forumId, false)),
+                            Arrays.stream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).map(forumId -> Pair.of(forumId, true))
+                    ).forEach(suggestionForum -> {
+                        String id = suggestionForum.getLeft();
+                        boolean alpha = suggestionForum.getRight();
+                        ForumChannel forumChannel = NerdBotApp.getBot().getJDA().getForumChannelById(id);
+                        log.info("Processing" + (alpha ? " alpha" : "") + " suggestion forum channel with ID " + id + ".");
+
+                        if (forumChannel == null) {
+                            log.error("Couldn't find the suggestion forum channel with ID " + id + "!");
+                            return;
+                        }
+
+                        List<GreenlitMessage> result = forumChannelCurator.curate(forumChannel);
+                        if (result.isEmpty()) {
+                            log.info("No new suggestions were greenlit from ID " + id + " this time!");
+                        } else {
+                            log.info("Greenlit " + result.size() + " new suggestions from ID " + id + ". Took " + (forumChannelCurator.getEndTime() - forumChannelCurator.getStartTime()) + "ms!");
+                        }
+
+                        // Update Database
+                        result.forEach(greenlitMessage -> database.upsertDocument(
+                                database.getCollection(
+                                        "greenlit_messages",
+                                        GreenlitMessage.class
+                                ),
+                                "messageId",
+                                greenlitMessage.getMessageId(),
+                                greenlitMessage
+                        ));
+                        log.info("Inserted " + result.size() + " new greenlit messages into the database!");
                     });
-                    log.info("Inserted " + result.size() + " new greenlit messages into the database!");
                 });
             }
-        };
-
-        Timer timer = new Timer();
-        timer.scheduleAtFixedRate(timerTask, 30_000L, NerdBotApp.getBot().getConfig().getInterval());
+        }, 30_000L, NerdBotApp.getBot().getConfig().getInterval());
     }
 
     @Override
     public void onEnd() {
-
+        this.timer.cancel();
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/feature/GreenlitUpdateFeature.java
+++ b/src/main/java/net/hypixel/nerdbot/feature/GreenlitUpdateFeature.java
@@ -104,6 +104,7 @@ public class GreenlitUpdateFeature extends BotFeature {
                         greenlitMessage.setSuggestionContent(message.getContentRaw());
                         greenlitMessage.setTags(thread.getAppliedTags().stream().map(BaseForumTag::getName).toList());
                         greenlitMessage.setAgrees(agree);
+                        greenlitMessage.setNeutrals(neutral);
                         greenlitMessage.setDisagrees(disagree);
                         greenlitMessage.setNeutrals(neutral);
 
@@ -115,7 +116,7 @@ public class GreenlitUpdateFeature extends BotFeature {
         };
 
         Timer timer = new Timer();
-        timer.scheduleAtFixedRate(timerTask, TimeUnit.MINUTES.toMillis(5), NerdBotApp.getBot().getConfig().getInterval() + (TimeUnit.MINUTES.toMillis(5)));
+        timer.scheduleAtFixedRate(timerTask, 0L, TimeUnit.HOURS.toMillis(1L));
     }
 
     @Override

--- a/src/main/java/net/hypixel/nerdbot/feature/GreenlitUpdateFeature.java
+++ b/src/main/java/net/hypixel/nerdbot/feature/GreenlitUpdateFeature.java
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.forums.BaseForumTag;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
+import net.dv8tion.jda.internal.utils.tuple.Pair;
 import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.bot.Bot;
 import net.hypixel.nerdbot.api.database.Database;
@@ -16,111 +17,114 @@ import net.hypixel.nerdbot.api.database.greenlit.GreenlitMessage;
 import net.hypixel.nerdbot.api.feature.BotFeature;
 import net.hypixel.nerdbot.bot.config.EmojiConfig;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 @Log4j2
 public class GreenlitUpdateFeature extends BotFeature {
 
     @Override
     public void onStart() {
-        TimerTask timerTask = new TimerTask() {
+        this.timer.scheduleAtFixedRate(new TimerTask() {
             @Override
             public void run() {
-                Bot nerdBot = NerdBotApp.getBot();
-                ForumChannel suggestions = nerdBot.getJDA().getForumChannelById(nerdBot.getConfig().getSuggestionForumId());
-                if (suggestions == null) {
-                    log.error("Couldn't find the suggestion forum channel from the bot config!");
-                    return;
-                }
+                Stream.concat(
+                        Arrays.stream(NerdBotApp.getBot().getConfig().getSuggestionForumIds()).map(forumId -> Pair.of(forumId, false)),
+                        Arrays.stream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).map(forumId -> Pair.of(forumId, true))
+                ).forEach(suggestionForum -> {
+                    String id = suggestionForum.getLeft();
+                    boolean alpha = suggestionForum.getRight();
+                    ForumChannel forumChannel = NerdBotApp.getBot().getJDA().getForumChannelById(id);
+                    log.info("Processing" + (alpha ? " alpha" : "") + " suggestion forum channel with ID " + id + ".");
 
-                List<ThreadChannel> greenlitThreads = new ArrayList<>(suggestions.getThreadChannels().stream().filter(threadChannel -> threadChannel.getAppliedTags().stream().map(ForumTag::getName).toList().contains("Greenlit")).toList());
-                List<ThreadChannel> archived = suggestions.retrieveArchivedPublicThreadChannels().complete();
-
-                log.info("Found " + suggestions.getThreadChannels().size() + " threads in the suggestion forum channel!");
-                log.info("Found " + archived.size() + " archived threads in the suggestion forum channel!");
-
-                greenlitThreads.addAll(archived.stream()
-                        .filter(threadChannel -> !greenlitThreads.contains(threadChannel))
-                        .filter(threadChannel -> threadChannel.getAppliedTags().stream().map(ForumTag::getName).toList().contains("Greenlit"))
-                        .toList());
-
-                Database database = nerdBot.getDatabase();
-                if (!database.isConnected()) {
-                    log.info("Database is not connected, skipping greenlit message update!");
-                    return;
-                }
-
-                List<GreenlitMessage> greenlits = database.getCollection("greenlit_messages", GreenlitMessage.class).find().into(new ArrayList<>());
-                if (greenlits.size() == 0) {
-                    log.info("No greenlit messages found in the database to update!");
-                    return;
-                }
-
-                log.info("Found " + greenlitThreads.size() + " total greenlit threads");
-                log.info("Found " + greenlits.size() + " greenlit messages in the database!");
-
-                greenlits.forEach(greenlitMessage -> {
-                    if (greenlitThreads.stream().anyMatch(threadChannel -> threadChannel.getId().equals(greenlitMessage.getMessageId()))) {
-                        ThreadChannel thread = greenlitThreads.stream().filter(threadChannel -> threadChannel.getId().equals(greenlitMessage.getMessageId())).findFirst().orElse(null);
-                        if (thread == null) {
-                            return;
-                        }
-
-                        log.info("Found matching thread for greenlit message " + greenlitMessage.getMessageId() + ": '" + thread.getName() + "' (ID: " + thread.getId() + ")");
-
-                        MessageHistory history = thread.getHistoryFromBeginning(1).complete();
-                        Message message = history.getRetrievedHistory().get(0);
-                        if (message == null) {
-                            log.error("Message for thread '" + thread.getName() + "' (ID: " + thread.getId() + ") is null!");
-                            return;
-                        }
-
-                        EmojiConfig emojiConfig = nerdBot.getConfig().getEmojiConfig();
-                        List<MessageReaction> reactions = message.getReactions()
-                                .stream()
-                                .filter(reaction -> reaction.getEmoji().getType() == Emoji.Type.CUSTOM)
-                                .toList();
-                        int agree = reactions.stream()
-                                .filter(reaction -> reaction.getEmoji().asCustom().getId().equalsIgnoreCase(emojiConfig.getAgreeEmojiId()))
-                                .mapToInt(MessageReaction::getCount)
-                                .findFirst()
-                                .orElse(0);
-                        int disagree = reactions.stream()
-                                .filter(reaction -> reaction.getEmoji().asCustom().getId().equalsIgnoreCase(emojiConfig.getDisagreeEmojiId()))
-                                .mapToInt(MessageReaction::getCount)
-                                .findFirst()
-                                .orElse(0);
-                        int neutral = reactions.stream()
-                                .filter(reaction -> reaction.getEmoji().asCustom().getId().equalsIgnoreCase(emojiConfig.getNeutralEmojiId()))
-                                .mapToInt(MessageReaction::getCount)
-                                .findFirst()
-                                .orElse(0);
-
-                        greenlitMessage.setSuggestionTitle(thread.getName());
-                        greenlitMessage.setSuggestionContent(message.getContentRaw());
-                        greenlitMessage.setTags(thread.getAppliedTags().stream().map(BaseForumTag::getName).toList());
-                        greenlitMessage.setAgrees(agree);
-                        greenlitMessage.setNeutrals(neutral);
-                        greenlitMessage.setDisagrees(disagree);
-                        greenlitMessage.setNeutrals(neutral);
-
-                        database.upsertDocument(database.getCollection("greenlit_messages", GreenlitMessage.class), "messageId", greenlitMessage.getMessageId(), greenlitMessage);
-                        log.info("Updated greenlit message " + greenlitMessage.getMessageId() + " in the database!");
+                    if (forumChannel == null) {
+                        log.error("Couldn't find the suggestion forum channel with ID " + id + "!");
+                        return;
                     }
+
+                    List<ThreadChannel> greenlitThreads = new ArrayList<>(forumChannel.getThreadChannels().stream().filter(threadChannel -> threadChannel.getAppliedTags().stream().map(ForumTag::getName).toList().contains("Greenlit")).toList());
+                    List<ThreadChannel> archived = forumChannel.retrieveArchivedPublicThreadChannels().complete();
+
+                    log.info("Found " + forumChannel.getThreadChannels().size() + " threads in the suggestion forum channel!");
+                    log.info("Found " + archived.size() + " archived threads in the suggestion forum channel!");
+
+                    greenlitThreads.addAll(archived.stream()
+                            .filter(threadChannel -> !greenlitThreads.contains(threadChannel))
+                            .filter(threadChannel -> threadChannel.getAppliedTags().stream().map(ForumTag::getName).toList().contains("Greenlit"))
+                            .toList());
+
+                    Database database = NerdBotApp.getBot().getDatabase();
+                    if (!database.isConnected()) {
+                        log.info("Database is not connected, skipping greenlit message update!");
+                        return;
+                    }
+
+                    List<GreenlitMessage> greenlits = database.getCollection("greenlit_messages", GreenlitMessage.class).find().into(new ArrayList<>());
+                    if (greenlits.size() == 0) {
+                        log.info("No greenlit messages found in the database to update!");
+                        return;
+                    }
+
+                    log.info("Found " + greenlitThreads.size() + " total greenlit threads");
+                    log.info("Found " + greenlits.size() + " greenlit messages in the database!");
+
+                    greenlits.forEach(greenlitMessage -> {
+                        if (greenlitThreads.stream().anyMatch(threadChannel -> threadChannel.getId().equals(greenlitMessage.getMessageId()))) {
+                            ThreadChannel thread = greenlitThreads.stream().filter(threadChannel -> threadChannel.getId().equals(greenlitMessage.getMessageId())).findFirst().orElse(null);
+                            if (thread == null) {
+                                return;
+                            }
+
+                            log.info("Found matching thread for greenlit message " + greenlitMessage.getMessageId() + ": '" + thread.getName() + "' (ID: " + thread.getId() + ")");
+
+                            MessageHistory history = thread.getHistoryFromBeginning(1).complete();
+                            Message message = history.getRetrievedHistory().get(0);
+                            if (message == null) {
+                                log.error("Message for thread '" + thread.getName() + "' (ID: " + thread.getId() + ") is null!");
+                                return;
+                            }
+
+                            EmojiConfig emojiConfig = NerdBotApp.getBot().getConfig().getEmojiConfig();
+                            List<MessageReaction> reactions = message.getReactions()
+                                    .stream()
+                                    .filter(reaction -> reaction.getEmoji().getType() == Emoji.Type.CUSTOM)
+                                    .toList();
+                            int agree = reactions.stream()
+                                    .filter(reaction -> reaction.getEmoji().asCustom().getId().equalsIgnoreCase(emojiConfig.getAgreeEmojiId()))
+                                    .mapToInt(MessageReaction::getCount)
+                                    .findFirst()
+                                    .orElse(0);
+                            int disagree = reactions.stream()
+                                    .filter(reaction -> reaction.getEmoji().asCustom().getId().equalsIgnoreCase(emojiConfig.getDisagreeEmojiId()))
+                                    .mapToInt(MessageReaction::getCount)
+                                    .findFirst()
+                                    .orElse(0);
+                            int neutral = reactions.stream()
+                                    .filter(reaction -> reaction.getEmoji().asCustom().getId().equalsIgnoreCase(emojiConfig.getNeutralEmojiId()))
+                                    .mapToInt(MessageReaction::getCount)
+                                    .findFirst()
+                                    .orElse(0);
+
+                            greenlitMessage.setSuggestionTitle(thread.getName());
+                            greenlitMessage.setSuggestionContent(message.getContentRaw());
+                            greenlitMessage.setTags(thread.getAppliedTags().stream().map(BaseForumTag::getName).toList());
+                            greenlitMessage.setAgrees(agree);
+                            greenlitMessage.setNeutrals(neutral);
+                            greenlitMessage.setDisagrees(disagree);
+                            greenlitMessage.setNeutrals(neutral);
+
+                            database.upsertDocument(database.getCollection("greenlit_messages", GreenlitMessage.class), "messageId", greenlitMessage.getMessageId(), greenlitMessage);
+                            log.info("Updated greenlit message " + greenlitMessage.getMessageId() + " in the database!");
+                        }
+                    });
                 });
             }
-        };
-
-        Timer timer = new Timer();
-        timer.scheduleAtFixedRate(timerTask, 0L, TimeUnit.HOURS.toMillis(1L));
+        }, 0L, TimeUnit.HOURS.toMillis(1L));
     }
 
     @Override
     public void onEnd() {
-
+        this.timer.cancel();
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
@@ -2,6 +2,7 @@ package net.hypixel.nerdbot.listener;
 
 import lombok.extern.log4j.Log4j2;
 import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
@@ -32,25 +33,22 @@ public class ActivityListener {
 
     @SubscribeEvent
     public void onMessageReceived(MessageReceivedEvent event) {
-        if (!event.isFromGuild()) {
-            return;
-        }
+        if (!event.isFromGuild())
+            return; // Ignore Non Guild
 
         Member member = event.getMember();
-        GuildChannel channel = event.getGuildChannel();
-
-        if (!event.isFromGuild() || member == null || member.getUser().isBot()) {
+        if (member == null || member.getUser().isBot()) {
             return;
         }
 
         DiscordUser discordUser = Util.getOrAddUserToCache(database, member.getId());
+
+        if (discordUser == null)
+            return; // Ignore Empty User
+
+        GuildChannel channel = event.getGuildChannel();
         long time = System.currentTimeMillis();
-
-        if (discordUser == null) {
-            return;
-        }
-
-        if (channel.getName().contains("alpha")) {
+        if (channel.getName().toLowerCase().contains("alpha")) {
             discordUser.getLastActivity().setLastAlphaActivity(time);
             log.info("Updating last alpha activity date for " + member.getEffectiveName() + " to " + time);
         }
@@ -63,15 +61,23 @@ public class ActivityListener {
     public void onVoiceChannelJoin(GuildVoiceUpdateEvent event) {
         Member member = event.getMember();
 
-        if (member.getUser().isBot()) {
-            return;
-        }
+        if (member.getUser().isBot())
+            return; // Ignore Bots
 
         DiscordUser discordUser = Util.getOrAddUserToCache(database, member.getId());
-        if (discordUser == null) {
-            return;
+        if (discordUser == null)
+            return; // Ignore Empty User
+
+        long time = System.currentTimeMillis();
+        if (event.getChannelJoined() instanceof VoiceChannel) {
+            VoiceChannel channel = event.getChannelJoined().asVoiceChannel();
+
+            if (channel.getName().toLowerCase().contains("alpha")) {
+                discordUser.getLastActivity().setAlphaVoiceJoinDate(time);
+                log.info("Updating last alpha voice activity date for " + member.getEffectiveName() + " to " + time);
+            }
         }
-        discordUser.getLastActivity().setLastVoiceChannelJoinDate(System.currentTimeMillis());
-        log.info("Updating last voice channel activity date for " + member.getEffectiveName() + " to " + System.currentTimeMillis());
+        discordUser.getLastActivity().setLastVoiceChannelJoinDate(time);
+        log.info("Updating last global voice activity date for " + member.getEffectiveName() + " to " + time);
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
@@ -51,7 +51,6 @@ public class ActivityListener {
         }
 
         DiscordUser discordUser = Util.getOrAddUserToCache(this.database, member.getId());
-
         if (discordUser == null) {
             return; // Ignore Empty User
         }

--- a/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
@@ -48,7 +48,13 @@ public class ActivityListener {
 
         GuildChannel channel = event.getGuildChannel();
         long time = System.currentTimeMillis();
-        if (channel.getName().toLowerCase().contains("alpha")) {
+
+        if (channel.getId().equals(NerdBotApp.getBot().getConfig().getSuggestionForumId())) {
+            discordUser.getLastActivity().setLastSuggestionDate(time);
+            log.info("Updating last suggestion activity date for " + member.getEffectiveName() + " to " + time);
+        }
+
+        if (channel.getName().contains("alpha")) {
             discordUser.getLastActivity().setLastAlphaActivity(time);
             log.info("Updating last alpha activity date for " + member.getEffectiveName() + " to " + time);
         }

--- a/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
@@ -2,17 +2,25 @@ package net.hypixel.nerdbot.listener;
 
 import lombok.extern.log4j.Log4j2;
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
-import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageHistory;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.entities.channel.unions.GuildMessageChannelUnion;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.hooks.SubscribeEvent;
 import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.database.Database;
 import net.hypixel.nerdbot.api.database.user.DiscordUser;
+import net.hypixel.nerdbot.bot.config.BotConfig;
+import net.hypixel.nerdbot.bot.config.EmojiConfig;
 import net.hypixel.nerdbot.util.Util;
+
+import java.util.Arrays;
 
 @Log4j2
 public class ActivityListener {
@@ -21,13 +29,13 @@ public class ActivityListener {
 
     @SubscribeEvent
     public void onGuildMemberJoin(GuildMemberJoinEvent event) {
-        Util.getOrAddUserToCache(database, event.getUser().getId());
+        Util.getOrAddUserToCache(this.database, event.getUser().getId());
         log.info("User " + event.getUser().getAsTag() + " joined guild " + event.getGuild().getName());
     }
 
     @SubscribeEvent
     public void onGuildMemberLeave(GuildMemberRemoveEvent event) {
-        database.deleteDocument(database.getCollection("users"), "discordId", event.getUser().getId());
+        this.database.deleteDocument(this.database.getCollection("users"), "discordId", event.getUser().getId());
         log.info("User " + event.getUser().getAsTag() + " left guild " + event.getGuild().getName());
     }
 
@@ -37,24 +45,51 @@ public class ActivityListener {
             return; // Ignore Non Guild
 
         Member member = event.getMember();
-        if (member == null || member.getUser().isBot()) {
-            return;
-        }
+        if (member == null || member.getUser().isBot())
+            return; // Ignore Empty Member
 
-        DiscordUser discordUser = Util.getOrAddUserToCache(database, member.getId());
+        DiscordUser discordUser = Util.getOrAddUserToCache(this.database, member.getId());
 
         if (discordUser == null)
             return; // Ignore Empty User
 
-        GuildChannel channel = event.getGuildChannel();
+        GuildMessageChannelUnion guildChannel = event.getGuildChannel();
+        String channelId = guildChannel.getId();
         long time = System.currentTimeMillis();
+        boolean isAlphaChannel = guildChannel.getName().contains("alpha");
 
-        if (channel.getId().equals(NerdBotApp.getBot().getConfig().getSuggestionForumId())) {
+        // New Suggestions
+        if (Arrays.stream(NerdBotApp.getBot().getConfig().getSuggestionForumIds()).anyMatch(channelId::equalsIgnoreCase)) {
             discordUser.getLastActivity().setLastSuggestionDate(time);
-            log.info("Updating last suggestion activity date for " + member.getEffectiveName() + " to " + time);
+            log.info("Updating new suggestion activity date for " + member.getEffectiveName() + " to " + time);
         }
 
-        if (channel.getName().contains("alpha")) {
+        // New Alpha Suggestions
+        if (Arrays.stream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).anyMatch(channelId::equalsIgnoreCase)) {
+            isAlphaChannel = true;
+            discordUser.getLastActivity().setLastAlphaSuggestionDate(time);
+            log.info("Updating new alpha suggestion activity date for " + member.getEffectiveName() + " to " + time);
+        }
+
+        // New Suggestion Comments
+        if (guildChannel instanceof ThreadChannel) {
+            String forumChannelId = guildChannel.asThreadChannel().getParentChannel().getId();
+
+            // New Suggestion Comments
+            if (Arrays.stream(NerdBotApp.getBot().getConfig().getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+                discordUser.getLastActivity().setSuggestionCommentDate(time);
+                log.info("Updating suggestion comment activity date for " + member.getEffectiveName() + " to " + time);
+            }
+
+            // New Alpha Suggestion Comments
+            if (Arrays.stream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+                isAlphaChannel = true;
+                discordUser.getLastActivity().setAlphaSuggestionCommentDate(time);
+                log.info("Updating alpha suggestion comment activity date for " + member.getEffectiveName() + " to " + time);
+            }
+        }
+
+        if (isAlphaChannel) {
             discordUser.getLastActivity().setLastAlphaActivity(time);
             log.info("Updating last alpha activity date for " + member.getEffectiveName() + " to " + time);
         }
@@ -70,20 +105,70 @@ public class ActivityListener {
         if (member.getUser().isBot())
             return; // Ignore Bots
 
-        DiscordUser discordUser = Util.getOrAddUserToCache(database, member.getId());
+        DiscordUser discordUser = Util.getOrAddUserToCache(this.database, member.getId());
         if (discordUser == null)
             return; // Ignore Empty User
 
-        long time = System.currentTimeMillis();
-        if (event.getChannelJoined() instanceof VoiceChannel) {
-            VoiceChannel channel = event.getChannelJoined().asVoiceChannel();
+        if (event.getChannelJoined() == null)
+            return; // Ignore Leave Events
 
-            if (channel.getName().toLowerCase().contains("alpha")) {
-                discordUser.getLastActivity().setAlphaVoiceJoinDate(time);
-                log.info("Updating last alpha voice activity date for " + member.getEffectiveName() + " to " + time);
+        long time = System.currentTimeMillis();
+        if (event.getChannelJoined().getName().toLowerCase().contains("alpha")) {
+            discordUser.getLastActivity().setAlphaVoiceJoinDate(time);
+            log.info("Updating last alpha voice activity date for " + member.getEffectiveName() + " to " + time);
+        } else {
+            discordUser.getLastActivity().setLastVoiceChannelJoinDate(time);
+            log.info("Updating last global voice activity date for " + member.getEffectiveName() + " to " + time);
+        }
+    }
+
+    @SubscribeEvent
+    public void onReactionReceived(MessageReactionAddEvent event) {
+        if (!event.isFromGuild())
+            return; // Ignore Non Guild
+
+        Member member = event.getMember();
+        if (member == null || member.getUser().isBot())
+            return; // Ignore Empty Member
+
+        DiscordUser discordUser = Util.getOrAddUserToCache(this.database, member.getId());
+
+        if (discordUser == null)
+            return; // Ignore Empty User
+
+        if (event.getReaction().getEmoji().getType() != Emoji.Type.CUSTOM)
+            return; // Ignore Native Emojis
+
+        if (event.getGuildChannel() instanceof ThreadChannel) {
+            BotConfig config = NerdBotApp.getBot().getConfig();
+            EmojiConfig emojiConfig = config.getEmojiConfig();
+
+            if (emojiConfig.isEquals(event.getReaction(), EmojiConfig::getAgreeEmojiId) || emojiConfig.isEquals(event.getReaction(), EmojiConfig::getDisagreeEmojiId)) {
+                ThreadChannel threadChannel = event.getGuildChannel().asThreadChannel();
+                MessageHistory history = threadChannel.getHistoryFromBeginning(1).complete();
+                Message message = history.getRetrievedHistory().get(0);
+
+                if (message == null) {
+                    log.error("Message for thread '" + threadChannel.getName() + "' (ID: " + threadChannel.getId() + ") is null!");
+                    return;
+                }
+
+                String forumChannelId = threadChannel.getParentChannel().getId();
+                long time = System.currentTimeMillis();
+
+                // New Suggestion Voting
+                if (Arrays.stream(NerdBotApp.getBot().getConfig().getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+                    discordUser.getLastActivity().setSuggestionVoteDate(time);
+                    log.info("Updating suggestion voting activity date for " + member.getEffectiveName() + " to " + time);
+                }
+
+                // New Alpha Suggestion Voting
+                if (Arrays.stream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+                    discordUser.getLastActivity().setAlphaSuggestionVoteDate(time);
+                    log.info("Updating alpha suggestion voting activity date for " + member.getEffectiveName() + " to " + time);
+                }
             }
         }
-        discordUser.getLastActivity().setLastVoiceChannelJoinDate(time);
-        log.info("Updating last global voice activity date for " + member.getEffectiveName() + " to " + time);
+
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
@@ -41,17 +41,20 @@ public class ActivityListener {
 
     @SubscribeEvent
     public void onMessageReceived(MessageReceivedEvent event) {
-        if (!event.isFromGuild())
+        if (!event.isFromGuild()) {
             return; // Ignore Non Guild
+        }
 
         Member member = event.getMember();
-        if (member == null || member.getUser().isBot())
+        if (member == null || member.getUser().isBot()) {
             return; // Ignore Empty Member
+        }
 
         DiscordUser discordUser = Util.getOrAddUserToCache(this.database, member.getId());
 
-        if (discordUser == null)
+        if (discordUser == null) {
             return; // Ignore Empty User
+        }
 
         GuildMessageChannelUnion guildChannel = event.getGuildChannel();
         String channelId = guildChannel.getId();
@@ -102,15 +105,18 @@ public class ActivityListener {
     public void onVoiceChannelJoin(GuildVoiceUpdateEvent event) {
         Member member = event.getMember();
 
-        if (member.getUser().isBot())
+        if (member.getUser().isBot()) {
             return; // Ignore Bots
+        }
 
         DiscordUser discordUser = Util.getOrAddUserToCache(this.database, member.getId());
-        if (discordUser == null)
+        if (discordUser == null) {
             return; // Ignore Empty User
+        }
 
-        if (event.getChannelJoined() == null)
+        if (event.getChannelJoined() == null) {
             return; // Ignore Leave Events
+        }
 
         long time = System.currentTimeMillis();
         if (event.getChannelJoined().getName().toLowerCase().contains("alpha")) {
@@ -124,20 +130,24 @@ public class ActivityListener {
 
     @SubscribeEvent
     public void onReactionReceived(MessageReactionAddEvent event) {
-        if (!event.isFromGuild())
+        if (!event.isFromGuild()) {
             return; // Ignore Non Guild
+        }
 
         Member member = event.getMember();
-        if (member == null || member.getUser().isBot())
+        if (member == null || member.getUser().isBot()) {
             return; // Ignore Empty Member
+        }
 
         DiscordUser discordUser = Util.getOrAddUserToCache(this.database, member.getId());
 
-        if (discordUser == null)
+        if (discordUser == null) {
             return; // Ignore Empty User
+        }
 
-        if (event.getReaction().getEmoji().getType() != Emoji.Type.CUSTOM)
+        if (event.getReaction().getEmoji().getType() != Emoji.Type.CUSTOM) {
             return; // Ignore Native Emojis
+        }
 
         if (event.getGuildChannel() instanceof ThreadChannel) {
             BotConfig config = NerdBotApp.getBot().getConfig();

--- a/src/main/resources/example-config.json
+++ b/src/main/resources/example-config.json
@@ -5,7 +5,12 @@
   "interval": 120000,
   "guildId": "123456789012345678",
   "logChannel": "123456789012345678",
-  "suggestionForumId": "123456789012345678",
+  "suggestionForumIds": [
+    "123456789012345678"
+  ],
+  "alphaSuggestionForumIds": [
+    "123456789012345678"
+  ],
   "emojiConfig": {
     "agree": "123456789012345678",
     "disagree": "123456789012345678",


### PR DESCRIPTION
This adds code to separate Suggestion and Alpha activity for users in the database. It also adds an alpha tag for GreenlitMessage's in the database.

The following config fields in the build process and server storage need to be updated:
> suggestionForumId : suggestionForumIds

The following database fields in LastActivity need to be migrated and associated class files updated:
> lastGlobalActivity : globalMostRecent
> lastVoiceChannelJoinDate : globalVoiceJoinDate
> lastItemGenUsage : itemGenUsage
> lastSuggestionDate : suggestionCreationDate
> lastAlphaActivity : alphaMostRecent
> lastAlphaSuggestionDate : alphaSuggestionCreationDate