### PR TITLE
Fix Formatter string

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/generator/GeneratorStrings.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/GeneratorStrings.java
@@ -217,7 +217,7 @@ public class GeneratorStrings {
                         
                         Follow the guide for `/%1$s help item` for more information about creating an item.
                         Follow the guide for `/%1$s help display` for more information about putting a item next to the item lore.
-                        Follow the guide for `/%1Ss help recipe` for more information about putting a recipe next to the item lore.
+                        Follow the guide for `/%1$s help recipe` for more information about putting a recipe next to the item lore.
                         """.formatted(COMMAND_PREFIX);
 
     // stat symbols text


### PR DESCRIPTION
When performing the ``/gen help full`` command, it currently shows ``/GENs help recipe`` as a valid command.
This PR fixes the formatter string and now shows the correct command ``/gen help recipe``.