### PR TITLE
Cache suggestion threads on startup

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/NerdBotApp.java
+++ b/src/main/java/net/hypixel/nerdbot/NerdBotApp.java
@@ -5,12 +5,14 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Scheduler;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import net.hypixel.nerdbot.api.bot.Bot;
 import net.hypixel.nerdbot.api.database.Database;
 import net.hypixel.nerdbot.api.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.bot.NerdBot;
 import net.hypixel.nerdbot.util.discord.MessageCache;
+import net.hypixel.nerdbot.util.discord.SuggestionCache;
 
 import javax.security.auth.login.LoginException;
 import java.time.Duration;
@@ -32,8 +34,9 @@ public class NerdBotApp {
                 log.info("Upserted cached user '" + discordUser.getDiscordId() + "'");
             }).build();
 
-    private static MessageCache messageCache;
-    private static Bot bot;
+    @Getter private static SuggestionCache suggestionCache;
+    @Getter private static MessageCache messageCache;
+    @Getter private static Bot bot;
 
     public static void main(String[] args) {
         NerdBot nerdBot = new NerdBot();
@@ -41,6 +44,7 @@ public class NerdBotApp {
         try {
             nerdBot.create(args);
             messageCache = new MessageCache();
+            suggestionCache = new SuggestionCache();
         } catch (LoginException e) {
             log.error("Failed to find login for bot!");
             System.exit(-1);
@@ -56,11 +60,4 @@ public class NerdBotApp {
         Runtime.getRuntime().addShutdownHook(userSavingTask);
     }
 
-    public static Bot getBot() {
-        return bot;
-    }
-
-    public static MessageCache getMessageCache() {
-        return messageCache;
-    }
 }

--- a/src/main/java/net/hypixel/nerdbot/bot/NerdBot.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/NerdBot.java
@@ -29,6 +29,7 @@ import net.hypixel.nerdbot.listener.ActivityListener;
 import net.hypixel.nerdbot.listener.ModLogListener;
 import net.hypixel.nerdbot.listener.ModMailListener;
 import net.hypixel.nerdbot.listener.ReactionChannelListener;
+import net.hypixel.nerdbot.listener.SuggestionListener;
 import net.hypixel.nerdbot.util.Environment;
 import net.hypixel.nerdbot.util.Util;
 import net.hypixel.nerdbot.util.discord.ForumChannelResolver;
@@ -82,7 +83,8 @@ public class NerdBot implements Bot {
                         new ModLogListener(),
                         new FeatureEventListener(),
                         new ActivityListener(),
-                        new ReactionChannelListener()
+                        new ReactionChannelListener(),
+                        new SuggestionListener()
                 ).setActivity(Activity.of(config.getActivityType(), config.getActivity()));
         configureMemoryUsage(builder);
 

--- a/src/main/java/net/hypixel/nerdbot/command/UserCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/UserCommands.java
@@ -226,7 +226,7 @@ public class UserCommands extends ApplicationCommand {
         final Member searchMember = (member == null) ? event.getMember() : member;
         final boolean isAlpha = (alpha != null && alpha);
 
-        List<Suggestion> suggestions = getSuggestions(suggestionForumIds, searchMember, tags, title, isAlpha);
+        List<SuggestionCache.Suggestion> suggestions = getSuggestions(searchMember, tags, title, isAlpha);
 
         if (suggestions.isEmpty()) {
             event.getHook().editOriginal("Found no suggestions matching the specified filters!").queue();

--- a/src/main/java/net/hypixel/nerdbot/command/UserCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/UserCommands.java
@@ -278,6 +278,7 @@ public class UserCommands extends ApplicationCommand {
             .getSuggestions()
             .stream()
             .filter(suggestion -> suggestion.isAlpha() == alpha)
+            .filter(SuggestionCache.Suggestion::notDeleted)
             .filter(suggestion -> member == null || suggestion.getThread().getOwnerIdLong() == member.getIdLong())
             .filter(suggestion -> searchTags.isEmpty() || searchTags.stream().allMatch(tag -> suggestion.getThread()
                 .getAppliedTags()

--- a/src/main/java/net/hypixel/nerdbot/command/UserCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/UserCommands.java
@@ -11,26 +11,20 @@ import com.mongodb.Function;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.InsertOneResult;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageHistory;
-import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
-import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.internal.utils.tuple.Pair;
 import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.database.Database;
 import net.hypixel.nerdbot.api.database.model.reminder.Reminder;
 import net.hypixel.nerdbot.api.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.api.database.model.user.stats.LastActivity;
-import net.hypixel.nerdbot.bot.config.BotConfig;
 import net.hypixel.nerdbot.bot.config.EmojiConfig;
 import net.hypixel.nerdbot.util.discord.DiscordTimestamp;
+import net.hypixel.nerdbot.util.discord.SuggestionCache;
 
 import java.awt.*;
 import java.time.Duration;
@@ -40,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -49,7 +42,7 @@ import java.util.stream.Collectors;
 @Log4j2
 public class UserCommands extends ApplicationCommand {
 
-    private static final List<String> GREENLIT_TAGS = Arrays.asList("greenlit", "docced");
+    private static final Pattern DURATION = Pattern.compile("((\\d+)w)?((\\d+)d)?((\\d+)h)?((\\d+)m)?((\\d+)s)?");
 
     @JDASlashCommand(name = "remind", subcommand = "create", description = "Set a reminder")
     public void createReminder(GuildSlashEvent event, @AppOption(description = "Use a format such as \"in 1 hour\" or \"1w3d7h\"") String time, @AppOption String description, @AppOption(description = "Send the reminder through DMs") @Optional Boolean silent) {
@@ -187,8 +180,7 @@ public class UserCommands extends ApplicationCommand {
      * @throws DateTimeParseException If the string could not be parsed
      */
     public static Date parseCustomFormat(String time) throws DateTimeParseException {
-        Pattern pattern = Pattern.compile("((\\d+)w)?((\\d+)d)?((\\d+)h)?((\\d+)m)?((\\d+)s)?");
-        Matcher matcher = pattern.matcher(time);
+        Matcher matcher = DURATION.matcher(time);
 
         if (!matcher.matches()) {
             throw new DateTimeParseException("Could not parse date: " + time, time, 0);
@@ -220,7 +212,7 @@ public class UserCommands extends ApplicationCommand {
     }
 
     @JDASlashCommand(name = "suggestions", subcommand = "by-member", description = "View user suggestions.")
-    public void viewOwnSuggestions(
+    public void viewMemberSuggestions(
         GuildSlashEvent event,
         @AppOption @Optional Integer page,
         @AppOption(description = "Member to view.") @Optional Member member,
@@ -228,26 +220,20 @@ public class UserCommands extends ApplicationCommand {
         @AppOption(description = "Words to filter title for.") @Optional String title,
         @AppOption(description = "Toggle alpha suggestions.") @Optional Boolean alpha
     ) {
-        BotConfig config = NerdBotApp.getBot().getConfig();
+        event.deferReply(true).queue();
         page = (page == null) ? 1 : page;
         final int pageNum = Math.max(page, 1);
         final Member searchMember = (member == null) ? event.getMember() : member;
         final boolean isAlpha = (alpha != null && alpha);
-        final String[] suggestionForumIds = (alpha != null && alpha) ? config.getAlphaSuggestionForumIds() : config.getSuggestionForumIds();
 
-        if (suggestionForumIds == null || suggestionForumIds.length == 0) {
-            event.reply("No " + (isAlpha ? "alpha " : "") + "suggestion forums are setup in the config.").setEphemeral(true).queue();
-            return;
-        }
-
-        List<Suggestion> suggestions = getSuggestions(suggestionForumIds, searchMember, tags, title, isAlpha);
+        List<SuggestionCache.Suggestion> suggestions = getSuggestions(searchMember, tags, title, isAlpha);
 
         if (suggestions.isEmpty()) {
             event.reply("Found no suggestions matching the specified filters!").setEphemeral(true).queue();
             return;
         }
 
-        event.replyEmbeds(buildSuggestionsEmbed(suggestions, tags, title, isAlpha, pageNum).setAuthor(searchMember.getEffectiveName()).build()).setEphemeral(true).queue();
+        event.getHook().editOriginalEmbeds(buildSuggestionsEmbed(suggestions, tags, title, isAlpha, pageNum).setAuthor(searchMember.getEffectiveName()).build()).queue();
     }
 
     @JDASlashCommand(name = "suggestions", subcommand = "by-everyone", description = "View all suggestions.")
@@ -258,25 +244,19 @@ public class UserCommands extends ApplicationCommand {
         @AppOption(description = "Words to filter title for.") @Optional String title,
         @AppOption(description = "Toggle alpha suggestions.") @Optional Boolean alpha
     ) {
-        BotConfig config = NerdBotApp.getBot().getConfig();
+        event.deferReply(true).queue();
         page = (page == null) ? 1 : page;
         final int pageNum = Math.max(page, 1);
         final boolean isAlpha = (alpha != null && alpha);
-        final String[] suggestionForumIds = isAlpha ? config.getAlphaSuggestionForumIds() : config.getSuggestionForumIds();
 
-        if (suggestionForumIds == null || suggestionForumIds.length == 0) {
-            event.reply("No " + (isAlpha ? "alpha " : "") + "suggestion forums are setup in the config.").setEphemeral(true).queue();
-            return;
-        }
-
-        List<Suggestion> suggestions = getSuggestions(suggestionForumIds, null, tags, title, isAlpha);
+        List<SuggestionCache.Suggestion> suggestions = getSuggestions(null, tags, title, isAlpha);
 
         if (suggestions.isEmpty()) {
-            event.reply("You have no suggestions matched with tags " + (tags != null ? ("`" + tags + "`") : "*ANY*") + " or title containing " + (title != null ? ("`" + title + "`") : "*ANYTHING*") + ".").setEphemeral(true).queue();
+            event.reply("Found no suggestions matching the specified filters!").setEphemeral(true).queue();
             return;
         }
 
-        event.replyEmbeds(buildSuggestionsEmbed(suggestions, tags, title, isAlpha, pageNum).build()).setEphemeral(true).queue();
+        event.getHook().editOriginalEmbeds(buildSuggestionsEmbed(suggestions, tags, title, isAlpha, pageNum).build()).queue();
     }
 
     @JDASlashCommand(name = "activity", description = "View your recent activity.")
@@ -288,52 +268,45 @@ public class UserCommands extends ApplicationCommand {
             return;
         }
 
-        event.replyEmbeds(activityEmbeds.getLeft().build(), activityEmbeds.getRight().build())
-            .setEphemeral(true)
-            .queue();
+        event.replyEmbeds(activityEmbeds.getLeft().build(), activityEmbeds.getRight().build()).setEphemeral(true).queue();
     }
 
-    private static List<Suggestion> getSuggestions(String[] suggestionForumIds, Member member, String tags, String title, boolean alpha) {
+    private static List<SuggestionCache.Suggestion> getSuggestions(Member member, String tags, String title, boolean alpha) {
         final List<String> searchTags = Arrays.asList(tags != null ? tags.split(", *") : new String[0]);
 
-        return Arrays.stream(suggestionForumIds)
-            .filter(Objects::nonNull)
-            .map(forumId -> NerdBotApp.getBot().getJDA().getForumChannelById(forumId))
-            .filter(Objects::nonNull)
-            .flatMap(forumChannel -> forumChannel.getThreadChannels()
+        return NerdBotApp.getSuggestionCache()
+            .getSuggestions()
+            .stream()
+            .filter(suggestion -> suggestion.isAlpha() == alpha)
+            .filter(suggestion -> member == null || suggestion.getThread().getOwnerIdLong() == member.getIdLong())
+            .filter(suggestion -> searchTags.isEmpty() || searchTags.stream().allMatch(tag -> suggestion.getThread()
+                .getAppliedTags()
                 .stream()
-                .sorted((o1, o2) -> Long.compare(o2.getTimeCreated().toInstant().toEpochMilli(), o1.getTimeCreated().toInstant().toEpochMilli())) // Sort by most recent
-                .filter(thread -> member == null || thread.getOwnerIdLong() == member.getIdLong())
-                .filter(thread -> thread.getHistoryFromBeginning(1).complete().getRetrievedHistory().get(0) != null) // Lol
-                .filter(thread -> searchTags.isEmpty() || searchTags.stream().allMatch(tag -> thread.getAppliedTags()
-                    .stream()
-                    .anyMatch(forumTag -> forumTag.getName().equalsIgnoreCase(tag))
-                ))
-                .filter(thread -> title == null || thread.getName()
-                    .toLowerCase()
-                    .contains(title.toLowerCase())
-                )
-                .map(thread -> new Suggestion(thread, alpha))
+                .anyMatch(forumTag -> forumTag.getName().equalsIgnoreCase(tag))
+            ))
+            .filter(suggestion -> title == null || suggestion.getThread()
+                .getName()
+                .toLowerCase()
+                .contains(title.toLowerCase())
             )
             .toList();
     }
 
-    private static EmbedBuilder buildSuggestionsEmbed(List<Suggestion> suggestions, String tags, String title, boolean alpha, int pageNum) {
-        List<Suggestion> pages = InfoCommands.getPage(suggestions, pageNum, 10);
+    private static EmbedBuilder buildSuggestionsEmbed(List<SuggestionCache.Suggestion> suggestions, String tags, String title, boolean alpha, int pageNum) {
+        List<SuggestionCache.Suggestion> pages = InfoCommands.getPage(suggestions, pageNum, 10);
         int totalPages = (int) Math.ceil(suggestions.size() / 10.0);
         List<List<String>> fieldData = new ArrayList<>();
         double total = suggestions.size();
-        double greenlit = suggestions.stream().filter(Suggestion::isGreenlit).count();
+        double greenlit = suggestions.stream().filter(SuggestionCache.Suggestion::isGreenlit).count();
 
-        for (Suggestion suggestion : pages) {
+        for (SuggestionCache.Suggestion suggestion : pages) {
             String name = suggestion.getThread().getName().replaceAll("`", "");
             if (name.length() > 50) {
                 name = name.substring(0, 50);
                 name += "...";
             }
 
-            String link = "[" + name + "](" + suggestion.getThread().getJumpUrl() + ")" +
-                (suggestion.isGreenlit() ? " " + getEmojiFormat(EmojiConfig::getGreenlitEmojiId) : "");
+            String link = suggestion.getThread().getJumpUrl() + (suggestion.isGreenlit() ? " " + getEmojiFormat(EmojiConfig::getGreenlitEmojiId) : "");
 
             fieldData.add(Arrays.asList(
                 link,
@@ -433,42 +406,6 @@ public class UserCommands extends ApplicationCommand {
 
     private static String getEmojiFormat(Function<EmojiConfig, String> emojiIdFunction) {
         return NerdBotApp.getBot().getJDA().getEmojiById(emojiIdFunction.apply(NerdBotApp.getBot().getConfig().getEmojiConfig())).getFormatted();
-    }
-
-    @RequiredArgsConstructor
-    private static class Suggestion {
-
-        @Getter
-        private final ThreadChannel thread;
-        @Getter private final boolean alpha;
-        @Getter private final int agrees;
-        @Getter private final int disagrees;
-        @Getter private final boolean greenlit;
-
-        public Suggestion(ThreadChannel thread, boolean alpha) {
-            this.thread = thread;
-            this.alpha = alpha;
-            MessageHistory history = thread.getHistoryFromBeginning(1).complete();
-            Message message = history.getRetrievedHistory().get(0);
-            this.agrees = getReactionCount(message, NerdBotApp.getBot().getConfig().getEmojiConfig().getAgreeEmojiId());
-            this.disagrees = getReactionCount(message, NerdBotApp.getBot().getConfig().getEmojiConfig().getDisagreeEmojiId());
-            this.greenlit = thread.getAppliedTags().stream().anyMatch(forumTag -> GREENLIT_TAGS.contains(forumTag.getName().toLowerCase()));
-        }
-
-        public static int getReactionCount(Message message, String emojiId) {
-            return message.getReactions()
-                .stream()
-                .filter(reaction -> reaction.getEmoji().getType() == Emoji.Type.CUSTOM)
-                .filter(reaction -> reaction.getEmoji()
-                    .asCustom()
-                    .getId()
-                    .equalsIgnoreCase(emojiId)
-                )
-                .mapToInt(MessageReaction::getCount)
-                .findFirst()
-                .orElse(0);
-        }
-
     }
 
 }

--- a/src/main/java/net/hypixel/nerdbot/listener/SuggestionListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/SuggestionListener.java
@@ -1,0 +1,27 @@
+package net.hypixel.nerdbot.listener;
+
+import lombok.extern.log4j.Log4j2;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.events.channel.ChannelCreateEvent;
+import net.dv8tion.jda.api.events.channel.ChannelDeleteEvent;
+import net.dv8tion.jda.api.hooks.SubscribeEvent;
+import net.hypixel.nerdbot.NerdBotApp;
+import org.jetbrains.annotations.NotNull;
+
+@Log4j2
+public class SuggestionListener {
+
+    @SubscribeEvent
+    public void onThreadCreateEvent(@NotNull ChannelCreateEvent event) {
+        if (event.getChannelType() == ChannelType.GUILD_PUBLIC_THREAD) {
+            NerdBotApp.getSuggestionCache().addSuggestion(event.getChannel().asThreadChannel());
+        }
+    }
+
+    @SubscribeEvent
+    public void onThreadDeleteEvent(@NotNull ChannelDeleteEvent event) {
+        if (event.getChannelType() == ChannelType.GUILD_PUBLIC_THREAD) {
+            NerdBotApp.getSuggestionCache().removeSuggestion(event.getChannel().asThreadChannel());
+        }
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/util/discord/MessageCache.java
+++ b/src/main/java/net/hypixel/nerdbot/util/discord/MessageCache.java
@@ -40,6 +40,7 @@ public class MessageCache implements EventListener {
 
     @SubscribeEvent
     public void onEvent(@NotNull GenericEvent event) {
+
         if (event instanceof MessageReceivedEvent messageReceivedEvent) {
             cache.put(messageReceivedEvent.getMessage().getId(), messageReceivedEvent.getMessage());
         }

--- a/src/main/java/net/hypixel/nerdbot/util/discord/SuggestionCache.java
+++ b/src/main/java/net/hypixel/nerdbot/util/discord/SuggestionCache.java
@@ -79,6 +79,7 @@ public class SuggestionCache {
         @Getter private final int agrees;
         @Getter private final int disagrees;
         @Getter private final boolean greenlit;
+        @Getter private final boolean deleted;
 
         public Suggestion(ThreadChannel thread) {
             this.thread = thread;
@@ -86,8 +87,9 @@ public class SuggestionCache {
             this.alpha = Arrays.stream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).anyMatch(this.parentId::equalsIgnoreCase) || thread.getName().toLowerCase().contains("alpha");
             MessageHistory history = thread.getHistoryFromBeginning(1).complete();
             Message message = history.getRetrievedHistory().get(0);
-            this.agrees = getReactionCount(message, NerdBotApp.getBot().getConfig().getEmojiConfig().getAgreeEmojiId());
-            this.disagrees = getReactionCount(message, NerdBotApp.getBot().getConfig().getEmojiConfig().getDisagreeEmojiId());
+            this.deleted = message == null;
+            this.agrees = this.deleted ? 0 : getReactionCount(message, NerdBotApp.getBot().getConfig().getEmojiConfig().getAgreeEmojiId());
+            this.disagrees = this.deleted ? 0 : getReactionCount(message, NerdBotApp.getBot().getConfig().getEmojiConfig().getDisagreeEmojiId());
             this.greenlit = thread.getAppliedTags().stream().anyMatch(forumTag -> GREENLIT_TAGS.contains(forumTag.getName().toLowerCase()));
         }
 
@@ -103,6 +105,10 @@ public class SuggestionCache {
                 .mapToInt(MessageReaction::getCount)
                 .findFirst()
                 .orElse(0);
+        }
+
+        public boolean notDeleted() {
+            return !this.isDeleted();
         }
 
     }

--- a/src/main/java/net/hypixel/nerdbot/util/discord/SuggestionCache.java
+++ b/src/main/java/net/hypixel/nerdbot/util/discord/SuggestionCache.java
@@ -1,0 +1,110 @@
+package net.hypixel.nerdbot.util.discord;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Scheduler;
+import lombok.Getter;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageHistory;
+import net.dv8tion.jda.api.entities.MessageReaction;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
+import net.hypixel.nerdbot.NerdBotApp;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+public class SuggestionCache {
+
+    private static final List<String> GREENLIT_TAGS = Arrays.asList("greenlit", "docced");
+    private final Cache<String, Suggestion> cache = Caffeine.newBuilder()
+        .scheduler(Scheduler.systemScheduler())
+        .refreshAfterWrite(60, TimeUnit.MINUTES)
+        .softValues()
+        .build(id -> new Suggestion(NerdBotApp.getBot().getJDA().getThreadChannelById(id)));
+
+    public SuggestionCache() {
+        Stream.concat(
+                Arrays.stream(NerdBotApp.getBot().getConfig().getSuggestionForumIds()),
+                Arrays.stream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds())
+            )
+            .filter(Objects::nonNull)
+            .map(forumId -> NerdBotApp.getBot().getJDA().getForumChannelById(forumId))
+            .filter(Objects::nonNull)
+            .flatMap(forumChannel -> Stream.concat(
+                forumChannel.getThreadChannels().stream(),
+                forumChannel.retrieveArchivedPublicThreadChannels().stream()
+            ))
+            .distinct()
+                .forEach(thread -> this.cache.put(thread.getId(), new Suggestion(thread)));
+    }
+
+    public void addSuggestion(ThreadChannel threadChannel) {
+        String forumId = threadChannel.getParentChannel().asForumChannel().getId();
+        boolean suggestionForum = Arrays.stream(NerdBotApp.getBot().getConfig().getSuggestionForumIds()).anyMatch(forumId::equalsIgnoreCase);
+        boolean alphaSuggestionForum = Arrays.stream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).anyMatch(forumId::equalsIgnoreCase);
+
+        if (suggestionForum || alphaSuggestionForum) {
+            this.cache.put(threadChannel.getId(), new Suggestion(threadChannel));
+        }
+    }
+
+    public Suggestion getSuggestion(String id) {
+        return this.cache.getIfPresent(id);
+    }
+
+    public List<Suggestion> getSuggestions() {
+        return this.cache.asMap()
+            .values()
+            .stream()
+            .sorted((o1, o2) -> Long.compare( // Sort by most recent
+                o2.getThread().getTimeCreated().toInstant().toEpochMilli(),
+                o1.getThread().getTimeCreated().toInstant().toEpochMilli())
+            )
+            .toList();
+    }
+
+    public void removeSuggestion(ThreadChannel threadChannel) {
+        this.cache.invalidate(threadChannel.getId());
+    }
+
+    public static class Suggestion {
+
+        @Getter private final ThreadChannel thread;
+        @Getter private final String parentId;
+        @Getter private final boolean alpha;
+        @Getter private final int agrees;
+        @Getter private final int disagrees;
+        @Getter private final boolean greenlit;
+
+        public Suggestion(ThreadChannel thread) {
+            this.thread = thread;
+            this.parentId = thread.getParentChannel().asForumChannel().getId();
+            this.alpha = Arrays.stream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).anyMatch(this.parentId::equalsIgnoreCase) || thread.getName().toLowerCase().contains("alpha");
+            MessageHistory history = thread.getHistoryFromBeginning(1).complete();
+            Message message = history.getRetrievedHistory().get(0);
+            this.agrees = getReactionCount(message, NerdBotApp.getBot().getConfig().getEmojiConfig().getAgreeEmojiId());
+            this.disagrees = getReactionCount(message, NerdBotApp.getBot().getConfig().getEmojiConfig().getDisagreeEmojiId());
+            this.greenlit = thread.getAppliedTags().stream().anyMatch(forumTag -> GREENLIT_TAGS.contains(forumTag.getName().toLowerCase()));
+        }
+
+        public static int getReactionCount(Message message, String emojiId) {
+            return message.getReactions()
+                .stream()
+                .filter(reaction -> reaction.getEmoji().getType() == Emoji.Type.CUSTOM)
+                .filter(reaction -> reaction.getEmoji()
+                    .asCustom()
+                    .getId()
+                    .equalsIgnoreCase(emojiId)
+                )
+                .mapToInt(MessageReaction::getCount)
+                .findFirst()
+                .orElse(0);
+        }
+
+    }
+
+}


### PR DESCRIPTION
This is a followup to https://github.com/TheMGRF/NerdBot/pull/86 that caches all suggestion threads on startup. It's garbage collector safe with a 1 hour expiry time and auto-renew once an hour.

There's also a 2nd attempt at fixing reading archived public threads from suggestion forums.