### PR TITLE
Config editor

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/api/bot/Bot.java
+++ b/src/main/java/net/hypixel/nerdbot/api/bot/Bot.java
@@ -5,8 +5,10 @@ import net.dv8tion.jda.api.JDABuilder;
 import net.hypixel.nerdbot.api.database.Database;
 import net.hypixel.nerdbot.api.feature.BotFeature;
 import net.hypixel.nerdbot.bot.config.BotConfig;
+import org.jetbrains.annotations.NotNull;
 
 import javax.security.auth.login.LoginException;
+import java.io.IOException;
 import java.util.List;
 
 public interface Bot {
@@ -32,4 +34,7 @@ public interface Bot {
     long getUptime();
 
     boolean isReadOnly();
+
+    boolean writeConfig(@NotNull BotConfig newConfig);
+
 }

--- a/src/main/java/net/hypixel/nerdbot/bot/NerdBot.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/NerdBot.java
@@ -209,18 +209,20 @@ public class NerdBot implements Bot {
         } else {
             log.info("Config property not defined, going to default path!");
             fileName = Environment.getEnvironment().name().toLowerCase() + ".config.json";
-            return false;
         }
 
         Gson jsonConfig = new GsonBuilder().setPrettyPrinting().create();
         //Actually write the new config
         try {
-            jsonConfig.toJson(newConfig, new FileWriter(fileName));
+            //SPECIAL NOTE: You need to close the FileWriter or else it doesn't write the whole config :)
+            FileWriter fw = new FileWriter(fileName);
+            jsonConfig.toJson(newConfig, fw);
+            fw.close();
+            return true;
         } catch (IOException e) {
             log.error("Could not save config file.");
             e.printStackTrace();
             return false;
         }
-        return true;
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/bot/NerdBot.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/NerdBot.java
@@ -209,6 +209,7 @@ public class NerdBot implements Bot {
         } else {
             log.info("Config property not defined, going to default path!");
             fileName = Environment.getEnvironment().name().toLowerCase() + ".config.json";
+            return false;
         }
 
         Gson jsonConfig = new GsonBuilder().setPrettyPrinting().create();
@@ -218,8 +219,8 @@ public class NerdBot implements Bot {
         } catch (IOException e) {
             log.error("Could not save config file.");
             e.printStackTrace();
+            return false;
         }
-
         return true;
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/bot/NerdBot.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/NerdBot.java
@@ -1,6 +1,7 @@
 package net.hypixel.nerdbot.bot;
 
 import com.freya02.botcommands.api.CommandsBuilder;
+import com.google.gson.Gson;
 import lombok.extern.log4j.Log4j2;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
@@ -26,6 +27,8 @@ import net.hypixel.nerdbot.util.Environment;
 import net.hypixel.nerdbot.util.Util;
 import net.hypixel.nerdbot.util.discord.ForumChannelResolver;
 import net.hypixel.nerdbot.util.discord.Users;
+import org.bson.json.JsonObject;
+import org.jetbrains.annotations.NotNull;
 
 import javax.security.auth.login.LoginException;
 import java.io.*;
@@ -194,5 +197,28 @@ public class NerdBot implements Bot {
             log.error("Could not find config file " + fileName);
             System.exit(-1);
         }
+    }
+
+    public boolean writeConfig(@NotNull BotConfig newConfig) {
+        //Get the location that we're saving the config at
+        String fileName;
+        if (System.getProperty("bot.config") != null) {
+            fileName = System.getProperty("bot.config");
+            log.info("Found config property: " + fileName);
+        } else {
+            log.info("Config property not defined, going to default path!");
+            fileName = Environment.getEnvironment().name().toLowerCase() + ".config.json";
+        }
+
+        //Actually write the new config
+        Gson gsonConfig = new Gson();
+        try {
+            gsonConfig.toJson(newConfig, new FileWriter(fileName));
+        } catch (IOException e) {
+            log.error("Could not save config file.");
+            e.printStackTrace();
+        }
+
+        return true;
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/bot/NerdBot.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/NerdBot.java
@@ -27,7 +27,6 @@ import net.hypixel.nerdbot.util.Environment;
 import net.hypixel.nerdbot.util.Util;
 import net.hypixel.nerdbot.util.discord.ForumChannelResolver;
 import net.hypixel.nerdbot.util.discord.Users;
-import org.bson.json.JsonObject;
 import org.jetbrains.annotations.NotNull;
 
 import javax.security.auth.login.LoginException;
@@ -199,6 +198,7 @@ public class NerdBot implements Bot {
         }
     }
 
