### PR TITLE
Reminder QOL 2 Finale.

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/command/ReminderCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/ReminderCommands.java
@@ -113,7 +113,12 @@ public class ReminderCommands extends ApplicationCommand {
                 .setTimestamp(Instant.now())
                 .setFooter(reminder.getUuid().toString())
                 .setColor(Color.GREEN);
-            channel.sendMessage("Reminder set for: " + new DiscordTimestamp(date.getTime()).toLongDateTime())
+            StringBuilder messageContents = new StringBuilder();
+            messageContents.append("Reminder set for: ").append(new DiscordTimestamp(date.getTime()).toLongDateTime());
+            if (sendPublicly){
+                messageContents.append("\n\nIn channel: ").append(event.getChannel().getAsMention());
+            }
+            channel.sendMessage(messageContents.toString())
                 .addEmbeds(embedBuilder.build())
                 .setSuppressedNotifications(true)
                 .queue();


### PR DESCRIPTION
This change is specifically for if a reminder is public to addon a message linking to where it will be sent too later.

Discussion seemed to lean towards the 2 newlines + "In channel:" however this is still up for debate as I only got 3 responses to this inquiry.