### PR TITLE
Text Gen Background Color

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/command/GeneratorCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/GeneratorCommands.java
@@ -86,6 +86,7 @@ public class GeneratorCommands extends ApplicationCommand {
     @JDASlashCommand(name = COMMAND_PREFIX, subcommand = "text", description = "Creates an image that looks like a message from Minecraft, primarily used for Hypixel Skyblock")
     public void generateText(GuildSlashEvent event,
                              @AppOption(description = DESC_TEXT) String message,
+                             @Optional @AppOption(description = DESC_ALPHA) Integer alpha,
                              @Optional @AppOption(description = DESC_CENTERED) Boolean centered,
                              @Optional @AppOption(description = DESC_HIDDEN) Boolean hidden) throws IOException {
         if (isIncorrectChannel(event)) {
@@ -93,9 +94,10 @@ public class GeneratorCommands extends ApplicationCommand {
         }
         hidden = (hidden != null && hidden);
         centered = (centered != null && centered);
+        alpha = alpha == null ? 128 : Math.max(0, Math.min(alpha, 255));
         event.deferReply(hidden).complete();
         // building the chat message
-        BufferedImage generatedImage = builder.buildItem(event, "NONE", "NONE", message, "", true, 0, 1, StringColorParser.MAX_FINAL_LINE_LENGTH, false, centered);
+        BufferedImage generatedImage = builder.buildItem(event, "NONE", "NONE", message, "", true, alpha, 1, StringColorParser.MAX_FINAL_LINE_LENGTH, false, centered);
         if (generatedImage != null) {
             event.getHook().sendFiles(FileUpload.fromData(Util.toFile(generatedImage))).setEphemeral(hidden).queue();
         }

--- a/src/main/java/net/hypixel/nerdbot/generator/GeneratorBuilder.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/GeneratorBuilder.java
@@ -221,7 +221,7 @@ public class GeneratorBuilder {
         return new MinecraftImage(
             colorParser.getParsedDescription(),
             MCColor.GRAY,
-            colorParser.getEstimatedImageWidth() * 20,
+            colorParser.getEstimatedImageWidth() * 30,
             alpha,
             padding,
             isNormalItem,

--- a/src/main/java/net/hypixel/nerdbot/generator/MinecraftImage.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/MinecraftImage.java
@@ -101,7 +101,7 @@ public class MinecraftImage {
             );
         }
         else {
-            g2d.setColor(new Color(0, 0, 0, 128));
+            g2d.setColor(new Color(0, 0, 0, this.getAlpha()));
             g2d.fillRect(0, 0, width, height);
         }
 
@@ -143,7 +143,7 @@ public class MinecraftImage {
      * Creates the inner and outer purple borders around the image.
      */
     public void drawBorders() {
-        if (this.getAlpha() == 0) {
+        if (!this.isNormalItem) {
             return;
         }
 

--- a/src/main/java/net/hypixel/nerdbot/generator/MinecraftImage.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/MinecraftImage.java
@@ -91,13 +91,20 @@ public class MinecraftImage {
 
         // Draw Primary Background
         Graphics2D g2d = this.getImage().createGraphics();
-        g2d.setColor(new Color(18, 3, 18, this.getAlpha()));
-        g2d.fillRect(
-            PIXEL_SIZE * 2,
-            PIXEL_SIZE * 2,
-            width - PIXEL_SIZE * 4,
-            height - PIXEL_SIZE * 4
-        );
+        if (isNormalItem) {
+            g2d.setColor(new Color(18, 3, 18, this.getAlpha()));
+            g2d.fillRect(
+                PIXEL_SIZE * 2,
+                PIXEL_SIZE * 2,
+                width - PIXEL_SIZE * 4,
+                height - PIXEL_SIZE * 4
+            );
+        }
+        else {
+            g2d.setColor(new Color(0, 0, 0, 128));
+            g2d.fillRect(0, 0, width, height);
+        }
+
 
         return g2d;
     }


### PR DESCRIPTION
- Adds a black background color to all `/gen text` commands.
    - This can be turned off by setting the alpha to 0
- Fixes underestimation again.