### PR TITLE
Add Rift Damage and Mana Regen as stats

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/util/skyblock/Stat.java
+++ b/src/main/java/net/hypixel/nerdbot/util/skyblock/Stat.java
@@ -59,6 +59,8 @@ public enum Stat {
     RUNECRAFTING_WISDOM("☯", "Runecrafting Wisdom", MCColor.DARK_AQUA),
     SOCIAL_WISDOM("☯", "Social Wisdom", MCColor.DARK_AQUA),
     RIFT_TIME("ф", "Rift Time", MCColor.GREEN),
+    RIFT_DAMAGE("❁", "Rift Damage", MCColor.DARK_PURPLE),
+    MANA_REGEN("⚡", "Mana Regen", MCColor.AQUA),
     RIFT_TRANSFERABLE("", "Rift-Transferable", MCColor.DARK_PURPLE, StatColorParser::noParsing),
     UNDEAD("༕", "This armor piece is undead ༕!", MCColor.DARK_GREEN, StatColorParser::noParsing);
 


### PR DESCRIPTION
Adds Rift Damage and Mana Regen to the list of stats.
Rift Damage uses the normal Damage Icon, so that's fine. The default text for Mana Regen looks close enough, that I didn't add it to the font file. 