### PR TITLE
Add /flared slash command

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
@@ -386,11 +386,6 @@ public class AdminCommands extends ApplicationCommand {
 
         ForumTag forumTag = forumTags.get(0);
 
-        if (forumTag == null) {
-            event.reply("Couldn't find a Flared tag in this forum channel!").setEphemeral(true).queue();
-            return;
-        }
-
         if (threadChannel.getAppliedTags().contains(forumTag)) {
             event.reply("This suggestion is already flared!").setEphemeral(true).queue();
             return;

--- a/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
@@ -373,23 +373,31 @@ public class AdminCommands extends ApplicationCommand {
         Channel channel = event.getChannel();
 
         if (!(channel instanceof ThreadChannel threadChannel) || !(threadChannel.getParentChannel() instanceof ForumChannel forumChannel)) {
-            event.getHook().sendMessage("This command can only be used inside a thread that is part of a forum!").queue();
+            event.reply("This command can only be used inside a thread that is part of a forum!").queue();
             return;
         }
 
         ForumTag forumTag = forumChannel.getAvailableTagsByName("flared", true).get(0);
 
         if (forumTag == null) {
-            event.getHook().sendMessage("Couldn't find a Flared tag in this forum channel!").queue();
+            event.reply("Couldn't find a Flared tag in this forum channel!").queue();
             return;
         }
 
         List<ForumTag> appliedTags = new ArrayList<>(threadChannel.getAppliedTags());
+
+        if (appliedTags.contains(forumTag)) {
+            event.reply("This suggestion is already flared!").queue();
+            return;
+        }
+
         appliedTags.add(forumTag);
 
         threadChannel.getManager()
             .setLocked(true)
             .setAppliedTags(appliedTags)
             .queue();
+
+        event.reply("Applied the tag and locked this suggestion!").queue();
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
@@ -373,24 +373,30 @@ public class AdminCommands extends ApplicationCommand {
         Channel channel = event.getChannel();
 
         if (!(channel instanceof ThreadChannel threadChannel) || !(threadChannel.getParentChannel() instanceof ForumChannel forumChannel)) {
-            event.reply("This command can only be used inside a thread that is part of a forum!").queue();
+            event.reply("This command can only be used inside a thread that is part of a forum!").setEphemeral(true).queue();
             return;
         }
 
-        ForumTag forumTag = forumChannel.getAvailableTagsByName("flared", true).get(0);
+        List<ForumTag> forumTags = forumChannel.getAvailableTagsByName("flared", true);
+
+        if (forumTags.isEmpty()) {
+            event.reply("This forum channel has no tags!").setEphemeral(true).queue();
+            return;
+        }
+
+        ForumTag forumTag = forumTags.get(0);
 
         if (forumTag == null) {
-            event.reply("Couldn't find a Flared tag in this forum channel!").queue();
+            event.reply("Couldn't find a Flared tag in this forum channel!").setEphemeral(true).queue();
+            return;
+        }
+
+        if (threadChannel.getAppliedTags().contains(forumTag)) {
+            event.reply("This suggestion is already flared!").setEphemeral(true).queue();
             return;
         }
 
         List<ForumTag> appliedTags = new ArrayList<>(threadChannel.getAppliedTags());
-
-        if (appliedTags.contains(forumTag)) {
-            event.reply("This suggestion is already flared!").queue();
-            return;
-        }
-
         appliedTags.add(forumTag);
 
         threadChannel.getManager()
@@ -398,6 +404,6 @@ public class AdminCommands extends ApplicationCommand {
             .setAppliedTags(appliedTags)
             .queue();
 
-        event.reply("Applied the tag and locked this suggestion!").queue();
+        event.reply(event.getUser().getAsMention() + " applied the " + forumTag.getName() + " tag and locked this suggestion!").queue();
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
@@ -380,7 +380,7 @@ public class AdminCommands extends ApplicationCommand {
         List<ForumTag> forumTags = forumChannel.getAvailableTagsByName("flared", true);
 
         if (forumTags.isEmpty()) {
-            event.reply("This forum channel has no tags!").setEphemeral(true).queue();
+            event.reply("This forum channel does not have the Flared tag!").setEphemeral(true).queue();
             return;
         }
 


### PR DESCRIPTION
Requested by Flare

Adds a `/flared` slash command which only works within threads in forum channels that have a "flared" tag. The command will not work in other forum channels that don't have said tag.

It applies this tag and locks the suggestion, sending a message to everybody saying the suggestion was "flared" and locked