### PR TITLE
Pingable Roles

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/bot/config/RoleConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/RoleConfig.java
@@ -3,12 +3,8 @@ package net.hypixel.nerdbot.bot.config;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.emoji.Emoji;
-
-import java.util.Objects;
-import java.util.function.Function;
+import net.hypixel.nerdbot.role.PingableRole;
 
 @Getter
 @Setter
@@ -30,11 +26,8 @@ public class RoleConfig {
      */
     private String limboRoleId = "";
 
-    public boolean isEquals(MessageReaction reaction, Function<RoleConfig, String> function) {
-        if (reaction.getEmoji().getType() != Emoji.Type.CUSTOM) {
-            return false;
-        }
-
-        return Objects.equals(reaction.getEmoji().asCustom().getId(), function.apply(this));
-    }
+    /**
+     * A list of {@link PingableRole}s used for announcements etc.
+     */
+    private PingableRole[] pingableRoles = {};
 }

--- a/src/main/java/net/hypixel/nerdbot/command/InfoCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/InfoCommands.java
@@ -14,6 +14,7 @@ import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.database.Database;
 import net.hypixel.nerdbot.api.database.model.greenlit.GreenlitMessage;
 import net.hypixel.nerdbot.api.database.model.user.DiscordUser;
+import net.hypixel.nerdbot.role.RoleManager;
 import net.hypixel.nerdbot.util.Environment;
 import net.hypixel.nerdbot.util.Time;
 import net.hypixel.nerdbot.util.Util;
