### PR TITLE
Add support for blacklisted channels for user activity

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/bot/config/BotConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/BotConfig.java
@@ -3,17 +3,9 @@ package net.hypixel.nerdbot.bot.config;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import net.dv8tion.jda.api.entities.Activity;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageReaction;
-import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
-import net.hypixel.nerdbot.channel.ReactionChannel;
-
-import java.util.List;
 
 @Getter
 @Setter
@@ -26,29 +18,9 @@ public class BotConfig {
     private String guildId;
 
     /**
-     * The {@link TextChannel} ID that the bot will be logging to
-     */
-    private String logChannel;
-
-    /**
      * The {@link Role} ID of the Bot Manager role
      */
     private String botManagerRoleId;
-
-    /**
-     * The {@link TextChannel} IDs for the suggestion forums
-     */
-    private String[] suggestionForumIds;
-
-    /**
-     * The {@link TextChannel} IDs for the alpha suggestion forums
-     */
-    private String[] alphaSuggestionForumIds;
-
-    /**
-     * The {@link TextChannel} ID for the itemgen channel
-     */
-    private String[] itemGenChannel;
 
     /**
      * The minimum threshold of {@link MessageReaction reactions} needed for a suggestion to be considered greenlit
@@ -101,12 +73,12 @@ public class BotConfig {
     private ModMailConfig modMailConfig;
 
     /**
-     * Configuration for channels that will have reactions automatically added to all new messages
-     */
-    private List<ReactionChannel> reactionChannels;
-
-    /**
      * The amount of days that a user must be inactive for to show up in the inactive user list
      */
     private int inactivityDays;
+
+    /**
+     * Configuration for anything related to channels the bot will be using
+     */
+    private ChannelConfig channelConfig;
 }

--- a/src/main/java/net/hypixel/nerdbot/bot/config/ChannelConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/ChannelConfig.java
@@ -1,0 +1,45 @@
+package net.hypixel.nerdbot.bot.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.hypixel.nerdbot.channel.ReactionChannel;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+public class ChannelConfig {
+
+    /**
+     * The {@link TextChannel} ID that the bot will be logging to
+     */
+    private String logChannel;
+
+    /**
+     * The {@link TextChannel} IDs for the suggestion forums
+     */
+    private String[] suggestionForumIds;
+
+    /**
+     * The {@link TextChannel} IDs for the alpha suggestion forums
+     */
+    private String[] alphaSuggestionForumIds;
+
+    /**
+     * The {@link TextChannel} ID for the itemgen channel
+     */
+    private String[] itemGenChannel;
+
+    /**
+     * Configuration for channels that will have reactions automatically added to all new messages
+     */
+    private List<ReactionChannel> reactionChannels;
+
+    /**
+     * The {@link TextChannel} IDs for the channels that the bot will ignore messages from
+     */
+    private String[] blacklistedChannels;
+}

