### PR TITLE
Less annoying modmail

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/api/database/model/user/stats/LastActivity.java
+++ b/src/main/java/net/hypixel/nerdbot/api/database/model/user/stats/LastActivity.java
@@ -16,6 +16,7 @@ public class LastActivity {
     private long lastGlobalActivity = -1L;
     private long lastVoiceChannelJoinDate = -1L;
     private long lastItemGenUsage = -1L;
+    private long lastModMailUsage = -1L;
 
     // Suggestion Activity
     private long lastSuggestionDate = -1L;

--- a/src/main/java/net/hypixel/nerdbot/bot/config/ModMailConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/ModMailConfig.java
@@ -38,6 +38,14 @@ public class ModMailConfig {
      * <br><br>
      * Valid formats are ABOVE, INLINE and BELOW
      */
-    private String roleFormat = "BELOW";
+    private RoleFormat roleFormat = RoleFormat.BELOW;
+
+    public enum RoleFormat {
+
+        ABOVE,
+        INLINE,
+        BELOW
+
+    }
 
 }

--- a/src/main/java/net/hypixel/nerdbot/bot/config/ModMailConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/ModMailConfig.java
@@ -35,15 +35,22 @@ public class ModMailConfig {
 
     /**
      * How to display the role ping when receiving a new mod mail message from a user
-     * <br><br>
-     * Valid formats are ABOVE, INLINE and BELOW
      */
     private RoleFormat roleFormat = RoleFormat.BELOW;
 
     public enum RoleFormat {
 
+        /**
+         * Above the first (or only) message
+         */
         ABOVE,
+        /**
+         * Inline with the first (or only) message
+         */
         INLINE,
+        /**
+         * After the last (or only) message
+         */
         BELOW
 
     }

--- a/src/main/java/net/hypixel/nerdbot/bot/config/ModMailConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/ModMailConfig.java
@@ -28,4 +28,16 @@ public class ModMailConfig {
      */
     private String webhookId = "";
 
+    /**
+     * The uninterruptible time (in seconds) before pinging {@link #getRoleId()}
+     */
+    private int timeBetweenPings = 60;
+
+    /**
+     * How to display the role ping when receiving a new mod mail message from a user
+     * <br><br>
+     * Valid formats are ABOVE, INLINE and BELOW
+     */
+    private String roleFormat = "BELOW";
+
 }

--- a/src/main/java/net/hypixel/nerdbot/command/GeneratorCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/GeneratorCommands.java
@@ -18,6 +18,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.utils.FileUpload;
 import net.hypixel.nerdbot.NerdBotApp;
+import net.hypixel.nerdbot.api.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.channel.ChannelManager;
 import net.hypixel.nerdbot.generator.GeneratorBuilder;
 import net.hypixel.nerdbot.generator.ImageMerger;
@@ -60,12 +61,18 @@ public class GeneratorCommands extends ApplicationCommand {
             return;
         }
         hidden = (hidden != null && hidden);
-        event.deferReply(hidden).queue();
+        event.deferReply(hidden).complete();
         // building the item's description
         BufferedImage generatedImage = builder.buildItem(event, itemName, rarity, itemLore, type, disableRarityLinebreak, alpha, padding, maxLineLength, true);
         if (generatedImage != null) {
             event.getHook().sendFiles(FileUpload.fromData(Util.toFile(generatedImage))).setEphemeral(hidden).queue();
         }
+
+        // Log item gen activity
+        DiscordUser discordUser = Util.getOrAddUserToCache(NerdBotApp.getBot().getDatabase(), event.getMember().getId());
+        long currentTime = System.currentTimeMillis();
+        discordUser.getLastActivity().setLastItemGenUsage(currentTime);
+        log.info("Updating last item generator activity date for " + Util.getDisplayName(event.getUser()) + " to " + currentTime);
     }
 
     @JDASlashCommand(name = COMMAND_PREFIX, subcommand = "text", description = "Creates an image that looks like a message from Minecraft, primarily used for Hypixel Skyblock")
@@ -74,12 +81,18 @@ public class GeneratorCommands extends ApplicationCommand {
             return;
         }
         hidden = (hidden != null && hidden);
-        event.deferReply(hidden).queue();
+        event.deferReply(hidden).complete();
         // building the chat message
         BufferedImage generatedImage = builder.buildItem(event, "NONE", "NONE", message, "", true, 0, 1, StringColorParser.MAX_FINAL_LINE_LENGTH, false);
         if (generatedImage != null) {
             event.getHook().sendFiles(FileUpload.fromData(Util.toFile(generatedImage))).setEphemeral(hidden).queue();
         }
+
+        // Log item gen activity
+        DiscordUser discordUser = Util.getOrAddUserToCache(NerdBotApp.getBot().getDatabase(), event.getMember().getId());
+        long currentTime = System.currentTimeMillis();
+        discordUser.getLastActivity().setLastItemGenUsage(currentTime);
+        log.info("Updating last item generator activity date for " + Util.getDisplayName(event.getUser()) + " to " + currentTime);
     }
 
     @JDASlashCommand(name = COMMAND_PREFIX, subcommand = "head", description = "Draws a minecraft head into a file")