@@ -81,11 +82,11 @@ public class InfoCommands extends ApplicationCommand {
 
         int staff = 0;
         for (String roleName : SPECIAL_ROLES) {
-            if (Util.getRole(roleName) == null) {
+            if (RoleManager.getRole(roleName) == null) {
                 log.warn("Role {} not found", roleName);
                 continue;
             }
-            staff += guild.getMembersWithRoles(Util.getRole(roleName)).size();
+            staff += guild.getMembersWithRoles(RoleManager.getRole(roleName)).size();
         }
 
         builder.append("Server name: ").append(guild.getName()).append(" (Server ID: ").append(guild.getId()).append(")\n")
@@ -94,8 +95,8 @@ public class InfoCommands extends ApplicationCommand {
             .append("Channels: ").append(guild.getChannels().size()).append("\n")
             .append("Members: ").append(guild.getMembers().size()).append("/").append(guild.getMaxMembers()).append("\n")
             .append("- Staff: ").append(staff).append("\n")
-            .append("- Grapes: ").append(guild.getMembersWithRoles(Util.getRole("Grape")).size()).append("\n")
-            .append("- Nerds: ").append(guild.getMembersWithRoles(Util.getRole("Nerd")).size());
+            .append("- Grapes: ").append(guild.getMembersWithRoles(RoleManager.getRole("Grape")).size()).append("\n")
+            .append("- Nerds: ").append(guild.getMembersWithRoles(RoleManager.getRole("Nerd")).size());
 
         event.reply(builder.toString()).setEphemeral(true).queue();
     }

--- a/src/main/java/net/hypixel/nerdbot/command/MyCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/MyCommands.java
@@ -25,6 +25,7 @@ import net.hypixel.nerdbot.api.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.api.database.model.user.stats.LastActivity;
 import net.hypixel.nerdbot.api.database.model.user.stats.MojangProfile;
 import net.hypixel.nerdbot.channel.ChannelManager;
+import net.hypixel.nerdbot.role.RoleManager;
 import net.hypixel.nerdbot.util.Util;
 import net.hypixel.nerdbot.util.discord.SuggestionCache;
 import net.hypixel.nerdbot.util.exception.HttpException;
@@ -270,7 +271,7 @@ public class MyCommands extends ApplicationCommand {
         }
 
         if (newMemberRole.isPresent()) {
-            if (!Util.hasHigherOrEqualRole(member, newMemberRole.get())) { // Ignore Existing Members
+            if (!RoleManager.hasHigherOrEqualRole(member, newMemberRole.get())) { // Ignore Existing Members
                 try {
                     guild.addRoleToMember(member, newMemberRole.get()).complete();
                     String limboRoleId = NerdBotApp.getBot().getConfig().getRoleConfig().getLimboRoleId();

--- a/src/main/java/net/hypixel/nerdbot/listener/MetricsListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/MetricsListener.java
@@ -14,6 +14,7 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.SubscribeEvent;
 import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.metrics.PrometheusMetrics;
+import net.hypixel.nerdbot.role.RoleManager;
 import net.hypixel.nerdbot.util.Util;
 
 @Log4j2
@@ -27,7 +28,7 @@ public class MetricsListener {
     @SubscribeEvent
     public void onMessageSent(MessageReceivedEvent event) {
         if (event.getMember() != null) {
-            PrometheusMetrics.TOTAL_MESSAGES_AMOUNT.labels(event.getAuthor().getName(), Util.getHighestRole(event.getMember()).getName(), event.getChannel().getName()).inc();
+            PrometheusMetrics.TOTAL_MESSAGES_AMOUNT.labels(event.getAuthor().getName(), RoleManager.getHighestRole(event.getMember()).getName(), event.getChannel().getName()).inc();
         }
 
         if (event.getChannel() instanceof ThreadChannel) {

--- a/src/main/java/net/hypixel/nerdbot/listener/ModMailListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ModMailListener.java
@@ -21,6 +21,7 @@ import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.database.Database;
 import net.hypixel.nerdbot.api.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.bot.config.ModMailConfig;
+import net.hypixel.nerdbot.role.RoleManager;
 import net.hypixel.nerdbot.util.Util;
 
 import java.util.ArrayList;
@@ -87,7 +88,7 @@ public class ModMailListener {
             String modMailRoleId = NerdBotApp.getBot().getConfig().getModMailConfig().getRoleId();
 
             if (modMailRoleId != null) {
-                modMailThread.getGuild().getMembersWithRoles(Util.getRoleById(modMailRoleId)).forEach(member -> modMailThread.addThreadMember(member).complete());
+                modMailThread.getGuild().getMembersWithRoles(RoleManager.getRoleById(modMailRoleId)).forEach(member -> modMailThread.addThreadMember(member).complete());
             }
         }
 

--- a/src/main/java/net/hypixel/nerdbot/role/PingableRole.java
+++ b/src/main/java/net/hypixel/nerdbot/role/PingableRole.java
@@ -1,0 +1,14 @@
+package net.hypixel.nerdbot.role;
+
+public record PingableRole(String name, String roleId) {
+
+    public PingableRole {
+        if (name == null) {
+            throw new IllegalArgumentException("Name cannot be null");
+        }
+
+        if (roleId == null) {
+            throw new IllegalArgumentException("Role ID cannot be null");
+        }
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/role/RoleManager.java
+++ b/src/main/java/net/hypixel/nerdbot/role/RoleManager.java
@@ -1,0 +1,76 @@
+package net.hypixel.nerdbot.role;
+
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import net.hypixel.nerdbot.NerdBotApp;
+import net.hypixel.nerdbot.util.Util;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RoleManager {
+
+    private RoleManager() {
+    }
+
+    @Nullable
+    public static PingableRole getPingableRoleByName(String name) {
+        return Arrays.stream(NerdBotApp.getBot().getConfig().getRoleConfig().getPingableRoles())
+            .filter(pingableRole -> pingableRole.name().equalsIgnoreCase(name))
+            .findFirst()
+            .orElse(null);
+    }
+
+    @Nullable
+    public static PingableRole getPingableRoleById(String id) {
+        return Arrays.stream(NerdBotApp.getBot().getConfig().getRoleConfig().getPingableRoles())
+            .filter(pingableRole -> pingableRole.roleId().equalsIgnoreCase(id))
+            .findFirst()
+            .orElse(null);
+    }
+
+    public static String formatPingableRoleAsMention(@NotNull PingableRole pingableRole) {
+        return "<@&" + pingableRole.roleId() + ">";
+    }
+
+    public static boolean hasRole(Member member, String name) {
+        return member.getRoles().stream().anyMatch(role -> role.getName().equalsIgnoreCase(name));
+    }
+
+    public static boolean hasAnyRole(Member member, String... names) {
+        List<Role> roles = member.getRoles();
+        List<String> nameList = Arrays.asList(names);
+
+        if (names.length == 0) {
+            return false;
+        } else {
+            return roles.stream().anyMatch(role -> nameList.stream().anyMatch(name -> role.getName().equalsIgnoreCase(name)));
+        }
+    }
+
+    public static boolean hasHigherOrEqualRole(Member member, Role role) {
+        return member.getRoles().stream().anyMatch(memberRole -> memberRole.getPosition() >= role.getPosition());
+    }
+
+    @Nullable
+    public static Role getRole(String name) {
+        return Util.getMainGuild().getRoles().stream()
+            .filter(role -> role.getName().equals(name))
+            .findFirst()
+            .orElse(null);
+    }
+
+    public static Role getHighestRole(Member member) {
+        return member.getRoles().get(0);
+    }
+
+    @Nullable
+    public static Role getRoleById(String id) {
+        return Util.getMainGuild().getRoles().stream()
+            .filter(role -> role.getId().equals(id))
+            .findFirst()
+            .orElse(null);
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/util/Util.java
+++ b/src/main/java/net/hypixel/nerdbot/util/Util.java
@@ -5,12 +5,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.prometheus.client.Summary;
 import lombok.extern.log4j.Log4j2;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageReaction;
-import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.internal.utils.tuple.Pair;
 import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.database.Database;
@@ -25,27 +20,17 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.imageio.ImageIO;
-import java.awt.*;
+import java.awt.Font;
+import java.awt.FontFormatException;
 import java.awt.image.BufferedImage;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -94,49 +79,6 @@ public class Util {
     @NotNull
     public static Guild getMainGuild() {
         return Objects.requireNonNull(NerdBotApp.getBot().getJDA().getGuildById(NerdBotApp.getBot().getConfig().getGuildId()));
-    }
-
-    public static boolean hasRole(Member member, String name) {
-        List<Role> roles = member.getRoles();
-        return roles.stream().anyMatch(role -> role.getName().equalsIgnoreCase(name));
-    }
-
-    public static boolean hasAnyRole(Member member, String... names) {
-        List<Role> roles = member.getRoles();
-        List<String> nameList = Arrays.asList(names);
-        if (names.length == 0) {
-            return false;
-        } else {
-            return roles.stream().anyMatch(role -> nameList.stream().anyMatch(name -> role.getName().equalsIgnoreCase(name)));
-        }
-    }
-
-    public static boolean hasHigherOrEqualRole(Member member, Role role) {
-        return member.getRoles()
-            .stream()
-            .anyMatch(memberRole -> memberRole.getPosition() >= role.getPosition());
-    }
-
-    @Nullable
-    public static Role getRole(String name) {
-        Guild guild = Util.getMainGuild();
-        if (guild == null) {
-            return null;
-        }
-        return guild.getRoles().stream().filter(role -> role.getName().equals(name)).findFirst().orElse(null);
-    }
-
-    public static Role getHighestRole(Member member) {
-        return member.getRoles().get(0);
-    }
-
-    @Nullable
-    public static Role getRoleById(String id) {
-        Guild guild = Util.getMainGuild();
-        if (guild == null) {
-            return null;
-        }
-        return guild.getRoles().stream().filter(role -> role.getId().equals(id)).findFirst().orElse(null);
     }
 
     public static File createTempFile(String fileName, String content) throws IOException {

--- a/src/main/resources/example-config.json
+++ b/src/main/resources/example-config.json
@@ -31,7 +31,8 @@
   "roleConfig": {
     "botManagerRoleId": "",
     "newMemberRoleId": "",
-    "limboRoleId": ""
+    "limboRoleId": "",
+    "pingableRoles": []
   },
   "metricsConfig": {
     "enabled": false,


### PR DESCRIPTION
Adds two new commands and configuration functionality for what we call pingable roles. These are roles that'll primarily be used for things like announcements of new Fire Sales, updates, etc etc.

Commands are:
- /roles
- /role <name>

The /role <name> command can only assign pingable roles specified in the new configuration section `pingableRoles` and /roles only lists these too

![image](https://github.com/TheMGRF/NerdBot/assets/22944369/affe6e8b-1247-4f28-bd95-0b65c4280316)