+    @Override
     public boolean writeConfig(@NotNull BotConfig newConfig) {
         //Get the location that we're saving the config at
         String fileName;

--- a/src/main/java/net/hypixel/nerdbot/bot/NerdBot.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/NerdBot.java
@@ -2,6 +2,7 @@ package net.hypixel.nerdbot.bot;
 
 import com.freya02.botcommands.api.CommandsBuilder;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import lombok.extern.log4j.Log4j2;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
@@ -210,10 +211,10 @@ public class NerdBot implements Bot {
             fileName = Environment.getEnvironment().name().toLowerCase() + ".config.json";
         }
 
+        Gson jsonConfig = new GsonBuilder().setPrettyPrinting().create();
         //Actually write the new config
-        Gson gsonConfig = new Gson();
         try {
-            gsonConfig.toJson(newConfig, new FileWriter(fileName));
+            jsonConfig.toJson(newConfig, new FileWriter(fileName));
         } catch (IOException e) {
             log.error("Could not save config file.");
             e.printStackTrace();

--- a/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
@@ -124,24 +124,25 @@ public class AdminCommands extends ApplicationCommand {
 
     @JDASlashCommand(name = "config", subcommand = "edit", description = "Edit the config file", defaultLocked = true)
     public void editConfig(GuildSlashEvent event, @AppOption() String json) {
+//         json = json.replace(" ", "");
         Gson jsonConfig = new Gson();
+        BotConfig newConfig;
 
         try { //This should require all the fields of BotConfig.class to be filled
-            jsonConfig.toJson(json, BotConfig.class);
+            newConfig = jsonConfig.fromJson(json, BotConfig.class);
         } catch(Exception e) {
-            event.reply("I failed to edit the config file. ):").setEphemeral(true).queue();
+            event.reply("I failed to edit the config file because I couldn't parse the json. ):").setEphemeral(true).queue();
             e.printStackTrace();
             return;
         }
-
-        BotConfig newConfig = new BotConfig();
 
         Bot bot = NerdBotApp.getBot();
         boolean success = bot.writeConfig(newConfig);
         if (success) {
             event.reply("Edited the config file!").setEphemeral(true).queue();
+            log.info(event.getUser().getName() + " edited the config!\n" + newConfig);
         } else {
-            event.reply("I failed to edit the config file. ):").setEphemeral(true).queue();
+            event.reply("I failed to edit the config file because I couldn't write the config. ):").setEphemeral(true).queue();
         }
     }
 

--- a/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
@@ -5,6 +5,7 @@ import com.freya02.botcommands.api.application.ApplicationCommand;
 import com.freya02.botcommands.api.application.annotations.AppOption;
 import com.freya02.botcommands.api.application.slash.GuildSlashEvent;
 import com.freya02.botcommands.api.application.slash.annotations.JDASlashCommand;
+import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import lombok.extern.log4j.Log4j2;
@@ -107,11 +108,20 @@ public class AdminCommands extends ApplicationCommand {
 
     @JDASlashCommand(name = "config", subcommand = "show", description = "View the currently loaded config", defaultLocked = true)
     public void showConfig(GuildSlashEvent event) {
-        event.reply("```json\n" + NerdBotApp.getBot().getConfig().toString() + "```").setEphemeral(true).queue();
+        Gson jsonConfig = new Gson();
+        event.reply("```json\n" + jsonConfig.toJson(NerdBotApp.getBot().getConfig()) + "```").setEphemeral(true).queue();
     }
 
     @JDASlashCommand(name = "config", subcommand = "reload", description = "Reload the config file", defaultLocked = true)
     public void reloadConfig(GuildSlashEvent event) {
+        Bot bot = NerdBotApp.getBot();
+        bot.loadConfig();
+        bot.getJDA().getPresence().setActivity(Activity.of(bot.getConfig().getActivityType(), bot.getConfig().getActivity()));
+        event.reply("Reloaded the config file!").setEphemeral(true).queue();
+    }
+
+    @JDASlashCommand(name = "config", subcommand = "edit", description = "Edit the config file", defaultLocked = true)
+    public void editConfig(GuildSlashEvent event) {
         Bot bot = NerdBotApp.getBot();
         bot.loadConfig();
         bot.getJDA().getPresence().setActivity(Activity.of(bot.getConfig().getActivityType(), bot.getConfig().getActivity()));


### PR DESCRIPTION
Allows admins to edit the config through discord without having to SSH in.

Requires `/config reload` to be used afterwards. 