@@ -91,12 +104,18 @@ public class GeneratorCommands extends ApplicationCommand {
             return;
         }
         hidden = (hidden != null && hidden);
-        event.deferReply(hidden).queue();
+        event.deferReply(hidden).complete();
 
         BufferedImage head = builder.buildHead(event, skinId, isPlayerName);
         if (head != null) {
             event.getHook().sendFiles(FileUpload.fromData(Util.toFile(head))).setEphemeral(hidden).queue();
         }
+
+        // Log item gen activity
+        DiscordUser discordUser = Util.getOrAddUserToCache(NerdBotApp.getBot().getDatabase(), event.getMember().getId());
+        long currentTime = System.currentTimeMillis();
+        discordUser.getLastActivity().setLastItemGenUsage(currentTime);
+        log.info("Updating last item generator activity date for " + Util.getDisplayName(event.getUser()) + " to " + currentTime);
     }
 
     @JDASlashCommand(name = COMMAND_PREFIX, subcommand = "full", description = "Generates a full item stack!")
@@ -118,7 +137,7 @@ public class GeneratorCommands extends ApplicationCommand {
             return;
         }
         hidden = (hidden != null && hidden);
-        event.deferReply(hidden).queue();
+        event.deferReply(hidden).complete();
 
         // checking that there are two or more different items to merge the images
         if ((itemName == null || rarity == null || itemLore == null) && itemID == null && recipe == null) {
@@ -159,6 +178,12 @@ public class GeneratorCommands extends ApplicationCommand {
         ImageMerger merger = new ImageMerger(generatedDescription, generatedItem, generatedRecipe);
         merger.drawFinalImage();
         event.getHook().sendFiles(FileUpload.fromData(Util.toFile(merger.getImage()))).setEphemeral(hidden).queue();
+
+        // Log item gen activity
+        DiscordUser discordUser = Util.getOrAddUserToCache(NerdBotApp.getBot().getDatabase(), event.getMember().getId());
+        long currentTime = System.currentTimeMillis();
+        discordUser.getLastActivity().setLastItemGenUsage(currentTime);
+        log.info("Updating last item generator activity date for " + Util.getDisplayName(event.getUser()) + " to " + currentTime);
     }
 
     @JDASlashCommand(name = COMMAND_PREFIX, subcommand = "recipe", description = "Generates a Minecraft Recipe Image")
@@ -170,7 +195,7 @@ public class GeneratorCommands extends ApplicationCommand {
             return;
         }
         hidden = (hidden != null && hidden);
-        event.deferReply(hidden).queue();
+        event.deferReply(hidden).complete();
 
         renderBackground = (renderBackground == null || renderBackground);
 
@@ -179,6 +204,12 @@ public class GeneratorCommands extends ApplicationCommand {
         if (generatedRecipe != null) {
             event.getHook().sendFiles(FileUpload.fromData(Util.toFile(generatedRecipe))).queue();
         }
+
+        // Log item gen activity
+        DiscordUser discordUser = Util.getOrAddUserToCache(NerdBotApp.getBot().getDatabase(), event.getMember().getId());
+        long currentTime = System.currentTimeMillis();
+        discordUser.getLastActivity().setLastItemGenUsage(currentTime);
+        log.info("Updating last item generator activity date for " + Util.getDisplayName(event.getUser()) + " to " + currentTime);
     }
 
     @JDASlashCommand(name = COMMAND_PREFIX, subcommand = "parse", description = "Converts a minecraft item into a Nerd Bot item!")
@@ -192,7 +223,7 @@ public class GeneratorCommands extends ApplicationCommand {
         }
 
         hidden = (hidden != null && hidden);
-        event.deferReply(hidden).queue();
+        event.deferReply(hidden).complete();
         includeItem = Objects.requireNonNullElse(includeItem, false);
 
         // converting the nbt into json
@@ -346,6 +377,12 @@ public class GeneratorCommands extends ApplicationCommand {
         }
 
         event.getHook().sendMessage(String.format(ITEM_PARSE_COMMAND, itemGenCommand)).setEphemeral(true).queue();
+
+        // Log item gen activity
+        DiscordUser discordUser = Util.getOrAddUserToCache(NerdBotApp.getBot().getDatabase(), event.getMember().getId());
+        long currentTime = System.currentTimeMillis();
+        discordUser.getLastActivity().setLastItemGenUsage(currentTime);
+        log.info("Updating last item generator activity date for " + Util.getDisplayName(event.getUser()) + " to " + currentTime);
     }
 
     @JDASlashCommand(name = COMMAND_PREFIX, group = "help", subcommand = "args", description = "Show help related to the arguments of the Item Generation command.")

