### PR TITLE
Added a modifier to repeat icons

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/generator/IconParser.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/IconParser.java
@@ -1,0 +1,42 @@
+package net.hypixel.nerdbot.generator;
+
+import net.hypixel.nerdbot.util.skyblock.Icon;
+
+public class IconParser {
+
+    private IconParser() {
+    }
+
+    /**
+     * Returns the icon with no extra data
+     *
+     * @param icon      the selected icon
+     * @param extraData the extra arguments provided
+     *
+     * @return the icon with no extra data
+     */
+    public static String defaultIconParser(Icon icon, String extraData) {
+        return icon.getIcon();
+    }
+
+    /**
+     * Returns the icon repeated the amount of times specified in the extra data
+     *
+     * @param icon      the selected icon
+     * @param extraData the extra arguments provided
+     *
+     * @return the icon repeated the amount of times specified in the extra data
+     */
+    public static String repeatingIconParser(Icon icon, String extraData) {
+        String text = defaultIconParser(icon, extraData);
+        try {
+            int amount = Integer.parseInt(extraData);
+            if (amount < 1) {
+                return text;
+            }
+            return text.repeat(amount);
+        } catch (NumberFormatException e) {
+            return text;
+        }
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/generator/StringColorParser.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/StringColorParser.java
@@ -152,7 +152,7 @@ public class StringColorParser {
                     // checking if the command is an icon
                     Icon icon = (Icon) Util.findValue(icons, selectedCommand);
                     if(icon != null) {
-                        String replacementText = icon.getIcon() + currentColor;
+                        String replacementText = icon.getParsedIcon(extraData) + currentColor;
                         description.replace(charIndex, closingIndex + 2, replacementText);
                         continue;
                     }

--- a/src/main/java/net/hypixel/nerdbot/util/skyblock/Icon.java
+++ b/src/main/java/net/hypixel/nerdbot/util/skyblock/Icon.java
@@ -5,7 +5,7 @@ import net.hypixel.nerdbot.generator.IconParser;
 import java.util.function.BiFunction;
 
 public enum Icon {
-    DOT("•", "Dot", IconParser::repeatingIconParser),
+    DOT("•", "Dot"),
     TICKER("Ⓞ", "Ticker", IconParser::repeatingIconParser),
     ZOMBIE_CHARGE("ⓩ", "Available Charge", IconParser::repeatingIconParser),
     STAR("✪", "Star", IconParser::repeatingIconParser),

--- a/src/main/java/net/hypixel/nerdbot/util/skyblock/Icon.java
+++ b/src/main/java/net/hypixel/nerdbot/util/skyblock/Icon.java
@@ -1,10 +1,14 @@
 package net.hypixel.nerdbot.util.skyblock;
 
+import net.hypixel.nerdbot.generator.IconParser;
+
+import java.util.function.BiFunction;
+
 public enum Icon {
-    DOT("•", "Dot"),
-    TICKER("Ⓞ", "Ticker"),
-    ZOMBIE_CHARGE("ⓩ", "Available Charge"),
-    STAR("✪", "Star"),
+    DOT("•", "Dot", IconParser::repeatingIconParser),
+    TICKER("Ⓞ", "Ticker", IconParser::repeatingIconParser),
+    ZOMBIE_CHARGE("ⓩ", "Available Charge", IconParser::repeatingIconParser),
+    STAR("✪", "Star", IconParser::repeatingIconParser),
     STARRED("⚚", "Starred"),
     BINGO("Ⓑ", "Bingo");
 
@@ -12,10 +16,16 @@ public enum Icon {
 
     private final String icon;
     private final String name;
+    private final BiFunction<Icon, String, String> iconParser;
 
     Icon(String icon, String name) {
+        this(icon, name, IconParser::defaultIconParser);
+    }
+
+    Icon(String icon, String name, BiFunction<Icon, String, String> iconParser) {
         this.icon = icon;
         this.name = name;
+        this.iconParser = iconParser;
     }
 
     public String getIcon() {
@@ -24,5 +34,16 @@ public enum Icon {
 
     public String getName() {
         return name;
+    }
+
+    /**
+     * Parses the icon with the extra data provided
+     *
+     * @param extraData extra arguments provided in the section
+     *
+     * @return returns a color parsed replacement string
+     */
+    public String getParsedIcon(String extraData) {
+        return iconParser.apply(this, extraData);
     }
 }


### PR DESCRIPTION
Added a repeating modifier to some icons. Specifying an amount after the icon name will repeat it that many items. Icons will be repeated ``max(1, amount)`` times. 

Examples:
## Valid Cases
``%%STAR%%`` -> ✪
``%%STAR:5%%`` -> ✪✪✪✪✪

## Invalid Cases
``%%STAR:-1%%`` -> ✪ (invalid number) 
``%%STAR:0%%`` -> ✪ (invalid number) 
``%%STAR:test%%`` -> ✪ (not a number)