### PR TITLE
Add support for blacklisting channels from activity tracking

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/bot/config/BotConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/BotConfig.java
@@ -3,17 +3,9 @@ package net.hypixel.nerdbot.bot.config;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import net.dv8tion.jda.api.entities.Activity;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageReaction;
-import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
-import net.hypixel.nerdbot.channel.ReactionChannel;
-
-import java.util.List;
 
 @Getter
 @Setter
@@ -21,34 +13,34 @@ import java.util.List;
 public class BotConfig {
 
     /**
+     * Configuration for anything related to the Mod Mail feature
+     */
+    private ModMailConfig modMailConfig;
+
+    /**
+     * {@link Emoji Emojis} that the bot will use to react to suggestions
+     */
+    private EmojiConfig emojiConfig;
+
+    /**
+     * {@link ForumTag Forum tags} for the bot to use, such as the greenlit tag to set suggestions as greenlit
+     */
+    private TagConfig tagConfig;
+
+    /**
+     * Configuration for channels that the bot will be using
+     */
+    private ChannelConfig channelConfig;
+
+    /**
      * The {@link Guild} ID that the bot will be running in
      */
     private String guildId;
 
     /**
-     * The {@link TextChannel} ID that the bot will be logging to
-     */
-    private String logChannel;
-
-    /**
      * The {@link Role} ID of the Bot Manager role
      */
     private String botManagerRoleId;
-
-    /**
-     * The {@link TextChannel} IDs for the suggestion forums
-     */
-    private String[] suggestionForumIds;
-
-    /**
-     * The {@link TextChannel} IDs for the alpha suggestion forums
-     */
-    private String[] alphaSuggestionForumIds;
-
-    /**
-     * The {@link TextChannel} ID for the itemgen channel
-     */
-    private String[] itemGenChannel;
 
     /**
      * The minimum threshold of {@link MessageReaction reactions} needed for a suggestion to be considered greenlit
@@ -75,16 +67,6 @@ public class BotConfig {
     private long interval = 43_200_000;
 
     /**
-     * {@link Emoji Emojis} that the bot will use to react to suggestions
-     */
-    private EmojiConfig emojiConfig;
-
-    /**
-     * {@link ForumTag Forum tags} for the bot to use, such as the greenlit tag to set suggestions as greenlit
-     */
-    private TagConfig tagConfig;
-
-    /**
      * The {@link Activity.ActivityType} that the bot will display on its profile
      * Default is PLAYING
      */
@@ -94,16 +76,6 @@ public class BotConfig {
      * The message being displayed as the bots {@link Activity} on its profile
      */
     private String activity;
-
-    /**
-     * Configuration for anything related to the Mod Mail feature
-     */
-    private ModMailConfig modMailConfig;
-
-    /**
-     * Configuration for channels that will have reactions automatically added to all new messages
-     */
-    private List<ReactionChannel> reactionChannels;
 
     /**
      * The amount of days that a user must be inactive for to show up in the inactive user list

--- a/src/main/java/net/hypixel/nerdbot/bot/config/ChannelConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/ChannelConfig.java
@@ -1,0 +1,45 @@
+package net.hypixel.nerdbot.bot.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.hypixel.nerdbot.channel.ReactionChannel;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+public class ChannelConfig {
+
+    /**
+     * The {@link TextChannel} ID that the bot will be logging to
+     */
+    private String logChannel;
+
+    /**
+     * The {@link TextChannel} IDs for the suggestion forums
+     */
+    private String[] suggestionForumIds;
+
+    /**
+     * The {@link TextChannel} IDs for the alpha suggestion forums
+     */
+    private String[] alphaSuggestionForumIds;
+
+    /**
+     * The {@link TextChannel} ID for the itemgen channel
+     */
+    private String[] itemGenChannel;
+
+    /**
+     * Configuration for channels that will have reactions automatically added to all new messages
+     */
+    private List<ReactionChannel> reactionChannels;
+
+    /**
+     * The {@link TextChannel} IDs for the channels that the bot will ignore for activity tracking
+     */
+    private String[] blacklistedChannels;
+}

--- a/src/main/java/net/hypixel/nerdbot/channel/ChannelManager.java
+++ b/src/main/java/net/hypixel/nerdbot/channel/ChannelManager.java
@@ -24,6 +24,6 @@ public class ChannelManager {
 
     @Nullable
     public static TextChannel getLogChannel() {
-        return getChannel(NerdBotApp.getBot().getConfig().getLogChannel());
+        return getChannel(NerdBotApp.getBot().getConfig().getChannelConfig().getLogChannel());
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/ItemGenCommands.java
@@ -353,7 +353,7 @@ public class ItemGenCommands extends ApplicationCommand {
 
     private boolean isIncorrectChannel(GuildSlashEvent event) {
         String senderChannelId = event.getChannel().getId();
-        String[] itemGenChannelIds = NerdBotApp.getBot().getConfig().getItemGenChannel();
+        String[] itemGenChannelIds = NerdBotApp.getBot().getConfig().getChannelConfig().getItemGenChannel();
 
         if (itemGenChannelIds == null) {
             event.reply("The config for the item generating channel is not ready yet. Try again later!").setEphemeral(true).queue();

--- a/src/main/java/net/hypixel/nerdbot/feature/CurateFeature.java
+++ b/src/main/java/net/hypixel/nerdbot/feature/CurateFeature.java
@@ -20,10 +20,10 @@ import java.util.stream.Stream;
 @Log4j2
 public class CurateFeature extends BotFeature {
 
-    private final ChannelConfig channelConfig = NerdBotApp.getBot().getConfig().getChannelConfig();
-
     @Override
     public void onStart() {
+        ChannelConfig channelConfig = NerdBotApp.getBot().getConfig().getChannelConfig();
+
         if (channelConfig.getSuggestionForumIds() == null) {
             log.info("Not starting CurateFeature as 'suggestionForumIds' could not be found in the configuration file!");
             return;

--- a/src/main/java/net/hypixel/nerdbot/feature/CurateFeature.java
+++ b/src/main/java/net/hypixel/nerdbot/feature/CurateFeature.java
@@ -7,6 +7,7 @@ import net.hypixel.nerdbot.api.curator.Curator;
 import net.hypixel.nerdbot.api.database.Database;
 import net.hypixel.nerdbot.api.database.model.greenlit.GreenlitMessage;
 import net.hypixel.nerdbot.api.feature.BotFeature;
+import net.hypixel.nerdbot.bot.config.ChannelConfig;
 import net.hypixel.nerdbot.curator.ForumChannelCurator;
 import net.hypixel.nerdbot.util.Util;
 
@@ -19,9 +20,11 @@ import java.util.stream.Stream;
 @Log4j2
 public class CurateFeature extends BotFeature {
 
+    private final ChannelConfig channelConfig = NerdBotApp.getBot().getConfig().getChannelConfig();
+
     @Override
     public void onStart() {
-        if (NerdBotApp.getBot().getConfig().getSuggestionForumIds() == null) {
+        if (channelConfig.getSuggestionForumIds() == null) {
             log.info("Not starting CurateFeature as 'suggestionForumIds' could not be found in the configuration file!");
             return;
         }
@@ -32,15 +35,15 @@ public class CurateFeature extends BotFeature {
                 NerdBotApp.EXECUTOR_SERVICE.execute(() -> {
                     Database database = NerdBotApp.getBot().getDatabase();
                     Curator<ForumChannel> forumChannelCurator = new ForumChannelCurator(NerdBotApp.getBot().isReadOnly());
-                    Stream<ForumChannel> suggestions = Util.safeArrayStream(NerdBotApp.getBot().getConfig().getSuggestionForumIds(), NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds())
+                    Stream<ForumChannel> suggestions = Util.safeArrayStream(channelConfig.getSuggestionForumIds(), channelConfig.getAlphaSuggestionForumIds())
                         .map(NerdBotApp.getBot().getJDA()::getForumChannelById)
                         .filter(Objects::nonNull);
 
                     suggestions.forEach(channel -> {
                         boolean alpha;
 
-                        if (NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds() != null) {
-                            alpha = Arrays.asList(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).contains(channel.getId());
+                        if (channelConfig.getAlphaSuggestionForumIds() != null) {
+                            alpha = Arrays.asList(channelConfig.getAlphaSuggestionForumIds()).contains(channel.getId());
                         } else {
                             alpha = channel.getName().contains("alpha");
                         }

--- a/src/main/java/net/hypixel/nerdbot/feature/GreenlitUpdateFeature.java
+++ b/src/main/java/net/hypixel/nerdbot/feature/GreenlitUpdateFeature.java
@@ -30,11 +30,11 @@ public class GreenlitUpdateFeature extends BotFeature {
         "Docced"
     };
 
-    private final ChannelConfig channelConfig = NerdBotApp.getBot().getConfig().getChannelConfig();
-    private final EmojiConfig emojiConfig = NerdBotApp.getBot().getConfig().getEmojiConfig();
-
     @Override
     public void onStart() {
+        ChannelConfig channelConfig = NerdBotApp.getBot().getConfig().getChannelConfig();
+        EmojiConfig emojiConfig = NerdBotApp.getBot().getConfig().getEmojiConfig();
+
         this.timer.scheduleAtFixedRate(new TimerTask() {
             @Override
             public void run() {

--- a/src/main/java/net/hypixel/nerdbot/feature/GreenlitUpdateFeature.java
+++ b/src/main/java/net/hypixel/nerdbot/feature/GreenlitUpdateFeature.java
@@ -13,6 +13,7 @@ import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.database.Database;
 import net.hypixel.nerdbot.api.database.model.greenlit.GreenlitMessage;
 import net.hypixel.nerdbot.api.feature.BotFeature;
+import net.hypixel.nerdbot.bot.config.ChannelConfig;
 import net.hypixel.nerdbot.bot.config.EmojiConfig;
 import net.hypixel.nerdbot.util.Util;
 
@@ -29,20 +30,23 @@ public class GreenlitUpdateFeature extends BotFeature {
         "Docced"
     };
 
+    private final ChannelConfig channelConfig = NerdBotApp.getBot().getConfig().getChannelConfig();
+    private final EmojiConfig emojiConfig = NerdBotApp.getBot().getConfig().getEmojiConfig();
+
     @Override
     public void onStart() {
         this.timer.scheduleAtFixedRate(new TimerTask() {
             @Override
             public void run() {
-                Stream<ForumChannel> suggestions = Util.safeArrayStream(NerdBotApp.getBot().getConfig().getSuggestionForumIds(), NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds())
+                Stream<ForumChannel> suggestions = Util.safeArrayStream(channelConfig.getSuggestionForumIds(), channelConfig.getAlphaSuggestionForumIds())
                     .map(s -> NerdBotApp.getBot().getJDA().getForumChannelById(s))
                     .filter(Objects::nonNull);
 
                 suggestions.forEach(channel -> {
                     boolean alpha;
 
-                    if (NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds() != null) {
-                        alpha = Arrays.asList(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).contains(channel.getId());
+                    if (channelConfig.getAlphaSuggestionForumIds() != null) {
+                        alpha = Arrays.asList(channelConfig.getAlphaSuggestionForumIds()).contains(channel.getId());
                     } else {
                         alpha = channel.getName().contains("alpha");
                     }
@@ -102,7 +106,6 @@ public class GreenlitUpdateFeature extends BotFeature {
                                 return;
                             }
 
-                            EmojiConfig emojiConfig = NerdBotApp.getBot().getConfig().getEmojiConfig();
                             List<MessageReaction> reactions = message.getReactions()
                                 .stream()
                                 .filter(reaction -> reaction.getEmoji().getType() == Emoji.Type.CUSTOM)

--- a/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
@@ -19,14 +19,19 @@ import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.database.Database;
 import net.hypixel.nerdbot.api.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.bot.config.BotConfig;
+import net.hypixel.nerdbot.bot.config.ChannelConfig;
 import net.hypixel.nerdbot.bot.config.EmojiConfig;
 import net.hypixel.nerdbot.util.Util;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
 
 @Log4j2
 public class ActivityListener {
 
     private final Database database = NerdBotApp.getBot().getDatabase();
+    private final BotConfig config = NerdBotApp.getBot().getConfig();
+    private final ChannelConfig channelConfig = config.getChannelConfig();
 
     @SubscribeEvent
     public void onGuildMemberJoin(GuildMemberJoinEvent event) {
@@ -60,15 +65,13 @@ public class ActivityListener {
             long time = System.currentTimeMillis();
 
             // New Suggestions
-            BotConfig botConfig = NerdBotApp.getBot().getConfig();
-
-            if (Util.safeArrayStream(botConfig.getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+            if (Util.safeArrayStream(channelConfig.getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                 discordUser.getLastActivity().setLastSuggestionDate(time);
                 log.info("Updating new suggestion activity date for " + member.getEffectiveName() + " to " + time);
             }
 
             // New Alpha Suggestions
-            if (Util.safeArrayStream(botConfig.getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+            if (Util.safeArrayStream(channelConfig.getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                 discordUser.getLastActivity().setLastAlphaSuggestionDate(time);
                 log.info("Updating new alpha suggestion activity date for " + member.getEffectiveName() + " to " + time);
             }
@@ -100,13 +103,13 @@ public class ActivityListener {
             String forumChannelId = guildChannel.asThreadChannel().getParentChannel().getId();
 
             // New Suggestion Comments
-            if (Util.safeArrayStream(NerdBotApp.getBot().getConfig().getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+            if (Util.safeArrayStream(channelConfig.getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                 discordUser.getLastActivity().setSuggestionCommentDate(time);
                 log.info("Updating suggestion comment activity date for " + member.getEffectiveName() + " to " + time);
             }
 
             // New Alpha Suggestion Comments
-            if (Util.safeArrayStream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+            if (Util.safeArrayStream(channelConfig.getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                 isAlphaChannel = true;
                 discordUser.getLastActivity().setAlphaSuggestionCommentDate(time);
                 log.info("Updating alpha suggestion comment activity date for " + member.getEffectiveName() + " to " + time);
@@ -120,6 +123,11 @@ public class ActivityListener {
 
         discordUser.getLastActivity().setLastGlobalActivity(time);
         log.info("Updating last global activity date for " + member.getEffectiveName() + " to " + time);
+
+        // Ignore channel if blacklisted for activity tracking
+        if (Arrays.stream(channelConfig.getBlacklistedChannels()).anyMatch(guildChannel.getId()::equalsIgnoreCase)) {
+            return;
+        }
 
         discordUser.getLastActivity().getChannelActivity().put(guildChannel.getId(), discordUser.getLastActivity().getChannelActivity().getOrDefault(guildChannel.getId(), 0) + 1);
     }
@@ -190,13 +198,13 @@ public class ActivityListener {
                 long time = System.currentTimeMillis();
 
                 // New Suggestion Voting
-                if (Util.safeArrayStream(NerdBotApp.getBot().getConfig().getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+                if (Util.safeArrayStream(channelConfig.getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                     discordUser.getLastActivity().setSuggestionVoteDate(time);
                     log.info("Updating suggestion voting activity date for " + member.getEffectiveName() + " to " + time);
                 }
 
                 // New Alpha Suggestion Voting
-                if (Util.safeArrayStream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
+                if (Util.safeArrayStream(channelConfig.getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                     discordUser.getLastActivity().setAlphaSuggestionVoteDate(time);
                     log.info("Updating alpha suggestion voting activity date for " + member.getEffectiveName() + " to " + time);
                 }

--- a/src/main/java/net/hypixel/nerdbot/listener/ReactionChannelListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ReactionChannelListener.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 @Log4j2
 public class ReactionChannelListener {
 
-    private final List<ReactionChannel> reactionChannels = NerdBotApp.getBot().getConfig().getReactionChannels();
+    private final List<ReactionChannel> reactionChannels = NerdBotApp.getBot().getConfig().getChannelConfig().getReactionChannels();
 
     @SubscribeEvent
     public void onMessageReceive(MessageReceivedEvent event) {

--- a/src/main/java/net/hypixel/nerdbot/listener/SuggestionListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/SuggestionListener.java
@@ -28,7 +28,7 @@ public class SuggestionListener {
     }
 
     private boolean isInSuggestionChannel(GenericChannelEvent event) {
-        return Util.safeArrayStream(NerdBotApp.getBot().getConfig().getSuggestionForumIds(), NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds())
+        return Util.safeArrayStream(NerdBotApp.getBot().getConfig().getChannelConfig().getSuggestionForumIds(), NerdBotApp.getBot().getConfig().getChannelConfig().getAlphaSuggestionForumIds())
             .anyMatch(channelId -> channelId.equals(event.getChannel().getId()));
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/util/discord/SuggestionCache.java
+++ b/src/main/java/net/hypixel/nerdbot/util/discord/SuggestionCache.java
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.hypixel.nerdbot.NerdBotApp;
+import net.hypixel.nerdbot.bot.config.ChannelConfig;
 import net.hypixel.nerdbot.util.Util;
 
 import java.time.Duration;
@@ -41,7 +42,8 @@ public class SuggestionCache extends TimerTask {
             log.info("Started suggestion cache update.");
             this.loaded = false;
             this.cache.forEach((key, suggestion) -> suggestion.setExpired());
-            Util.safeArrayStream(NerdBotApp.getBot().getConfig().getSuggestionForumIds(), NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds())
+            ChannelConfig channelConfig = NerdBotApp.getBot().getConfig().getChannelConfig();
+            Util.safeArrayStream(channelConfig.getSuggestionForumIds(), channelConfig.getAlphaSuggestionForumIds())
                 .map(NerdBotApp.getBot().getJDA()::getForumChannelById)
                 .filter(Objects::nonNull)
                 .flatMap(forumChannel -> Stream.concat(forumChannel.getThreadChannels().stream(), forumChannel.retrieveArchivedPublicThreadChannels().stream()))
@@ -106,7 +108,7 @@ public class SuggestionCache extends TimerTask {
             this.parentId = thread.getParentChannel().asForumChannel().getId();
             this.greenlit = thread.getAppliedTags().stream().anyMatch(forumTag -> GREENLIT_TAGS.contains(forumTag.getName().toLowerCase()));
             this.expired = false;
-            this.alpha = thread.getName().toLowerCase().contains("alpha") || Util.safeArrayStream(NerdBotApp.getBot().getConfig().getAlphaSuggestionForumIds()).anyMatch(this.parentId::equalsIgnoreCase);
+            this.alpha = thread.getName().toLowerCase().contains("alpha") || Util.safeArrayStream(NerdBotApp.getBot().getConfig().getChannelConfig().getAlphaSuggestionForumIds()).anyMatch(this.parentId::equalsIgnoreCase);
 
             // Message & Reactions
             MessageHistory history = thread.getHistoryFromBeginning(1).complete();


### PR DESCRIPTION
This PR moves channel-related config stuff to its own class called ChannelConfig

It also implements a new feature to blacklist channels from incrementing a user's message count