--- a/src/main/java/net/hypixel/nerdbot/channel/ChannelManager.java
+++ b/src/main/java/net/hypixel/nerdbot/channel/ChannelManager.java
@@ -24,6 +24,6 @@ public class ChannelManager {
 
     @Nullable
     public static TextChannel getLogChannel() {
-        return getChannel(NerdBotApp.getBot().getConfig().getLogChannel());
+        return getChannel(NerdBotApp.getBot().getConfig().getChannelConfig().getLogChannel());
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
@@ -353,7 +353,7 @@ public class ItemGenCommands extends ApplicationCommand {
 
     private boolean isIncorrectChannel(GuildSlashEvent event) {
         String senderChannelId = event.getChannel().getId();
-        String[] itemGenChannelIds = NerdBotApp.getBot().getConfig().getItemGenChannel();
+        String[] itemGenChannelIds = NerdBotApp.getBot().getConfig().getChannelConfig().getItemGenChannel();
 
         if (itemGenChannelIds == null) {
             event.reply("The config for the item generating channel is not ready yet. Try again later!").setEphemeral(true).queue();

--- a/src/main/java/net/hypixel/nerdbot/feature/CurateFeature.java
+++ b/src/main/java/net/hypixel/nerdbot/feature/CurateFeature.java
@@ -7,6 +7,7 @@ import net.hypixel.nerdbot.api.curator.Curator;
 import net.hypixel.nerdbot.api.database.Database;
 import net.hypixel.nerdbot.api.database.model.greenlit.GreenlitMessage;
 import net.hypixel.nerdbot.api.feature.BotFeature;
+import net.hypixel.nerdbot.bot.config.ChannelConfig;
 import net.hypixel.nerdbot.curator.ForumChannelCurator;
 import net.hypixel.nerdbot.util.Util;
 
@@ -21,7 +22,7 @@ public class CurateFeature extends BotFeature {
 
     @Override
     public void onStart() {
-        if (NerdBotApp.getBot().getConfig().getSuggestionForumIds() == null) {
+        if (NerdBotApp.getBot().getConfig().getChannelConfig().getSuggestionForumIds() == null) {
             log.info("Not starting CurateFeature as 'suggestionForumIds' could not be found in the configuration file!");
             return;
         }
@@ -39,8 +40,8 @@ public class CurateFeature extends BotFeature {
                     suggestions.forEach(channel -> {
                         boolean alpha;
 
-                        if (NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds() != null) {
-                            alpha = Arrays.asList(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).contains(channel.getId());
+                        if (channelConfig.getAlphaSuggestionForumIds() != null) {
+                            alpha = Arrays.asList(channelConfig.getAlphaSuggestionForumIds()).contains(channel.getId());
                         } else {
                             alpha = channel.getName().contains("alpha");
                         }

--- a/src/main/java/net/hypixel/nerdbot/feature/CurateFeature.java
+++ b/src/main/java/net/hypixel/nerdbot/feature/CurateFeature.java
@@ -33,7 +33,8 @@ public class CurateFeature extends BotFeature {
                 NerdBotApp.EXECUTOR_SERVICE.execute(() -> {
                     Database database = NerdBotApp.getBot().getDatabase();
                     Curator<ForumChannel> forumChannelCurator = new ForumChannelCurator(NerdBotApp.getBot().isReadOnly());
-                    Stream<ForumChannel> suggestions = Util.concatStreams(NerdBotApp.getBot().getConfig().getSuggestionForumIds(), NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds())
+                    ChannelConfig channelConfig = NerdBotApp.getBot().getConfig().getChannelConfig();
+                    Stream<ForumChannel> suggestions = Util.concatStreams(channelConfig.getSuggestionForumIds(), channelConfig.getAlphaSuggestionForumIds())
                         .map(NerdBotApp.getBot().getJDA()::getForumChannelById)
                         .filter(Objects::nonNull);
 

--- a/src/main/java/net/hypixel/nerdbot/feature/GreenlitUpdateFeature.java
+++ b/src/main/java/net/hypixel/nerdbot/feature/GreenlitUpdateFeature.java
@@ -13,6 +13,7 @@ import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.database.Database;
 import net.hypixel.nerdbot.api.database.model.greenlit.GreenlitMessage;
 import net.hypixel.nerdbot.api.feature.BotFeature;
+import net.hypixel.nerdbot.bot.config.ChannelConfig;
 import net.hypixel.nerdbot.bot.config.EmojiConfig;
 import net.hypixel.nerdbot.util.Util;
 
@@ -34,15 +35,16 @@ public class GreenlitUpdateFeature extends BotFeature {
         this.timer.scheduleAtFixedRate(new TimerTask() {
             @Override
             public void run() {
-                Stream<ForumChannel> suggestions = Util.concatStreams(NerdBotApp.getBot().getConfig().getSuggestionForumIds(), NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds())
+                ChannelConfig channelConfig = NerdBotApp.getBot().getConfig().getChannelConfig();
+                Stream<ForumChannel> suggestions = Util.concatStreams(channelConfig.getSuggestionForumIds(), channelConfig.getAlphaSuggestionForumIds())
                     .map(s -> NerdBotApp.getBot().getJDA().getForumChannelById(s))
                     .filter(Objects::nonNull);
 
                 suggestions.forEach(channel -> {
                     boolean alpha;
 
-                    if (NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds() != null) {
-                        alpha = Arrays.asList(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).contains(channel.getId());
+                    if (channelConfig.getAlphaSuggestionForumIds() != null) {
+                        alpha = Arrays.asList(channelConfig.getAlphaSuggestionForumIds()).contains(channel.getId());
                     } else {
                         alpha = channel.getName().contains("alpha");
                     }

--- a/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
@@ -19,6 +19,7 @@ import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.database.Database;
 import net.hypixel.nerdbot.api.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.bot.config.BotConfig;
+import net.hypixel.nerdbot.bot.config.ChannelConfig;
 import net.hypixel.nerdbot.bot.config.EmojiConfig;
 import net.hypixel.nerdbot.util.Util;
 import org.jetbrains.annotations.NotNull;
@@ -63,14 +64,15 @@ public class ActivityListener {
 
             // New Suggestions
             BotConfig botConfig = NerdBotApp.getBot().getConfig();
+            ChannelConfig channelConfig = botConfig.getChannelConfig();
 
-            if (botConfig.getSuggestionForumIds() != null && Arrays.stream(botConfig.getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+            if (channelConfig.getSuggestionForumIds() != null && Arrays.stream(channelConfig.getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                 discordUser.getLastActivity().setLastSuggestionDate(time);
                 log.info("Updating new suggestion activity date for " + member.getEffectiveName() + " to " + time);
             }
 
             // New Alpha Suggestions
-            if (botConfig.getAlphaSuggestionForumIds() != null && Arrays.stream(botConfig.getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+            if (channelConfig.getAlphaSuggestionForumIds() != null && Arrays.stream(channelConfig.getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                 discordUser.getLastActivity().setLastAlphaSuggestionDate(time);
                 log.info("Updating new alpha suggestion activity date for " + member.getEffectiveName() + " to " + time);
             }
@@ -100,15 +102,16 @@ public class ActivityListener {
         // New Suggestion Comments
         if (guildChannel instanceof ThreadChannel && event.getChannel().getIdLong() != event.getMessage().getIdLong()) {
             String forumChannelId = guildChannel.asThreadChannel().getParentChannel().getId();
+            ChannelConfig channelConfig = NerdBotApp.getBot().getConfig().getChannelConfig();
 
             // New Suggestion Comments
-            if (Arrays.stream(NerdBotApp.getBot().getConfig().getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+            if (Arrays.stream(channelConfig.getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                 discordUser.getLastActivity().setSuggestionCommentDate(time);
                 log.info("Updating suggestion comment activity date for " + member.getEffectiveName() + " to " + time);
             }
 
             // New Alpha Suggestion Comments
-            if (Arrays.stream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+            if (Arrays.stream(channelConfig.getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                 isAlphaChannel = true;
                 discordUser.getLastActivity().setAlphaSuggestionCommentDate(time);
                 log.info("Updating alpha suggestion comment activity date for " + member.getEffectiveName() + " to " + time);
@@ -122,6 +125,11 @@ public class ActivityListener {
 
         discordUser.getLastActivity().setLastGlobalActivity(time);
         log.info("Updating last global activity date for " + member.getEffectiveName() + " to " + time);
+
+        // Ignore blacklisted channels from incrementing activity
+        if (Arrays.stream(NerdBotApp.getBot().getConfig().getChannelConfig().getBlacklistedChannels()).anyMatch(guildChannel.getId()::equalsIgnoreCase)) {
+            return;
+        }
 
         discordUser.getLastActivity().getChannelActivity().put(guildChannel.getId(), discordUser.getLastActivity().getChannelActivity().getOrDefault(guildChannel.getId(), 0) + 1);
     }
@@ -190,15 +198,16 @@ public class ActivityListener {
 
                 String forumChannelId = threadChannel.getParentChannel().getId();
                 long time = System.currentTimeMillis();
+                ChannelConfig channelConfig = config.getChannelConfig();
 
                 // New Suggestion Voting
-                if (Arrays.stream(NerdBotApp.getBot().getConfig().getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+                if (Arrays.stream(channelConfig.getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                     discordUser.getLastActivity().setSuggestionVoteDate(time);
                     log.info("Updating suggestion voting activity date for " + member.getEffectiveName() + " to " + time);
                 }
 
                 // New Alpha Suggestion Voting
-                if (Arrays.stream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+                if (Arrays.stream(channelConfig.getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                     discordUser.getLastActivity().setAlphaSuggestionVoteDate(time);
                     log.info("Updating alpha suggestion voting activity date for " + member.getEffectiveName() + " to " + time);
                 }

--- a/src/main/java/net/hypixel/nerdbot/listener/ReactionChannelListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ReactionChannelListener.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 @Log4j2
 public class ReactionChannelListener {
 
-    private final List<ReactionChannel> reactionChannels = NerdBotApp.getBot().getConfig().getReactionChannels();
+    private final List<ReactionChannel> reactionChannels = NerdBotApp.getBot().getConfig().getChannelConfig().getReactionChannels();
 
     @SubscribeEvent
     public void onMessageReceive(MessageReceivedEvent event) {

--- a/src/main/java/net/hypixel/nerdbot/listener/SuggestionListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/SuggestionListener.java
@@ -28,7 +28,7 @@ public class SuggestionListener {
     }
 
     private boolean isInSuggestionChannel(GenericChannelEvent event) {
-        return Util.concatStreams(NerdBotApp.getBot().getConfig().getSuggestionForumIds(), NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds())
+        return Util.concatStreams(NerdBotApp.getBot().getConfig().getChannelConfig().getSuggestionForumIds(), NerdBotApp.getBot().getConfig().getChannelConfig().getAlphaSuggestionForumIds())
             .anyMatch(channelId -> channelId.equals(event.getChannel().getId()));
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/util/discord/SuggestionCache.java
+++ b/src/main/java/net/hypixel/nerdbot/util/discord/SuggestionCache.java
@@ -41,7 +41,7 @@ public class SuggestionCache extends TimerTask {
             log.info("Started suggestion cache update.");
             this.loaded = false;
             this.cache.forEach((key, suggestion) -> suggestion.setExpired());
-            Util.concatStreams(NerdBotApp.getBot().getConfig().getSuggestionForumIds(), NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds())
+            Util.concatStreams(NerdBotApp.getBot().getConfig().getChannelConfig().getSuggestionForumIds(), NerdBotApp.getBot().getConfig().getChannelConfig().getAlphaSuggestionForumIds())
                 .map(NerdBotApp.getBot().getJDA()::getForumChannelById)
                 .filter(Objects::nonNull)
                 .flatMap(forumChannel -> Stream.concat(forumChannel.getThreadChannels().stream(), forumChannel.retrieveArchivedPublicThreadChannels().stream()))
@@ -107,8 +107,8 @@ public class SuggestionCache extends TimerTask {
 
             // Alpha
             boolean alpha = thread.getName().toLowerCase().contains("alpha");
-            if (NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds() != null) {
-                alpha = alpha || Arrays.stream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).anyMatch(this.parentId::equalsIgnoreCase);
+            if (NerdBotApp.getBot().getConfig().getChannelConfig().getAlphaSuggestionForumIds() != null) {
+                alpha = alpha || Arrays.stream(NerdBotApp.getBot().getConfig().getChannelConfig().getAlphaSuggestionForumIds()).anyMatch(this.parentId::equalsIgnoreCase);
             }
             this.alpha = alpha;
 


### PR DESCRIPTION
This PR moves channel-related config stuff to its own class called ChannelConfig

It also implements a new feature to blacklist channels from incrementing a user's message count