### PR TITLE
Add member verification

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/bot/NerdBot.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/NerdBot.java
@@ -71,7 +71,8 @@ public class NerdBot implements Bot {
                 new FeatureEventListener(),
                 new ActivityListener(),
                 new ReactionChannelListener(),
-                new SuggestionListener()
+                new SuggestionListener(),
+                new VerificationListener()
             ).setActivity(Activity.of(config.getActivityType(), config.getActivity()));
         configureMemoryUsage(builder);
 

--- a/src/main/java/net/hypixel/nerdbot/bot/config/ChannelConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/ChannelConfig.java
@@ -19,7 +19,7 @@ public class ChannelConfig {
     private String logChannelId = "";
 
     /**
-     * The {@link TextChannel} ID that the bot will be log mojang profile verification requests to
+     * Mojang profile verification requests will be logged to this {@link TextChannel} ID
      */
     private String verifyLogChannelId = "";
 

--- a/src/main/java/net/hypixel/nerdbot/bot/config/ChannelConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/ChannelConfig.java
@@ -19,6 +19,11 @@ public class ChannelConfig {
     private String logChannelId = "";
 
     /**
+     * The {@link TextChannel} ID that the bot will be log mojang profile verification requests to
+     */
+    private String verifyLogChannelId = "";
+
+    /**
      * The {@link TextChannel} IDs for the suggestion forums
      */
     private String[] suggestionForumIds = {};

--- a/src/main/java/net/hypixel/nerdbot/channel/ChannelManager.java
+++ b/src/main/java/net/hypixel/nerdbot/channel/ChannelManager.java
@@ -25,4 +25,9 @@ public class ChannelManager {
     public static TextChannel getLogChannel() {
         return getChannel(NerdBotApp.getBot().getConfig().getChannelConfig().getLogChannelId());
     }
+
+    @Nullable
+    public static TextChannel getVerifyLogChannel() {
+        return getChannel(NerdBotApp.getBot().getConfig().getChannelConfig().getVerifyLogChannelId());
+    }
 }

--- a/src/main/java/net/hypixel/nerdbot/command/SuggestionCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/SuggestionCommands.java
@@ -34,7 +34,7 @@ public class SuggestionCommands extends ApplicationCommand {
         @AppOption(description = "Words to filter title for.") @Optional String title,
         @AppOption(description = "Toggle alpha suggestions.") @Optional Boolean alpha
     ) {
-        event.deferReply(true).queue();
+        event.deferReply(true).complete();
         page = (page == null) ? 1 : page;
         final int pageNum = Math.max(page, 1);
         final User searchUser = NerdBotApp.getBot().getJDA().getUserById(userID);
@@ -64,7 +64,7 @@ public class SuggestionCommands extends ApplicationCommand {
         @AppOption(description = "Words to filter title for.") @Optional String title,
         @AppOption(description = "Toggle alpha suggestions.") @Optional Boolean alpha
     ) {
-        event.deferReply(true).queue();
+        event.deferReply(true).complete();
         page = (page == null) ? 1 : page;
         final int pageNum = Math.max(page, 1);
         final boolean isAlpha = (alpha != null && alpha);
@@ -92,7 +92,7 @@ public class SuggestionCommands extends ApplicationCommand {
         @AppOption(description = "Words to filter title for.") @Optional String title,
         @AppOption(description = "Toggle alpha suggestions.") @Optional Boolean alpha
     ) {
-        event.deferReply(true).queue();
+        event.deferReply(true).complete();
         page = (page == null) ? 1 : page;
         final int pageNum = Math.max(page, 1);
         final boolean isAlpha = (alpha != null && alpha);
@@ -179,7 +179,7 @@ public class SuggestionCommands extends ApplicationCommand {
                 .addBlankField(true);
         }
 
-        embedBuilder.setFooter("Page: " + pageNum + "/" + totalPages + (NerdBotApp.getSuggestionCache().isLoaded() ? "" : " | Caching is in progress!"));
+        embedBuilder.setFooter("Page: " + pageNum + "/" + totalPages);
 
         if (!filters.isEmpty()) {
             embedBuilder.addField("Filters", filters,  false);

--- a/src/main/java/net/hypixel/nerdbot/generator/GeneratorStrings.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/GeneratorStrings.java
@@ -28,7 +28,7 @@ public class GeneratorStrings {
     public static final String DESC_ITEM_ID = "The name of the Minecraft item you want to display";
     public static final String DESC_HEAD_ID = "The skin ID or player name (set is_player_name to True if it is a player's name)";
     public static final String DESC_IS_PLAYER_NAME = "If the skin ID is a player's username";
-    public static final String DESC_HIDDEN = "If you only want the generated image visible to be yourself. These will be deleted if you restart your Discord client!";
+    public static final String DESC_HIDDEN = "If you only want the generated image visible to be yourself. (Deleted on client restart!)";
     public static final String DESC_PARSE_ITEM = "The items NBT Data from in game";
     public static final String DESC_INCLUDE_ITEM = "Include the item along with the parsed description";
     public static final String DESC_RENDER_INVENTORY = "If the Minecraft Inventory background should be drawn";

--- a/src/main/java/net/hypixel/nerdbot/listener/VerificationListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/VerificationListener.java
@@ -1,0 +1,118 @@
+package net.hypixel.nerdbot.listener;
+
+import lombok.extern.log4j.Log4j2;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.UserSnowflake;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.hooks.SubscribeEvent;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
+import net.hypixel.nerdbot.api.database.model.user.stats.MojangProfile;
+import net.hypixel.nerdbot.command.MyCommands;
+import net.hypixel.nerdbot.util.Util;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Log4j2
+public class VerificationListener {
+
+    @SubscribeEvent
+    public void onButtonClickEvent(@NotNull ButtonInteractionEvent event) {
+        if (event.getButton().getId() == null) {
+            return; // Lol
+        }
+
+        if (event.getButton().getId().startsWith("verification")) {
+            String[] parts = event.getButton().getId().split("-");
+            String action = parts[1];
+            String memberId = parts[2];
+            ButtonStyle buttonStyle = ButtonStyle.SECONDARY;
+            String buttonLabel = "Unknown";
+            List<Button> buttons = new ArrayList<>();
+            boolean updateButtons = true;
+
+            if (action.equals("kick")) {
+                int remainingClicks = Integer.parseInt(parts[3]);
+                remainingClicks--;
+
+                if (remainingClicks == 0) {
+                    updateButtons = false;
+
+                    event.getInteraction()
+                        .reply("Are you sure you want to kick <@" + memberId + ">?")
+                        .setEphemeral(true)
+                        .addComponents(ActionRow.of(
+                            Button.of(
+                                ButtonStyle.DANGER,
+                                String.format("verification-kicknow-%s", memberId),
+                                "Kick Now"
+                            )
+                        ))
+                        .queue();
+                } else {
+                    event.getInteraction().deferEdit().complete();
+                    buttonStyle = ButtonStyle.DANGER;
+                    buttonLabel = "Denied";
+                    buttons.add(Button.of(ButtonStyle.DANGER, String.format("verification-kick-%s-%s", memberId, remainingClicks), String.format("Kick (%s)", remainingClicks)));
+                }
+            } else if (action.equals("kicknow")) {
+                updateButtons = false;
+                Guild guild = Util.getMainGuild();
+                Member member = guild.retrieveMemberById(memberId).complete();
+                String displayName = Util.getDisplayName(member.getUser());
+                guild.kick(UserSnowflake.fromId(memberId)).complete();
+
+                event.getInteraction()
+                    .replyEmbeds(
+                        new EmbedBuilder()
+                            .setTitle("Member Kicked")
+                            .setDescription(displayName + " has been kicked from the server after failing verification.")
+                            .setColor(Color.RED)
+                            .build()
+                    )
+                    .queue();
+            } else {
+                event.getInteraction().deferEdit().complete();
+
+                if (action.equals("deny")) {
+                    buttonStyle = ButtonStyle.DANGER;
+                    buttonLabel = "Denied";
+                    buttons.add(Button.of(ButtonStyle.DANGER, String.format("verification-kick-%s-3", memberId), "Kick (3)"));
+                } else if (action.equals("accept")) {
+                    MojangProfile mojangProfile = MyCommands.VERIFY_CACHE.getIfPresent(memberId);
+
+                    if (mojangProfile == null) {
+                        buttonStyle = ButtonStyle.DANGER;
+                        buttonLabel = "Expired";
+                    } else {
+                        Guild guild = Util.getMainGuild();
+                        Member member = guild.retrieveMemberById(memberId).complete();
+
+                        if (member == null) {
+                            buttonLabel = "Left Server";
+                        } else {
+                            MyCommands.updateMojangProfile(member, mojangProfile);
+                            buttonStyle = ButtonStyle.SUCCESS;
+                            buttonLabel = "Accepted";
+                        }
+                    }
+                }
+
+                MyCommands.VERIFY_CACHE.invalidate(memberId);
+            }
+
+            if (updateButtons) {
+                buttons.add(Button.of(buttonStyle, "verification-done", buttonLabel).asDisabled());
+                Collections.reverse(buttons);
+                event.getHook().editOriginalComponents(ActionRow.of(buttons)).complete();
+            }
+        }
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/util/discord/SuggestionCache.java
+++ b/src/main/java/net/hypixel/nerdbot/util/discord/SuggestionCache.java
@@ -27,9 +27,10 @@ public class SuggestionCache extends TimerTask {
 
     private static final List<String> GREENLIT_TAGS = Arrays.asList("greenlit", "docced");
     private Map<String, Suggestion> cache = new HashMap<>();
-    @Getter private boolean loaded;
-    @Getter private long lastUpdated;
-    @Getter private final Timer timer = new Timer();
+    @Getter
+    private long lastUpdated;
+    @Getter
+    private final Timer timer = new Timer();
 
     public SuggestionCache() {
         this.timer.scheduleAtFixedRate(this, 0, Duration.ofMinutes(60).toMillis());
@@ -39,7 +40,6 @@ public class SuggestionCache extends TimerTask {
     public void run() {
         try {
             log.info("Started suggestion cache update.");
-            this.loaded = false;
             this.cache.forEach((key, suggestion) -> suggestion.setExpired());
             ChannelConfig channelConfig = NerdBotApp.getBot().getConfig().getChannelConfig();
             Util.safeArrayStream(channelConfig.getSuggestionForumIds(), channelConfig.getAlphaSuggestionForumIds())
@@ -62,7 +62,6 @@ public class SuggestionCache extends TimerTask {
                 .filter(Suggestion::isExpired)
                 .forEach(suggestion -> this.removeSuggestion(suggestion.getThread()));
 
-            this.loaded = true;
             log.info("Finished caching suggestions.");
         } catch (Exception ex) {
             ex.printStackTrace();
@@ -130,7 +129,8 @@ public class SuggestionCache extends TimerTask {
         }
 
         public static int getReactionCount(Message message, String emojiId) {
-            return message.getReactions().stream()
+            return message.getReactions()
+                .stream()
                 .filter(reaction -> reaction.getEmoji().getType() == Emoji.Type.CUSTOM)
                 .filter(reaction -> reaction.getEmoji().asCustom().getId().equalsIgnoreCase(emojiId))
                 .mapToInt(MessageReaction::getCount)


### PR DESCRIPTION
This branches off from /link and builds a /verify command.

- Setup a verification log channel in config
- The `/verify` command works similarly to `/link` but sends the request to staff for review
- On accept
  - Saves the users mojang profile
  - If limbo and new member role IDs are setup, migrate them from Limbo to New Member
- On deny
  - Adds a button to kick the member
  - Requires clicking it 3 times
  - On the 3rd click it will send a message asking for confirmation one last time (just to be sure)
  - Clicking the Kick Now button will finally kick the user and log to the verification channel

![image](https://github.com/TheMGRF/NerdBot/assets/6407029/a5e06564-ab3a-4eb9-8877-bf40960a9ad1)
