### PR TITLE
Component Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,16 @@
             <artifactId>reflections</artifactId>
             <version>0.9.12</version>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.5.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.0.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
@@ -235,10 +235,11 @@ public class ActivityListener {
                         && reactionHistory.reactionName().equals(event.getReaction().getEmoji().asCustom().getName())
                 );
 
+                ReactionHistory reactionHistory = new ReactionHistory(threadChannel.getId(), event.getReaction().getEmoji().asCustom().getName(), startMessage.getTimeCreated().toEpochSecond());
+
                 // New Suggestion Voting
                 if (Util.safeArrayStream(channelConfig.getSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                     discordUser.getLastActivity().setSuggestionVoteDate(time);
-                    ReactionHistory reactionHistory = new ReactionHistory(threadChannel.getId(), event.getReaction().getEmoji().asCustom().getName(), startMessage.getTimeCreated().toEpochSecond());
                     discordUser.getLastActivity().getSuggestionReactionHistory().add(reactionHistory);
                     log.info("Updating suggestion voting activity date for " + member.getEffectiveName() + " to " + time);
                 }
@@ -246,7 +247,6 @@ public class ActivityListener {
                 // New Alpha Suggestion Voting
                 if (Util.safeArrayStream(channelConfig.getAlphaSuggestionForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                     discordUser.getLastActivity().setAlphaSuggestionVoteDate(time);
-                    ReactionHistory reactionHistory = new ReactionHistory(threadChannel.getId(), event.getReaction().getEmoji().asCustom().getName(), startMessage.getTimeCreated().toEpochSecond());
                     discordUser.getLastActivity().getSuggestionReactionHistory().add(reactionHistory);
                     log.info("Updating alpha suggestion voting activity date for " + member.getEffectiveName() + " to " + time);
                 }

--- a/src/main/java/net/hypixel/nerdbot/util/discord/ComponentDatabaseConnection.java
+++ b/src/main/java/net/hypixel/nerdbot/util/discord/ComponentDatabaseConnection.java
@@ -1,0 +1,35 @@
+package net.hypixel.nerdbot.util.discord;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.postgresql.ds.PGSimpleDataSource;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class ComponentDatabaseConnection {
+
+    private final HikariDataSource source;
+
+    public ComponentDatabaseConnection() throws SQLException {
+        final PGSimpleDataSource pgSource = new PGSimpleDataSource();
+        pgSource.setServerNames(new String[]{System.getProperty("db.postgres.host", "localhost")});
+        pgSource.setPortNumbers(new int[]{Integer.parseInt(System.getProperty("db.postgres.port", "5432"))});
+        pgSource.setUser(System.getProperty("db.postgres.user", "postgres"));
+        pgSource.setPassword(System.getProperty("db.postgres.password", "password"));
+        pgSource.setDatabaseName(System.getProperty("db.postgres.database", "postgres"));
+
+        source = new HikariDataSource();
+        source.setDataSource(pgSource);
+
+        source.getConnection().close();
+    }
+
+    public Connection getConnection() {
+        try {
+            return source.getConnection();
+        } catch (SQLException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/util/discord/SuggestionCache.java
+++ b/src/main/java/net/hypixel/nerdbot/util/discord/SuggestionCache.java
@@ -100,7 +100,7 @@ public class SuggestionCache extends TimerTask {
 
     public void addSuggestion(ThreadChannel thread) {
         this.cache.put(thread.getId(), new Suggestion(thread));
-        // log.info("Added new suggestion '" + thread.getName() + "' (ID: " + thread.getId() + ") to the suggestion cache.");
+        log.debug("Added new suggestion '" + thread.getName() + "' (ID: " + thread.getId() + ") to the suggestion cache.");
     }
 
     public Suggestion getSuggestion(String id) {
@@ -119,7 +119,7 @@ public class SuggestionCache extends TimerTask {
 
     public void removeSuggestion(ThreadChannel thread) {
         this.cache.remove(thread.getId());
-        // log.info("Removed suggestion '" + thread.getName() + "' (ID: " + thread.getId() + ") from the suggestion cache.");
+        log.debug("Removed suggestion '" + thread.getName() + "' (ID: " + thread.getId() + ") from the suggestion cache.");
     }
 
     public static class Suggestion {


### PR DESCRIPTION
Adds support for components using a SQL database. (yuck)

If you do not provide any details the bot will still run, only components will not be supported (which is not recommended)

The following properties are used:
- `db.postgres.host` (default `localhost`)
- `db.postgres.port` (default `5432`)
- `db.postgres.user` (default `postgres`)
- `db.postgres.password` (default `password`)
- `db.postgres.database` (default `postgres`)

I also changed the `mongodb.uri` property to be in line with this change, so it is now `db.mongodb.uri`