### PR TITLE
Enforce suggestion age

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/bot/config/SuggestionConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/SuggestionConfig.java
@@ -146,6 +146,17 @@ public class SuggestionConfig {
      */
     private int autoLockThreshold = -1;
 
+    // Review Settings
+
+    /**
+     * The minimum required age of a suggestion to be eligible for a review
+     * <br><br>
+     * Default is 7 days
+     * <br>
+     * Set to 0 to disable
+     */
+    private long minimumSuggestionRequestAge = 1_000L * 60L * 60L * 24L * 7L; // 7 days
+
     // Helper Methods
 
     public boolean isReactionEquals(MessageReaction reaction, Function<SuggestionConfig, String> function) {

--- a/src/main/java/net/hypixel/nerdbot/command/SuggestionCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/SuggestionCommands.java
@@ -99,6 +99,12 @@ public class SuggestionCommands extends ApplicationCommand {
             return;
         }
 
+        // Make sure the suggestion is old enough
+        if (System.currentTimeMillis() - suggestion.getFirstMessage().get().getTimeCreated().toInstant().toEpochMilli() < suggestionConfig.getMinimumSuggestionRequestAge()) {
+            event.getHook().editOriginal("This suggestion is not eligible for a review request yet!").complete();
+            return;
+        }
+
         // Handle Greenlit Ratio
         if (suggestionConfig.isEnforcingGreenlitRatioForRequestReview() && suggestion.getRatio() <= suggestionConfig.getGreenlitRatio()) {
             event.getHook().editOriginal(String.format("You need at least %s%% agrees to request a greenlit review!", suggestionConfig.getGreenlitRatio())).complete();

--- a/src/main/resources/example-config.json
+++ b/src/main/resources/example-config.json
@@ -25,7 +25,8 @@
     "requestReviewThreshold": 15,
     "enforcingGreenlitRatioForRequestReview": false,
     "autoArchiveThreshold": 168,
-    "autoLockThreshold": -1
+    "autoLockThreshold": -1,
+    "minimumSuggestionRequestAge": 604800000
   },
   "channelConfig": {
     "logChannelId": "",


### PR DESCRIPTION
Enforces a minimum required age of a suggestion before it can be sent for a review request. The default is 7 days.