### PR TITLE
Track users who positively greenlit a suggestion

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/api/database/greenlit/GreenlitMessage.java
+++ b/src/main/java/net/hypixel/nerdbot/api/database/greenlit/GreenlitMessage.java
@@ -70,7 +70,7 @@ public class GreenlitMessage {
         builder.setDescription(description.toString());
         builder.addField("Agrees", String.valueOf(this.agrees), true);
         builder.addField("Disagrees", String.valueOf(this.disagrees), true);
-        builder.addField("Neutrals", String.valueOf(this.disagrees), true);
+        builder.addField("Neutrals", String.valueOf(this.neutrals), true);
         builder.addBlankField(true);
         builder.setTimestamp(Instant.ofEpochMilli(this.suggestionTimestamp));
 

--- a/src/main/java/net/hypixel/nerdbot/api/database/greenlit/GreenlitMessage.java
+++ b/src/main/java/net/hypixel/nerdbot/api/database/greenlit/GreenlitMessage.java
@@ -16,6 +16,7 @@ import java.awt.*;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @Builder
@@ -26,6 +27,7 @@ public class GreenlitMessage {
     private ObjectId id;
     private String userId, messageId, greenlitMessageId, suggestionTitle, suggestionContent, suggestionUrl, channelGroupName;
     private List<String> tags;
+    private List<String> positiveVoterIDs;
     private long suggestionTimestamp;
     private int agrees, disagrees, neutrals;
     private boolean alpha;
@@ -52,23 +54,35 @@ public class GreenlitMessage {
     public EmbedBuilder getEmbed() {
         EmbedBuilder builder = new EmbedBuilder();
 
-        builder.setTitle(suggestionTitle, suggestionUrl);
+        builder.setTitle(this.suggestionTitle, this.suggestionUrl);
         builder.setColor(Color.GREEN);
 
         StringBuilder description = new StringBuilder();
 
-        if (tags != null && !tags.isEmpty()) {
+        if (this.tags != null && !this.tags.isEmpty()) {
             description.append("**Tags:** `");
-            String tagString = String.join("`, `", tags);
+            String tagString = String.join("`, `", this.tags);
             description.append(tagString).append("`\n\n");
         }
 
-        description.append(suggestionContent);
+        description.append(this.suggestionContent);
 
         builder.setDescription(description.toString());
-        builder.addField("Agrees", String.valueOf(agrees), true);
-        builder.addField("Disagrees", String.valueOf(disagrees), true);
-        builder.setTimestamp(Instant.ofEpochMilli(suggestionTimestamp));
+        builder.addField("Agrees", String.valueOf(this.agrees), true);
+        builder.addField("Disagrees", String.valueOf(this.disagrees), true);
+        builder.addField("Neutrals", String.valueOf(this.disagrees), true);
+        builder.addBlankField(true);
+        builder.setTimestamp(Instant.ofEpochMilli(this.suggestionTimestamp));
+
+        if (this.positiveVoterIDs != null && !this.positiveVoterIDs.isEmpty()) {
+            builder.addField(
+                "Pre-Greenlit Votes",
+                this.positiveVoterIDs.stream()
+                    .map(userId -> ("<@" + userId + ">"))
+                    .collect(Collectors.joining(", ")),
+                false
+            );
+        }
 
         Guild guild = NerdBotApp.getBot().getJDA().getGuildById(NerdBotApp.getBot().getConfig().getGuildId());
         if (guild == null) {
@@ -78,9 +92,9 @@ public class GreenlitMessage {
         if (userId != null) {
             CompletableFuture<Member> memberFuture = CompletableFuture.supplyAsync(() -> guild.retrieveMemberById(userId).complete());
             Member member = memberFuture.join();
-            builder.setFooter("Suggested by " + member.getUser().getName(), member.getUser().getEffectiveAvatarUrl());
+            builder.setFooter("Suggested by: " + member.getUser().getName(), member.getUser().getEffectiveAvatarUrl());
         } else {
-            builder.setFooter("Suggested by an unknown user");
+            builder.setFooter("Suggested by: Unknown User");
         }
 
         return builder;

--- a/src/main/java/net/hypixel/nerdbot/api/database/greenlit/GreenlitMessage.java
+++ b/src/main/java/net/hypixel/nerdbot/api/database/greenlit/GreenlitMessage.java
@@ -27,7 +27,7 @@ public class GreenlitMessage {
     private ObjectId id;
     private String userId, messageId, greenlitMessageId, suggestionTitle, suggestionContent, suggestionUrl, channelGroupName;
     private List<String> tags;
-    private List<String> positiveVoterIDs;
+    private List<String> positiveVoterIds;
     private long suggestionTimestamp;
     private int agrees, disagrees, neutrals;
     private boolean alpha;
@@ -74,10 +74,10 @@ public class GreenlitMessage {
         builder.addBlankField(true);
         builder.setTimestamp(Instant.ofEpochMilli(this.suggestionTimestamp));
 
-        if (this.positiveVoterIDs != null && !this.positiveVoterIDs.isEmpty()) {
+        if (this.positiveVoterIds != null && !this.positiveVoterIds.isEmpty()) {
             builder.addField(
                 "Pre-Greenlit Voters",
-                this.positiveVoterIDs.stream()
+                this.positiveVoterIds.stream()
                     .map(userId -> ("<@" + userId + ">"))
                     .collect(Collectors.joining(", ")),
                 false

--- a/src/main/java/net/hypixel/nerdbot/api/database/greenlit/GreenlitMessage.java
+++ b/src/main/java/net/hypixel/nerdbot/api/database/greenlit/GreenlitMessage.java
@@ -76,7 +76,7 @@ public class GreenlitMessage {
 
         if (this.positiveVoterIDs != null && !this.positiveVoterIDs.isEmpty()) {
             builder.addField(
-                "Pre-Greenlit Votes",
+                "Pre-Greenlit Voters",
                 this.positiveVoterIDs.stream()
                     .map(userId -> ("<@" + userId + ">"))
                     .collect(Collectors.joining(", ")),

--- a/src/main/java/net/hypixel/nerdbot/curator/ForumChannelCurator.java
+++ b/src/main/java/net/hypixel/nerdbot/curator/ForumChannelCurator.java
@@ -4,6 +4,7 @@ import lombok.extern.log4j.Log4j2;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageHistory;
 import net.dv8tion.jda.api.entities.MessageReaction;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.forums.BaseForumTag;
@@ -18,7 +19,6 @@ import net.hypixel.nerdbot.bot.config.BotConfig;
 import net.hypixel.nerdbot.bot.config.EmojiConfig;
 
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -60,26 +60,22 @@ public class ForumChannelCurator extends Curator<ForumChannel> {
         log.info("Curating forum channel: " + forumChannel.getName() + " (Channel ID: " + forumChannel.getId() + ")");
 
         List<ThreadChannel> threads = forumChannel.getThreadChannels()
+            .stream()
+            .filter(threadChannel -> threadChannel.getAppliedTags()
                 .stream()
-                .filter(threadChannel -> threadChannel.getAppliedTags()
-                        .stream()
-                        .noneMatch(tag -> greenlitTags.contains(tag.getName().toLowerCase()))
-                )
-                .toList();
+                .noneMatch(tag -> greenlitTags.contains(tag.getName().toLowerCase()))
+            )
+            .toList();
 
-        log.info("Found " + threads.size() + " non-greenlit forum post(s)!");
+        log.info("Found " + threads.size() + " non-greenlit/docced forum post(s)!");
 
         int index = 0;
         for (ThreadChannel thread : threads) {
             log.info("[" + (++index) + "/" + threads.size() + "] Curating thread '" + thread.getName() + "' (ID: " + thread.getId() + ")");
 
-            if (thread.getAppliedTags().stream().map(ForumTag::getName).anyMatch(s -> s.equalsIgnoreCase("docced"))) {
-                log.info("Skipping thread '" + thread.getName() + "' (ID: " + thread.getId() + ") as it is already docced!");
-                continue;
-            }
-
             MessageHistory history = thread.getHistoryFromBeginning(1).complete();
             Message message = history.getRetrievedHistory().get(0);
+
             if (message == null) {
                 log.error("Message for thread '" + thread.getName() + "' (ID: " + thread.getId() + ") is null!");
                 continue;
@@ -89,28 +85,28 @@ public class ForumChannelCurator extends Curator<ForumChannel> {
                 log.info("Checking reaction counts for message ID: " + message.getId());
 
                 List<MessageReaction> reactions = message.getReactions()
-                        .stream()
-                        .filter(reaction -> reaction.getEmoji().getType() == Emoji.Type.CUSTOM)
-                        .toList();
+                    .stream()
+                    .filter(reaction -> reaction.getEmoji().getType() == Emoji.Type.CUSTOM)
+                    .toList();
 
                 Map<String, Integer> votes = Stream.of(
-                                emojiConfig.getAgreeEmojiId(),
-                                emojiConfig.getNeutralEmojiId(),
-                                emojiConfig.getDisagreeEmojiId()
-                        )
-                        .map(emojiId -> Pair.of(
-                                emojiId,
-                                reactions.stream()
-                                        .filter(reaction -> reaction.getEmoji()
-                                                .asCustom()
-                                                .getId()
-                                                .equalsIgnoreCase(emojiId)
-                                        )
-                                        .mapToInt(MessageReaction::getCount)
-                                        .findFirst()
-                                        .orElse(0)
-                        ))
-                        .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+                        emojiConfig.getAgreeEmojiId(),
+                        emojiConfig.getNeutralEmojiId(),
+                        emojiConfig.getDisagreeEmojiId()
+                    )
+                    .map(emojiId -> Pair.of(
+                        emojiId,
+                        reactions.stream()
+                            .filter(reaction -> reaction.getEmoji()
+                                .asCustom()
+                                .getId()
+                                .equalsIgnoreCase(emojiId)
+                            )
+                            .mapToInt(MessageReaction::getCount)
+                            .findFirst()
+                            .orElse(0)
+                    ))
+                    .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
 
                 int agree = votes.get(emojiConfig.getAgreeEmojiId());
                 int neutral = votes.get(emojiConfig.getNeutralEmojiId());
@@ -138,18 +134,28 @@ public class ForumChannelCurator extends Curator<ForumChannel> {
                 thread.getManager().setAppliedTags(tags).complete();
 
                 GreenlitMessage greenlitMessage = GreenlitMessage.builder()
-                        .agrees(agree)
-                        .neutrals(neutral)
-                        .disagrees(disagree)
-                        .messageId(message.getId())
-                        .userId(message.getAuthor().getId())
-                        .alpha(forumChannel.getName().toLowerCase().contains("alpha"))
-                        .suggestionUrl(message.getJumpUrl())
-                        .suggestionTitle(thread.getName())
-                        .suggestionTimestamp(thread.getTimeCreated().toInstant().toEpochMilli())
-                        .suggestionContent(message.getContentRaw())
-                        .tags(thread.getAppliedTags().stream().map(BaseForumTag::getName).toList())
-                        .build();
+                    .agrees(agree)
+                    .neutrals(neutral)
+                    .disagrees(disagree)
+                    .messageId(message.getId())
+                    .userId(message.getAuthor().getId())
+                    .alpha(forumChannel.getName().toLowerCase().contains("alpha"))
+                    .suggestionUrl(message.getJumpUrl())
+                    .suggestionTitle(thread.getName())
+                    .suggestionTimestamp(thread.getTimeCreated().toInstant().toEpochMilli())
+                    .suggestionContent(message.getContentRaw())
+                    .tags(thread.getAppliedTags().stream().map(BaseForumTag::getName).toList())
+                    .positiveVoterIDs(
+                        reactions.stream()
+                            .filter(reaction -> emojiConfig.isEquals(reaction, EmojiConfig::getAgreeEmojiId))
+                            .flatMap(reaction -> reaction.retrieveUsers()
+                                .complete()
+                                .stream()
+                            )
+                            .map(User::getId)
+                            .collect(Collectors.toList())
+                    )
+                    .build();
                 output.add(greenlitMessage);
             } catch (Exception exception) {
                 exception.printStackTrace();

--- a/src/main/java/net/hypixel/nerdbot/curator/ForumChannelCurator.java
+++ b/src/main/java/net/hypixel/nerdbot/curator/ForumChannelCurator.java
@@ -145,7 +145,7 @@ public class ForumChannelCurator extends Curator<ForumChannel> {
                     .suggestionTimestamp(thread.getTimeCreated().toInstant().toEpochMilli())
                     .suggestionContent(message.getContentRaw())
                     .tags(thread.getAppliedTags().stream().map(BaseForumTag::getName).toList())
-                    .positiveVoterIDs(
+                    .positiveVoterIds(
                         reactions.stream()
                             .filter(reaction -> emojiConfig.isEquals(reaction, EmojiConfig::getAgreeEmojiId))
                             .flatMap(reaction -> reaction.retrieveUsers()

--- a/src/main/java/net/hypixel/nerdbot/feature/CurateFeature.java
+++ b/src/main/java/net/hypixel/nerdbot/feature/CurateFeature.java
@@ -31,8 +31,8 @@ public class CurateFeature extends BotFeature {
                     final Curator<ForumChannel> forumChannelCurator = new ForumChannelCurator(NerdBotApp.getBot().isReadOnly());
 
                     Stream.concat(
-                            Arrays.stream(NerdBotApp.getBot().getConfig().getSuggestionForumIds()).map(forumId -> Pair.of(forumId, false)),
-                            Arrays.stream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).map(forumId -> Pair.of(forumId, true))
+                        Arrays.stream(NerdBotApp.getBot().getConfig().getSuggestionForumIds()).map(forumId -> Pair.of(forumId, false)),
+                        Arrays.stream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).map(forumId -> Pair.of(forumId, true))
                     ).filter(pair -> Objects.nonNull(pair.getLeft()))
                     .forEach(suggestionForum -> {
                         String id = suggestionForum.getLeft();
@@ -54,13 +54,13 @@ public class CurateFeature extends BotFeature {
 
                         // Update Database
                         result.forEach(greenlitMessage -> database.upsertDocument(
-                                database.getCollection(
-                                        "greenlit_messages",
-                                        GreenlitMessage.class
-                                ),
-                                "messageId",
-                                greenlitMessage.getMessageId(),
-                                greenlitMessage
+                            database.getCollection(
+                                "greenlit_messages",
+                                GreenlitMessage.class
+                            ),
+                            "messageId",
+                            greenlitMessage.getMessageId(),
+                            greenlitMessage
                         ));
                         log.info("Inserted " + result.size() + " new greenlit messages into the database!");
                     });


### PR DESCRIPTION
This implements a change to Greenlit Suggestion curating that saves the user IDs of anyone who positively votes (agrees) with a suggestion, when it is curated and Greenlit. It also updates the greenlit suggestion embed with this information, dubbed "Pre-Greenlit Voters"