--- a/src/main/java/net/hypixel/nerdbot/generator/GeneratorBuilder.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/GeneratorBuilder.java
@@ -20,6 +20,8 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static net.hypixel.nerdbot.generator.GeneratorStrings.*;
 import static net.hypixel.nerdbot.generator.GeneratorStrings.stripString;
@@ -29,6 +31,7 @@ public class GeneratorBuilder {
 
     public static final int IMAGE_HEIGHT = 512;
     public static final int IMAGE_WIDTH = 512;
+    private static final Pattern TEXTURE_URL = Pattern.compile("(?:https?://textures.minecraft.net/texture/)?([a-zA-Z0-9]+)");
 
     private final HashMap<String, Item> items;
     private boolean itemsInitialisedCorrectly = true;
@@ -218,9 +221,9 @@ public class GeneratorBuilder {
         }
 
         // checking if there is the has added the full url to the texture ID
-        if (textureID.contains("http://textures.minecraft.net/texture/")) {
-            textureID = textureID.replace("http://textures.minecraft.net/texture/", "");
-            event.getHook().sendMessage(HEAD_URL_REMINDER).setEphemeral(true).queue();
+        Matcher textureMatcher = TEXTURE_URL.matcher(textureID);
+        if (textureMatcher.matches()) {
+            textureID = textureMatcher.group(1);
         }
 
         // converting the skin retrieved into a 3d head

--- a/src/main/java/net/hypixel/nerdbot/generator/GeneratorBuilder.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/GeneratorBuilder.java
@@ -3,9 +3,7 @@ package net.hypixel.nerdbot.generator;
 import com.freya02.botcommands.api.application.slash.GuildSlashEvent;
 import com.google.gson.JsonObject;
 import lombok.extern.log4j.Log4j2;
-import net.dv8tion.jda.api.entities.Member;
 import net.hypixel.nerdbot.NerdBotApp;
-import net.hypixel.nerdbot.api.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.command.GeneratorCommands;
 import net.hypixel.nerdbot.util.Util;
 import net.hypixel.nerdbot.util.generator.Item;
@@ -16,15 +14,21 @@ import net.hypixel.nerdbot.util.skyblock.Rarity;
 import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static net.hypixel.nerdbot.generator.GeneratorStrings.*;
-import static net.hypixel.nerdbot.generator.GeneratorStrings.stripString;
 
 @Log4j2
 public class GeneratorBuilder {
@@ -187,18 +191,16 @@ public class GeneratorBuilder {
         padding = Objects.requireNonNullElse(padding, 0);
         padding = Math.max(0, padding);
 
-        MinecraftImage minecraftImage = new MinecraftImage(colorParser.getParsedDescription(), MCColor.GRAY, maxLineLength * 25, alpha, padding, isNormalItem).render();
-
-        Member member = event.getMember();
-        DiscordUser discordUser = Util.getOrAddUserToCache(NerdBotApp.getBot().getDatabase(), member.getId());
-        if (discordUser == null) {
-            log.info("Not updating last item generator activity date for " + member.getEffectiveName() + " (ID: " + member.getId() + ") since we cannot find a user!");
-        } else {
-            discordUser.getLastActivity().setLastItemGenUsage(System.currentTimeMillis());
-            log.info("Updating last item generator activity date for " + member.getEffectiveName() + " to " + System.currentTimeMillis());
-        }
-
-        return minecraftImage.getImage();
+        return new MinecraftImage(
+            colorParser.getParsedDescription(),
+            MCColor.GRAY,
+            maxLineLength * 25,
+            alpha,
+            padding,
+            isNormalItem
+        )
+            .render()
+            .getImage();
     }
 
     /**

--- a/src/main/java/net/hypixel/nerdbot/generator/GeneratorStrings.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/GeneratorStrings.java
@@ -86,7 +86,6 @@ public class GeneratorStrings {
                         """.formatted(COMMAND_PREFIX);
 
     // item gen head messages
-    public static final String HEAD_URL_REMINDER = "Hey, a small heads up - you don't need to include the full URL! Only the skin ID is required";
     public static final String MALFORMED_HEAD_URL = "It seems that there is something wrong with the URL that was entered on the developer side of it. Please contact one of the Bot Developers!";
     public static final String INVALID_HEAD_URL = "It seems that the URL you entered in doesn't link to anything...\nEntered URL: `http://textures.minecraft.net/texture/%s`";
     public static final String REQUEST_PLAYER_UUID_ERROR = "There was an error trying to send a request to get the UUID of this player...";

--- a/src/main/java/net/hypixel/nerdbot/listener/ModMailListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ModMailListener.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
 import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.database.Database;
 import net.hypixel.nerdbot.api.database.model.user.DiscordUser;
+import net.hypixel.nerdbot.bot.config.ModMailConfig;
 import net.hypixel.nerdbot.util.Util;
 
 import java.util.ArrayList;
@@ -173,13 +174,13 @@ public class ModMailListener {
     private static String appendModMailRoleMention(List<String> messages, String content, int index) {
         String modMailRoleId = NerdBotApp.getBot().getConfig().getModMailConfig().getRoleId();
         String modMailRoleMention = "<@&%s>".formatted(modMailRoleId);
-        String roleFormat = NerdBotApp.getBot().getConfig().getModMailConfig().getRoleFormat();
+        ModMailConfig.RoleFormat roleFormat = NerdBotApp.getBot().getConfig().getModMailConfig().getRoleFormat();
 
         if (index == 0) { // First message
             if (modMailRoleId != null) {
-                if (roleFormat.equalsIgnoreCase("ABOVE")) {
+                if (roleFormat == ModMailConfig.RoleFormat.ABOVE) {
                     content = modMailRoleMention + "\n\n" + content;
-                } else if (roleFormat.equalsIgnoreCase("INLINE")) {
+                } else if (roleFormat == ModMailConfig.RoleFormat.INLINE) {
                     content = modMailRoleMention + " " + content;
                 }
             }
@@ -187,7 +188,7 @@ public class ModMailListener {
 
         if (index == messages.size() - 1) { // Last message
             if (modMailRoleId != null) {
-                if (roleFormat.equalsIgnoreCase("BELOW")) {
+                if (roleFormat == ModMailConfig.RoleFormat.BELOW) {
                     content += "\n\n" + modMailRoleMention;
                 }
             }

--- a/src/main/java/net/hypixel/nerdbot/listener/ModMailListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ModMailListener.java
@@ -32,30 +32,27 @@ import java.util.stream.Collectors;
 public class ModMailListener {
 
     private static final String MOD_MAIL_TITLE_TEMPLATE = "%s (%s)";
-    private final String modMailChannelId = NerdBotApp.getBot().getConfig().getModMailConfig().getChannelId();
-    private final String modMailRoleId = NerdBotApp.getBot().getConfig().getModMailConfig().getRoleId();
-    private final String modMailRoleMention = "<@&%s>".formatted(modMailRoleId);
 
     @SubscribeEvent
     public void onModMailReceived(MessageReceivedEvent event) {
-        if (event.getChannelType() != ChannelType.PRIVATE) {
-            return;
-        }
-
         User author = event.getAuthor();
         if (author.isBot() || author.isSystem()) {
             return;
         }
 
-        ForumChannel forumChannel = NerdBotApp.getBot().getJDA().getForumChannelById(modMailChannelId);
-        if (forumChannel == null) {
+        if (event.getChannelType() != ChannelType.PRIVATE) {
+            return;
+        }
+
+        ForumChannel modMailChannel = getModMailChannel();
+        if (modMailChannel == null) {
             return;
         }
 
         Message message = event.getMessage();
         Database database = NerdBotApp.getBot().getDatabase();
-        List<ThreadChannel> channels = new ArrayList<>(forumChannel.getThreadChannels());
-        channels.addAll(forumChannel.retrieveArchivedPublicThreadChannels().stream().toList());
+        List<ThreadChannel> channels = new ArrayList<>(modMailChannel.getThreadChannels());
+        channels.addAll(modMailChannel.retrieveArchivedPublicThreadChannels().stream().toList());
         Optional<ThreadChannel> existingTicket = channels.stream()
             .filter(threadChannel -> threadChannel.getName().contains(author.getId())) // Find Existing ModMail Thread
             .findFirst();
@@ -107,8 +104,9 @@ public class ModMailListener {
                 }
             }
         } else {
-            threadChannel = forumChannel.createForumPost(expectedThreadName, MessageCreateData.fromContent(expectedFirstPost)).complete().getThreadChannel();
+            threadChannel = modMailChannel.createForumPost(expectedThreadName, MessageCreateData.fromContent(expectedFirstPost)).complete().getThreadChannel();
             threadChannel.getManager().setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_24_HOURS).queue();
+            String modMailRoleId = NerdBotApp.getBot().getConfig().getModMailConfig().getRoleId();
 
             if (modMailRoleId != null) {
                 threadChannel.getGuild().getMembersWithRoles(Util.getRoleById(modMailRoleId)).forEach(member -> threadChannel.addThreadMember(member).complete());
@@ -117,6 +115,7 @@ public class ModMailListener {
 
         Optional<Webhook> webhook = getWebhook();
         log.info(author.getName() + " replied to their Mod Mail request (Thread ID: " + threadChannel.getId() + ")");
+        boolean shouldSendMention = shouldAppendRoleMention(discordUser);
 
         if (webhook.isPresent()) {
             try (JDAWebhookClient client = JDAWebhookClient.from(webhook.get()).onThread(threadChannel.getIdLong())) {
@@ -128,11 +127,11 @@ public class ModMailListener {
                     webhookMessage.setAvatarUrl(event.getAuthor().getEffectiveAvatarUrl());
                     String content = messages.get(i);
 
-                    if (i == messages.size() - 1) { // Last message
-                        if (modMailRoleId != null) {
-                            content += "\n\n" + modMailRoleMention;
-                        }
+                    if (shouldSendMention) {
+                        content = appendModMailRoleMention(messages, content, i);
+                    }
 
+                    if (i == messages.size() - 1) { // Last message
                         buildFiles(message).forEach(fileUpload -> webhookMessage.addFile(fileUpload.getName(), fileUpload.getData()));
                     }
 
@@ -147,10 +146,8 @@ public class ModMailListener {
                 MessageCreateBuilder messageBuilder = new MessageCreateBuilder();
                 String content = messages.get(i);
 
-                if (i == 0) { // First message
-                    if (modMailRoleId != null) {
-                        content = modMailRoleMention + " " + content;
-                    }
+                if (shouldSendMention) {
+                    content = appendModMailRoleMention(messages, content, i);
                 }
 
                 if (i == messages.size() - 1) { // Last message
@@ -161,10 +158,51 @@ public class ModMailListener {
                 threadChannel.sendMessage(messageBuilder.build()).complete();
             }
         }
+
+        // Update last use
+        discordUser.getLastActivity().setLastModMailUsage(System.currentTimeMillis());
+    }
+
+    private static boolean shouldAppendRoleMention(DiscordUser discordUser) {
+        long lastUsage = discordUser.getLastActivity().getLastModMailUsage();
+        long currentTime = System.currentTimeMillis();
+        int timeBetweenPings = NerdBotApp.getBot().getConfig().getModMailConfig().getTimeBetweenPings();
+        return (currentTime - lastUsage) / 1000 > timeBetweenPings;
+    }
+
+    private static String appendModMailRoleMention(List<String> messages, String content, int index) {
+        String modMailRoleId = NerdBotApp.getBot().getConfig().getModMailConfig().getRoleId();
+        String modMailRoleMention = "<@&%s>".formatted(modMailRoleId);
+        String roleFormat = NerdBotApp.getBot().getConfig().getModMailConfig().getRoleFormat();
+
+        if (index == 0) { // First message
+            if (modMailRoleId != null) {
+                if (roleFormat.equalsIgnoreCase("ABOVE")) {
+                    content = modMailRoleMention + "\n\n" + content;
+                } else if (roleFormat.equalsIgnoreCase("INLINE")) {
+                    content = modMailRoleMention + " " + content;
+                }
+            }
+        }
+
+        if (index == messages.size() - 1) { // Last message
+            if (modMailRoleId != null) {
+                if (roleFormat.equalsIgnoreCase("BELOW")) {
+                    content += "\n\n" + modMailRoleMention;
+                }
+            }
+        }
+
+        return content;
     }
 
     @SubscribeEvent
     public void onModMailResponse(MessageReceivedEvent event) {
+        User author = event.getAuthor();
+        if (author.isBot() || author.isSystem()) {
+            return;
+        }
+
         if (event.getChannelType() != ChannelType.GUILD_PUBLIC_THREAD) {
             return;
         }
@@ -174,18 +212,8 @@ public class ModMailListener {
             return;
         }
 
-        ForumChannel parent = threadChannel.getParentChannel().asForumChannel();
-        if (!parent.getId().equals(modMailChannelId)) {
-            return;
-        }
-
-        ForumChannel forumChannel = NerdBotApp.getBot().getJDA().getForumChannelById(modMailChannelId);
-        if (forumChannel == null) {
-            return;
-        }
-
-        User author = event.getAuthor();
-        if (author.isBot() || author.isSystem()) {
+        ForumChannel modMailChannel = getModMailChannel();
+        if (modMailChannel == null || !modMailChannel.getId().equals(threadChannel.getParentChannel().getId())) {
             return;
         }
 
@@ -228,6 +256,17 @@ public class ModMailListener {
                     .getWebhookId()
             ))
             .findFirst();
+    }
+
+    private static ForumChannel getModMailChannel() {
+        return NerdBotApp.getBot()
+            .getJDA()
+            .getForumChannelById(
+                NerdBotApp.getBot()
+                    .getConfig()
+                    .getModMailConfig()
+                    .getChannelId()
+            );
     }
 
     private static List<String> buildContent(Message message, boolean webhook) {

--- a/src/main/resources/example-config.json
+++ b/src/main/resources/example-config.json
@@ -1,1 +1,40 @@
-{"modMailConfig":{"channelId":"","roleId":"","webhookId":""},"emojiConfig":{"agreeEmojiId":"","disagreeEmojiId":"","neutralEmojiId":"","greenlitEmojiId":""},"tagConfig":{"greenlit":""},"channelConfig":{"logChannelId":"","verifyLogChannelId":"","suggestionForumIds":[],"alphaSuggestionForumIds":[],"genChannelIds":[],"reactionChannels":[],"blacklistedChannels":[]},"roleConfig":{"botManagerRoleId":"","newMemberRoleId":"","limboRoleId":""},"guildId":"","minimumThreshold":15,"messageLimit":100,"mojangUsernameCacheTTL":12,"voiceThreshold":60,"percentage":75.0,"interval":43200000,"activityType":"PLAYING","activity":"","inactivityDays":7}
+{
+  "modMailConfig": {
+    "channelId": "",
+    "roleId": "",
+    "webhookId": ""
+  },
+  "emojiConfig": {
+    "agreeEmojiId": "",
+    "disagreeEmojiId": "",
+    "neutralEmojiId": "",
+    "greenlitEmojiId": ""
+  },
+  "tagConfig": {
+    "greenlit": ""
+  },
+  "channelConfig": {
+    "logChannelId": "",
+    "verifyLogChannelId": "",
+    "suggestionForumIds": [],
+    "alphaSuggestionForumIds": [],
+    "genChannelIds": [],
+    "reactionChannels": [],
+    "blacklistedChannels": []
+  },
+  "roleConfig": {
+    "botManagerRoleId": "",
+    "newMemberRoleId": "",
+    "limboRoleId": ""
+  },
+  "guildId": "",
+  "minimumThreshold": 15,
+  "messageLimit": 100,
+  "mojangUsernameCacheTTL": 12,
+  "voiceThreshold": 60,
+  "percentage": 75.0,
+  "interval": 43200000,
+  "activityType": "PLAYING",
+  "activity": "",
+  "inactivityDays": 7
+}


### PR DESCRIPTION
- Adds rolling timer (defaults to 60 seconds) before it pings the mod mail role again.
- Adds a config option to change where the mod mail role ping is located.
  - Options are ABOVE, INLINE and BELOW (default)
- Removes head warning message when sending full URL
  - Now uses a pattern matcher to support SSL URLs just in case.
- Moved mod mail role id out of class variables and into execution code so they can be changed using config editor.

This is the complete version of https://github.com/TheMGRF/NerdBot/pull/122