### PR TITLE
Manual Curation Feedback Fixes.

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/AdminCommands.java
@@ -94,7 +94,7 @@ public class AdminCommands extends ApplicationCommand {
             if (output.isEmpty()) {
                 TranslationManager.edit(event.getHook(), discordUser, "curator.no_greenlit_messages");
             } else {
-                TranslationManager.edit(event.getHook(), discordUser, "curator.greenlit_messages", output.size());
+                TranslationManager.edit(event.getHook(), discordUser, "curator.greenlit_messages", output.size(), forumChannelCurator.getEndTime() - forumChannelCurator.getStartTime());
             }
         });
     }

--- a/src/main/resources/languages/english.json
+++ b/src/main/resources/languages/english.json
@@ -30,7 +30,7 @@
   },
   "curator": {
     "no_greenlit_messages": "No suggestions were greenlit",
-    "greenlit_messages": "Greenlit %d suggestions in %d!",
+    "greenlit_messages": "Greenlit %d suggestions in %dms!",
     "already_greenlit": "This suggestion has already been greenlit!"
   },
   "commands": {


### PR DESCRIPTION
When manually curating messages, the user was never given feedback when any suggestions were greenlit. 

Fixed translation to include the words "ms" after the time, and also include the arguments for the MS timings as well.