### PR TITLE
Greenlit Review Changes

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
@@ -153,6 +153,16 @@ public class AdminCommands extends ApplicationCommand {
         event.getHook().editOriginal("Deleted " + invites.size() + " invites.").queue();
     }
 
+    @JDASlashCommand(name = "lock", description = "Locks the thread that the command is executed in", defaultLocked = true)
+    public void lockThread(GuildSlashEvent event) {
+        if (!(event.getChannel() instanceof ThreadChannel threadChannel)) {
+            event.reply("This command can only be used inside a thread!").setEphemeral(true).queue();
+            return;
+        }
+
+        threadChannel.getManager().setLocked(!threadChannel.isLocked()).complete();
+        event.reply("This thread is now " + (threadChannel.isLocked() ? "locked" : "unlocked") + "!").queue();
+    }
 
     @JDASlashCommand(name = "archive", subcommand = "channel", description = "Archives a specific channel.", defaultLocked = true)
     public void archive(GuildSlashEvent event, @AppOption TextChannel channel, @AppOption @Optional Boolean nerd, @AppOption @Optional Boolean alpha) {

--- a/src/main/java/net/hypixel/nerdbot/command/SuggestionCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/SuggestionCommands.java
@@ -199,11 +199,8 @@ public class SuggestionCommands extends ApplicationCommand {
         });
 
         lastReviewRequestCache.put(event.getChannel().getId(), System.currentTimeMillis());
-
-        // Respond to User
-        event.getHook()
-            .editOriginal("This suggestion has been sent for review.")
-            .queue();
+        event.getHook().editOriginal("This suggestion has been sent for review.").queue();
+        event.getChannel().sendMessage("This suggestion has been sent for manual review.").queue();
     }
 
     @JDASlashCommand(name = "suggestions", subcommand = "by-id", description = "View user suggestions.")

--- a/src/main/java/net/hypixel/nerdbot/command/SuggestionCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/SuggestionCommands.java
@@ -44,9 +44,7 @@ public class SuggestionCommands extends ApplicationCommand {
         .build();
 
     @JDASlashCommand(name = "request-review", description = "Request a greenlit review of your suggestion.")
-    public void requestSuggestionReview(
-        GuildSlashEvent event
-    ) {
+    public void requestSuggestionReview(GuildSlashEvent event) {
         event.deferReply(true).complete();
 
         if (event.getChannel().getType() != ChannelType.GUILD_PUBLIC_THREAD) {
@@ -63,7 +61,7 @@ public class SuggestionCommands extends ApplicationCommand {
             return;
         }
 
-        if (lastReviewRequestCache.getIfPresent(event.getMember().getId()) != null) {
+        if (lastReviewRequestCache.getIfPresent(event.getChannel().getId()) != null) {
             event.getHook().editOriginal("You cannot request another review yet!").complete();
             return;
         }
@@ -200,7 +198,7 @@ public class SuggestionCommands extends ApplicationCommand {
             throw new RuntimeException("Requested review channel not found!");
         });
 
-        lastReviewRequestCache.put(event.getMember().getId(), System.currentTimeMillis());
+        lastReviewRequestCache.put(event.getChannel().getId(), System.currentTimeMillis());
 
         // Respond to User
         event.getHook()

--- a/src/main/java/net/hypixel/nerdbot/command/SuggestionCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/SuggestionCommands.java
@@ -183,7 +183,7 @@ public class SuggestionCommands extends ApplicationCommand {
                             "suggestion-review-deny-%s",
                             suggestion.getThread().getId()
                         ),
-                        "Deny",
+                        "Deny w/o Locking",
                         java.util.Optional.ofNullable(suggestionConfig.getDisagreeEmojiId())
                             .map(StringUtils::stripToNull)
                             .map(emojiId -> Emoji.fromCustom(

--- a/src/main/java/net/hypixel/nerdbot/command/SuggestionCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/SuggestionCommands.java
@@ -23,6 +23,7 @@ import net.hypixel.nerdbot.bot.config.SuggestionConfig;
 import net.hypixel.nerdbot.cache.SuggestionCache;
 import net.hypixel.nerdbot.channel.ChannelManager;
 import net.hypixel.nerdbot.util.Util;
+import net.hypixel.nerdbot.util.discord.DiscordTimestamp;
 import org.apache.commons.lang.StringUtils;
 
 import java.awt.*;
@@ -153,8 +154,8 @@ public class SuggestionCommands extends ApplicationCommand {
                             "Created",
                             suggestion.getFirstMessage()
                                 .map(Message::getTimeCreated)
-                                .map(date -> String.format("<t:%s:R>", date.toInstant().toEpochMilli() / 1000))
-                                .orElse("?"),
+                                .map(date -> new DiscordTimestamp(date.toInstant().toEpochMilli()).toRelativeTimestamp())
+                                .orElse("???"),
                             false
                         )
                         .build()
@@ -191,6 +192,15 @@ public class SuggestionCommands extends ApplicationCommand {
                                 false
                             ))
                             .orElse(null)
+                    ),
+                    Button.of(
+                        ButtonStyle.SECONDARY,
+                        String.format(
+                            "suggestion-review-lock-%s",
+                            suggestion.getThread().getId()
+                        ),
+                        "Lock",
+                        Emoji.fromUnicode("🔒")
                     )
                 )
                 .queue();

--- a/src/main/java/net/hypixel/nerdbot/listener/SuggestionListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/SuggestionListener.java
@@ -108,6 +108,7 @@ public class SuggestionListener {
                             event.getHook().sendMessage("Thread locked!").queue();
                             thread.sendMessage("This thread has been locked by a moderator. If you believe this is a mistake, please contact us through mod mail.").queue();
                         }, throwable -> event.getHook().sendMessage("Unable to lock thread!").queue());
+                default -> event.getHook().sendMessage("Invalid action!").queue();
             }
 
             event.getHook().editOriginalComponents(ActionRow.of(

--- a/src/main/java/net/hypixel/nerdbot/listener/SuggestionListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/SuggestionListener.java
@@ -106,7 +106,7 @@ public class SuggestionListener {
                 case "lock" ->
                     thread.getManager().setLocked(true).queue(unused -> {
                             event.getHook().sendMessage("Thread locked!").queue();
-                            thread.sendMessage("This thread has been locked by a moderator. If you believe this is a mistake, please contact us through mod mail.").queue();
+                            thread.sendMessage("We have reviewed your recent request and have decided to lock this suggestion. If you believe this to be a mistake or would like more information, please contact us through mod mail.").queue();
                         }, throwable -> event.getHook().sendMessage("Unable to lock thread!").queue());
                 default -> event.getHook().sendMessage("Invalid action!").queue();
             }


### PR DESCRIPTION
- Adds a new button to the review process titled "Lock" which will lock the suggestion and send a message with a generic reason
- Sends a message in the suggestion thread whenever a review has been requested
- Changes the cooldown to be per-thread rather than per-user
- Adds a new `/lock` command to toggle the lock state of a ThreadChannel