### PR TITLE
Add a help command to show all available colors

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/command/GeneratorCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/GeneratorCommands.java
@@ -25,6 +25,7 @@ import net.hypixel.nerdbot.generator.ImageMerger;
 import net.hypixel.nerdbot.generator.StringColorParser;
 import net.hypixel.nerdbot.util.Util;
 import net.hypixel.nerdbot.util.skyblock.Icon;
+import net.hypixel.nerdbot.util.skyblock.MCColor;
 import net.hypixel.nerdbot.util.skyblock.Rarity;
 import net.hypixel.nerdbot.util.skyblock.Stat;
 
@@ -549,6 +550,23 @@ public class GeneratorCommands extends ApplicationCommand {
 
         embedBuilder.addField("ID", idBuilder.toString(), true);
         embedBuilder.addField("Symbol", symbolBuilder.toString(), true);
+
+        event.replyEmbeds(embedBuilder.build()).setEphemeral(true).queue();
+    }
+
+    @JDASlashCommand(name = COMMAND_PREFIX, group = "help", subcommand = "colors", description = "Show a list of all other icons")
+    public void showAllColors(GuildSlashEvent event) {
+        EmbedBuilder embedBuilder = new EmbedBuilder().setTitle("All Available Colors").setColor(EMBED_COLORS[0]);
+        StringBuilder idBuilder = new StringBuilder();
+        StringBuilder colorBuilder = new StringBuilder();
+
+        for(MCColor color : MCColor.VALUES) {
+            idBuilder.append("&").append(color.getColorCode()).append(" or %%").append(color.name()).append("%%").append("\n");
+            colorBuilder.append(color.name()).append("\n");
+        }
+
+        embedBuilder.addField("IDs", idBuilder.toString(), true);
+        embedBuilder.addField("Color", colorBuilder.toString(), true);
 
         event.replyEmbeds(embedBuilder.build()).setEphemeral(true).queue();
     }

--- a/src/main/java/net/hypixel/nerdbot/generator/GeneratorStrings.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/GeneratorStrings.java
@@ -75,11 +75,11 @@ public class GeneratorStrings {
                         `max_line_length`: Defines the maximum length that the line can be. Can be between 1 and 54.
                         """;
     public static final String ITEM_COLOR_CODES = """ 
-                        The Item Generator bot also accepts color codes. You can use these with either manual Minecraft codes, such as `&1`, or Hypixel style color codes, such as `%%DARK_BLUE%%`.
+                        The Item Generator bot also accepts color codes. You can use these with either manual Minecraft codes, such as `&1`, or Hypixel style color codes, such as `%%DARK_BLUE%%`. You can use `/%s help colors` to view all available colors.
                         You can use this same format for stats, such as `%%%%PRISTINE%%%%`. This format can also have numbers, where `%%%%PRISTINE:+1%%%%` will become "+1 ✧ Pristine".
                         If you just want to get the icon for a specific stat, you can use `%%%%&PRISTINE%%%%` to automatically format it to the correct color, or retrieve it manually from the `/%s help symbols` command.
                         Another coloring shortcut you can use, such as `%%%%GEM_TOPAZ%%%%`, adding the `[✧]` gemstone slot into the item.
-                        """.formatted(COMMAND_PREFIX);
+                        """.formatted(COMMAND_PREFIX, COMMAND_PREFIX);
 
     public static final String ITEM_OTHER_INFO = """
                         The command will automatically soft-wrap text on your image so that you don't have to. You can change where this begins wrapping by using the `max_line_length` parameter. However, you can move your text to a newline by typing `\\n`.


### PR DESCRIPTION
This is the only part of the bot that doesn't have a help command to preview all of the options, so here goes nothing

![image](https://github.com/TheMGRF/NerdBot/assets/12937331/1d92b215-d9ef-4f99-b0bd-d696c7d7e2d2)
