### PR TITLE
Adding Titles into the buildSuggestionsEmbed.

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/command/UserCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/UserCommands.java
@@ -359,6 +359,7 @@ public class UserCommands extends ApplicationCommand {
         for (SuggestionCache.Suggestion suggestion : pages) {
             String link = suggestion.getThread().getJumpUrl();
             link += (suggestion.isGreenlit() ? " " + getEmojiFormat(EmojiConfig::getGreenlitEmojiId) : "") + "\n";
+            link += "Thread Name: " + suggestion.getThreadName() + "\n";
             link += suggestion.getThread().getAppliedTags().stream().map(ForumTag::getName).collect(Collectors.joining(", ")) + "\n";
 
             if (showNames) {

--- a/src/main/java/net/hypixel/nerdbot/util/discord/SuggestionCache.java
+++ b/src/main/java/net/hypixel/nerdbot/util/discord/SuggestionCache.java
@@ -95,6 +95,7 @@ public class SuggestionCache extends TimerTask {
 
         @Getter private final ThreadChannel thread;
         @Getter private final String parentId;
+        @Getter private final String threadName;
         @Getter private final boolean alpha;
         @Getter private final int agrees;
         @Getter private final int disagrees;
@@ -106,6 +107,7 @@ public class SuggestionCache extends TimerTask {
         public Suggestion(ThreadChannel thread) {
             this.thread = thread;
             this.parentId = thread.getParentChannel().asForumChannel().getId();
+            this.threadName = thread.getName();
             this.greenlit = thread.getAppliedTags().stream().anyMatch(forumTag -> GREENLIT_TAGS.contains(forumTag.getName().toLowerCase()));
             this.expired = false;
             this.alpha = thread.getName().toLowerCase().contains("alpha") || Util.safeArrayStream(NerdBotApp.getBot().getConfig().getChannelConfig().getAlphaSuggestionForumIds()).anyMatch(this.parentId::equalsIgnoreCase);


### PR DESCRIPTION
This is because over time, the suggestions get purged from the users cache, so grabbing them here lets users know what threads they are actually looking at.