### PR TITLE
New Stats and `/itemgenparse`

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
@@ -181,7 +181,7 @@ public class ItemGenCommands extends ApplicationCommand {
         // adding all the text to the string builders
         StringBuilder itemText = new StringBuilder();
         itemText.append(itemName).append("\\n");
-        itemGenCommand.append(" name:").append(itemName).append(" rarity:<> description:");
+        itemGenCommand.append(" name:").append(itemName).append(" rarity:NONE description:");
 
         for (JsonElement element : itemLoreArray) {
             String itemLore = element.getAsString().replaceAll("§", "&");

--- a/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
@@ -139,7 +139,7 @@ public class ItemGenCommands extends ApplicationCommand {
     @JDASlashCommand(name = "itemgenparse", description = "Converts a minecraft item into a Nerd Bot item!")
     public void parseItemDescription(GuildSlashEvent event,
                                      @AppOption(description = DESC_PARSE_ITEM) String description,
-                                     @AppOption(description = DESC_HIDDEN) Boolean hidden) throws IOException {
+                                     @Optional @AppOption(description = DESC_HIDDEN) Boolean hidden) throws IOException {
         if (isIncorrectChannel(event)) {
             return;
         }

--- a/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
@@ -237,7 +237,7 @@ public class ItemGenCommands extends ApplicationCommand {
                 `handle_line_breaks (true/false)`: To be used if you're manually handling line breaks between the description and rarity.
                 `alpha`: Sets the transparency of the background layer. 0 for transparent, 255 for opaque (default). 245 for overlay.
                 `padding`: Adds transparency around the entire image. Must be 0 (default) or higher.
-                `max_line_length`: Defines the maximum length that the line can be. Can be between 0 and 38.
+                `max_line_length`: Defines the maximum length that the line can be. Can be between 1 and 54.
                 """, false);
 
         colorBuilder.setColor(Color.YELLOW)
@@ -252,6 +252,7 @@ public class ItemGenCommands extends ApplicationCommand {
         extraInfoBuilder.setColor(Color.GRAY)
             .addField("Other Information",
                 """
+                There is another command `/itemgenparse` which can be used to easily convert the display NBT Tag from a Minecraft item into a Generated Image. This display tag should be surrounded with curly brackets with a "Lore" (string array) and "Name" (string) attribute in them
                 You can also check out `/infoheadgen` for more information about rendering items next to your creations!
                 Have fun making items! You can click the blue /itemgen command above anyone's image to see what command they're using to create their image. Thanks!
                 The item generation bot is maintained by the Bot Contributors. Feel free to tag them with any issues.

--- a/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
@@ -56,7 +56,7 @@ public class ItemGenCommands extends ApplicationCommand {
         hidden = (hidden != null && hidden);
         event.deferReply(hidden).queue();
 
-        MinecraftImage generatedImage = buildItem(event, "NONE", "NONE", description, "", true, 0, 1, StringColorParser.MAX_STANDARD_LINE_LENGTH);
+        MinecraftImage generatedImage = buildItem(event, "NONE", "NONE", description, "", true, 0, 1, StringColorParser.MAX_FINAL_LINE_LENGTH);
         if (generatedImage != null) {
             event.getHook().sendFiles(FileUpload.fromData(Util.toFile(generatedImage.getImage()))).setEphemeral(hidden).queue();
         }

--- a/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
@@ -7,7 +7,7 @@ import com.freya02.botcommands.api.application.slash.GuildSlashEvent;
 import com.freya02.botcommands.api.application.slash.annotations.JDASlashCommand;
 import com.freya02.botcommands.api.application.slash.autocomplete.AutocompletionMode;
 import com.freya02.botcommands.api.application.slash.autocomplete.annotations.AutocompletionHandler;
-import com.google.gson.JsonObject;
+import com.google.gson.*;
 import lombok.extern.log4j.Log4j2;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Member;
@@ -18,10 +18,7 @@ import net.dv8tion.jda.api.utils.FileUpload;
 import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.database.user.DiscordUser;
 import net.hypixel.nerdbot.channel.ChannelManager;
-import net.hypixel.nerdbot.generator.ImageMerger;
-import net.hypixel.nerdbot.generator.MinecraftHead;
-import net.hypixel.nerdbot.generator.MinecraftImage;
-import net.hypixel.nerdbot.generator.StringColorParser;
+import net.hypixel.nerdbot.generator.*;
 import net.hypixel.nerdbot.util.Util;
 import net.hypixel.nerdbot.util.skyblock.MCColor;
 import net.hypixel.nerdbot.util.skyblock.Rarity;
@@ -53,11 +50,11 @@ public class ItemGenCommands extends ApplicationCommand {
 
     @JDASlashCommand(name = "textgen", description = "Creates an image that looks like a message from Minecraft, primarily used for Hypixel Skyblock")
     public void generateText(GuildSlashEvent event, @AppOption(description = DESC_DESCRIPTION) String description, @Optional @AppOption(description = DESC_HIDDEN) Boolean hidden) throws IOException {
-        hidden = (hidden != null && hidden);
-        event.deferReply(hidden).queue();
         if (isIncorrectChannel(event)) {
             return;
         }
+        hidden = (hidden != null && hidden);
+        event.deferReply(hidden).queue();
 
         MinecraftImage generatedImage = buildItem(event, "NONE", "NONE", description, "", true, 0, 1, StringColorParser.MAX_LINE_LENGTH);
         if (generatedImage != null) {
@@ -76,11 +73,11 @@ public class ItemGenCommands extends ApplicationCommand {
                              @Optional @AppOption(description = DESC_PADDING) Integer padding,
                              @Optional @AppOption(description = DESC_MAX_LINE_LENGTH) Integer maxLineLength,
                              @Optional @AppOption(description = DESC_HIDDEN) Boolean hidden) throws IOException {
-        hidden = (hidden != null && hidden);
-        event.deferReply(hidden).queue();
         if (isIncorrectChannel(event)) {
             return;
         }
+        hidden = (hidden != null && hidden);
+        event.deferReply(hidden).queue();
 
         MinecraftImage generatedImage = buildItem(event, name, rarity, description, type, handleLineBreaks, alpha, padding, maxLineLength);
         if (generatedImage != null) {
@@ -93,11 +90,11 @@ public class ItemGenCommands extends ApplicationCommand {
                              @AppOption(description = DESC_HEAD_ID) String skinId,
                              @Optional @AppOption(description = DESC_IS_PLAYER_NAME) Boolean isPlayerName,
                              @Optional @AppOption(description = DESC_HIDDEN) Boolean hidden) throws IOException {
-        hidden = (hidden != null && hidden);
-        event.deferReply(hidden).queue();
         if (isIncorrectChannel(event)) {
             return;
         }
+        hidden = (hidden != null && hidden);
+        event.deferReply(hidden).queue();
 
         MinecraftHead head = buildHead(event, skinId, isPlayerName);
         if (head != null) {
@@ -118,11 +115,11 @@ public class ItemGenCommands extends ApplicationCommand {
                                  @Optional @AppOption(description = DESC_MAX_LINE_LENGTH) Integer maxLineLength,
                                  @Optional @AppOption(description = DESC_HIDDEN) Boolean hidden,
                                  @Optional @AppOption(description = DESC_IS_PLAYER_NAME) Boolean isPlayerName) throws IOException {
-        hidden = (hidden != null && hidden);
-        event.deferReply(hidden).queue();
         if (isIncorrectChannel(event)) {
             return;
         }
+        hidden = (hidden != null && hidden);
+        event.deferReply(hidden).queue();
 
         MinecraftHead generatedHead = buildHead(event, skinId, isPlayerName);
         if (generatedHead == null) {
@@ -333,7 +330,7 @@ public class ItemGenCommands extends ApplicationCommand {
         String[] itemGenChannelIds = NerdBotApp.getBot().getConfig().getItemGenChannel();
 
         if (itemGenChannelIds == null) {
-            event.getHook().sendMessage("The config for the item generating channel is not ready yet. Try again later!").setEphemeral(true).queue();
+            event.reply("The config for the item generating channel is not ready yet. Try again later!").setEphemeral(true).queue();
             return true;
         }
 
@@ -342,10 +339,10 @@ public class ItemGenCommands extends ApplicationCommand {
             //error message.
             TextChannel channel = ChannelManager.getChannel(itemGenChannelIds[0]);
             if (channel == null) {
-                event.getHook().sendMessage("This can only be used in the item generating channel.").setEphemeral(true).queue();
+                event.reply("This can only be used in the item generating channel.").setEphemeral(true).queue();
                 return true;
             }
-            event.getHook().sendMessage("This can only be used in the " + channel.getAsMention() + " channel.").setEphemeral(true).queue();
+            event.reply("This can only be used in the " + channel.getAsMention() + " channel.").setEphemeral(true).queue();
             return true;
         }
 

--- a/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
@@ -56,7 +56,7 @@ public class ItemGenCommands extends ApplicationCommand {
         hidden = (hidden != null && hidden);
         event.deferReply(hidden).queue();
 
-        MinecraftImage generatedImage = buildItem(event, "NONE", "NONE", description, "", true, 0, 1, StringColorParser.MAX_LINE_LENGTH);
+        MinecraftImage generatedImage = buildItem(event, "NONE", "NONE", description, "", true, 0, 1, StringColorParser.MAX_STANDARD_LINE_LENGTH);
         if (generatedImage != null) {
             event.getHook().sendFiles(FileUpload.fromData(Util.toFile(generatedImage.getImage()))).setEphemeral(hidden).queue();
         }
@@ -390,6 +390,8 @@ public class ItemGenCommands extends ApplicationCommand {
             // adds the items type in the description
             String createRarity = "\\n%%" + itemRarity.getRarityColor() + "%%%%BOLD%%" + itemRarity.getId().toUpperCase() + " " + type;
             itemLore.append(createRarity);
+        } else {
+            itemLore.append("\\n");
         }
 
         // creating a string parser to convert the string into color flagged text

--- a/src/main/java/net/hypixel/nerdbot/generator/ColoredString.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/ColoredString.java
@@ -16,6 +16,7 @@ public class ColoredString {
     private boolean isItalic;
     private boolean isStrikethrough;
     private boolean isUnderlined;
+    private boolean isObfuscated;
 
     public ColoredString() {
         this.currentString = new StringBuilder(36);

--- a/src/main/java/net/hypixel/nerdbot/generator/StatColorParser.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/StatColorParser.java
@@ -8,16 +8,27 @@ public class StatColorParser {
      * Displays the selected stat with its extra details and id in its primary color
      * @param stat the selected stat
      * @param extraDetails the extra arguments provided
-     * @return returns the color parsed replacement string
+     * @return the color parsed replacement string
      */
     public static String normalStatColorParser(Stat stat, String extraDetails) {
         return "%%" + stat.getColor() + "%%" + extraDetails + stat.getDisplay();
     }
 
+    /**
+     * Displays the selected stat with its icon bolded extra details and id in its primary color
+     * @param stat the selected stat
+     * @param extraDetails the extra arguments provided
+     * @return the color parsed replacement string
+     */
     public static String boldedIconColorParser(Stat stat, String extraDetails) {
         return "%%" + stat.getColor() + "%%" + extraDetails + "%%BOLD%%" + stat.getIcon() + "%%" + stat.getColor() + "%% " + stat.getStat();
     }
 
+    /**
+     * Displays the selected stat with its icon bolded
+     * @param stat the selected stat
+     * @return the color parsed replacement string
+     */
     public static String boldedIconParser(Stat stat) {
         return "%%" + stat.getColor() + "%%%%BOLD%%" + stat.getIcon();
     }
@@ -26,7 +37,7 @@ public class StatColorParser {
      * Displays the selected stat with numbers in the secondary color and remaining text in primary color
      * @param stat the stat selected
      * @param extraDetails the extra arguments provided
-     * @return returns the color parsed replacement string
+     * @return the color parsed replacement string
      */
     public static String dualStatColorParser(Stat stat, String extraDetails) {
         if (extraDetails.length() == 0) {
@@ -40,7 +51,7 @@ public class StatColorParser {
      * Displays the stat with no extra details added on
      * @param stat the stat selected
      * @param extraDetails the extra arguments provided (ignored)
-     * @return returns the color parsed replacement string
+     * @return the color parsed replacement string
      */
     public static String noParsing(Stat stat, String extraDetails) {
         return "%%" + stat.getColor() + "%%" + stat.getStat();
@@ -50,7 +61,7 @@ public class StatColorParser {
      * Displays the selected stat with extra data after the id.
      * @param stat the stat selected
      * @param extraDetails the extra arguments provided
-     * @return returns the color parsed replacement string
+     * @return the color parsed replacement string
      */
     public static String postStatColorParser(Stat stat, String extraDetails) {
         return "%%" + stat.getColor() + "%%" + stat.getDisplay() + " " + extraDetails;
@@ -68,9 +79,9 @@ public class StatColorParser {
 
     /**
      * Displays the selected stat with an Item Stat and amount
-     * @param stat the stat selected
+     * @param stat the stat selected (ITEM_STAT_color)
      * @param extraDetails the extra arguments provided
-     * @return returns the color parsed replacements string
+     * @return the color parsed replacements string
      */
     public static String itemStatColorParser(Stat stat, String extraDetails) {
         if (extraDetails.length() == 0) {

--- a/src/main/java/net/hypixel/nerdbot/generator/StatColorParser.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/StatColorParser.java
@@ -56,6 +56,16 @@ public class StatColorParser {
         return "%%" + stat.getColor() + "%%" + stat.getDisplay() + " " + extraDetails;
     }
 
+    /***
+     * Displays the selected stat with the text after it changed color
+     * @param stat the stat selected
+     * @param extraDetails the extra arguments provided
+     * @return the color parsed replacement string
+     */
+    public static String postDualColorParser(Stat stat, String extraDetails) {
+        return "%%" + stat.getColor() + "%%" + stat.getStat() + " %%" + stat.getSecondaryColor() + "%%" + extraDetails;
+    }
+
     /**
      * Displays the selected stat with an Item Stat and amount
      * @param stat the stat selected
@@ -76,5 +86,27 @@ public class StatColorParser {
         String amount = extraDetails.substring(separator + 1);
 
         return "%%GRAY%%" + itemStat + ": %%" + stat.getSecondaryColor() + "%%" + amount;
+    }
+
+    /**
+     * Displays the selected stat with an Ability name and amount
+     * @param stat the stat selected (ABILITY)
+     * @param extraDetails the extra arguments provided
+     * @return the color parsed replacements string
+     */
+    public static String abilityColorParser(Stat stat, String extraDetails) {
+        if (extraDetails.length() == 0) {
+            return "ABILITY_MISSING_DETAILS";
+        }
+
+        int separator = extraDetails.indexOf(":");
+        if (separator == -1) {
+            return "ABILITY_MISSING_SEPARATOR";
+        }
+
+        String abilityName = extraDetails.substring(0, separator);
+        String abilityType = extraDetails.substring(separator + 1);
+
+        return "%%" + stat.getColor() + "%%" + stat.getStat() + ": " + abilityName + " %%" + stat.getSecondaryColor() + "%%%%BOLD%%" + abilityType;
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/generator/StringColorParser.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/StringColorParser.java
@@ -10,7 +10,8 @@ import java.util.List;
 import java.util.Objects;
 
 public class StringColorParser {
-    public static final int MAX_LINE_LENGTH = 38;
+    public static final int MAX_STANDARD_LINE_LENGTH = 38;
+    public static final int MAX_FINAL_LINE_LENGTH = 50;
 
     private static final MCColor[] colors = MCColor.VALUES;
     private static final Stat[] stats = Stat.VALUES;
@@ -37,8 +38,8 @@ public class StringColorParser {
         lineLength = 0;
         successfullyParsed = false;
 
-        maxLength = Objects.requireNonNullElse(maxLength, StringColorParser.MAX_LINE_LENGTH);
-        maxLineLength = Math.min(StringColorParser.MAX_LINE_LENGTH, Math.max(0, maxLength));
+        maxLength = Objects.requireNonNullElse(maxLength, StringColorParser.MAX_STANDARD_LINE_LENGTH);
+        maxLineLength = Math.min(StringColorParser.MAX_FINAL_LINE_LENGTH, Math.max(1, maxLength));
     }
 
     public List<ArrayList<ColoredString>> getParsedDescription() {

--- a/src/main/java/net/hypixel/nerdbot/generator/StringColorParser.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/StringColorParser.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 
 public class StringColorParser {
     public static final int MAX_STANDARD_LINE_LENGTH = 38;
-    public static final int MAX_FINAL_LINE_LENGTH = 50;
+    public static final int MAX_FINAL_LINE_LENGTH = 54;
 
     private static final MCColor[] colors = MCColor.VALUES;
     private static final Stat[] stats = Stat.VALUES;

--- a/src/main/java/net/hypixel/nerdbot/generator/StringColorParser.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/StringColorParser.java
@@ -99,6 +99,7 @@ public class StringColorParser {
                             case ITALIC -> this.setItalic(true);
                             case STRIKETHROUGH -> this.setStrikethrough(true);
                             case UNDERLINE -> this.setUnderlined(true);
+                            case OBFUSCATED -> this.setObfuscated(true);
                             default -> this.setColor(mcColor);
                         }
                         charIndex = closingIndex + 2;
@@ -166,6 +167,7 @@ public class StringColorParser {
                                 case ITALIC -> this.setItalic(true);
                                 case STRIKETHROUGH -> this.setStrikethrough(true);
                                 case UNDERLINE -> this.setUnderlined(true);
+                                case OBFUSCATED -> this.setObfuscated(true);
                                 default -> this.setColor(mcColor);
                             }
                             charIndex += 2;
@@ -326,6 +328,19 @@ public class StringColorParser {
             currentString = new ColoredString(currentString);
         }
         currentString.setUnderlined(underline);
+    }
+
+    /**
+     * sets if the next segment has obfuscation
+     * @param obfuscated state of obfuscated to change to
+     */
+    private void setObfuscated(boolean obfuscated) {
+        // checking if there is any text on the current string before changing it to obfuscated
+        if (!currentString.isEmpty()) {
+            currentLine.add(currentString);
+            currentString = new ColoredString(currentString);
+        }
+        currentString.setStrikethrough(obfuscated);
     }
 
     /**

--- a/src/main/java/net/hypixel/nerdbot/util/skyblock/MCColor.java
+++ b/src/main/java/net/hypixel/nerdbot/util/skyblock/MCColor.java
@@ -23,6 +23,7 @@ public enum MCColor {
     STRIKETHROUGH('m', new Color(255, 255, 255), new Color(255, 255, 255)),
     UNDERLINE('n', new Color(255, 255, 255), new Color(255, 255, 255)),
     ITALIC('o', new Color(255, 255, 255), new Color(85, 85, 255)),
+    OBFUSCATED('k', new Color(255, 255, 255), new Color(85, 85, 255)),
     RESET('r', new Color(170, 170, 170), new Color(42, 42, 42));
 
     public static final MCColor[] VALUES = values();

--- a/src/main/java/net/hypixel/nerdbot/util/skyblock/Stat.java
+++ b/src/main/java/net/hypixel/nerdbot/util/skyblock/Stat.java
@@ -39,6 +39,8 @@ public enum Stat {
     ITEM_STAT_RED("", "ITEM_STAT_RED", MCColor.GRAY, MCColor.RED, StatColorParser::itemStatColorParser, null),
     ITEM_STAT_GREEN("", "ITEM_STAT_GREEN", MCColor.GRAY, MCColor.GREEN, StatColorParser::itemStatColorParser, null),
     ITEM_STAT_PURPLE("", "ITEM_STAT_PINK", MCColor.GRAY, MCColor.LIGHT_PURPLE, StatColorParser::itemStatColorParser, null),
+    COOLDOWN("", "Cooldown:", MCColor.DARK_GRAY, MCColor.GREEN, StatColorParser::postDualColorParser, null),
+    ABILITY("", "Ability", MCColor.GOLD, MCColor.YELLOW, StatColorParser::abilityColorParser, null),
     COMBAT_WISDOM("☯", "Combat Wisdom", MCColor.DARK_AQUA),
     MINING_WISDOM("☯", "Mining Wisdom", MCColor.DARK_AQUA),
     FARMING_WISDOM("☯", "Farming Wisdom", MCColor.DARK_AQUA),


### PR DESCRIPTION
- Adds a new command `/itemgenparse` which will convert the display tag in the NBT of an item into a format which is displayable with the bot.
    - This should only accept a full JSON object with both a `Name` string and `Lore` array.
- Adds new stats `ABILITY` which acts similar to `ITEM_STAT_GREEN`
    - `%%ABILITY:Instant Transmission:RIGHT CLICK%%` -> `%%GOLD%%Ability: Instant Transmission%%YELLOW%%%%BOLD%%RIGHT CLICK`
-  Adds new stat `COOLDOWN` which puts the text after it in green
- Fix for the items description from being chopped off
- Fix for the `itemgen` command displaying a message in channels it isn't supposed to
- Fix for being able to set the line length to 0
- Fix typos in comments and added missing function comments