### PR TITLE
Greenlit support for /lock

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/api/curator/Curator.java
+++ b/src/main/java/net/hypixel/nerdbot/api/curator/Curator.java
@@ -20,7 +20,7 @@ public abstract class Curator<T> {
 
     public abstract List<GreenlitMessage> curate(T t);
 
-    public double getRatio(double positiveReactions, double negativeReactions) {
+    public static double getRatio(double positiveReactions, double negativeReactions) {
         if (positiveReactions == 0 && negativeReactions == 0) {
             return 0;
         }

--- a/src/main/java/net/hypixel/nerdbot/cache/suggestion/Suggestion.java
+++ b/src/main/java/net/hypixel/nerdbot/cache/suggestion/Suggestion.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageHistory;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
@@ -109,14 +108,7 @@ public class Suggestion {
     }
 
     public Optional<Message> getFirstMessage() {
-        ThreadChannel threadChannel = NerdBotApp.getBot().getJDA().getThreadChannelById(this.getThreadId());
-
-        if (threadChannel != null) {
-            MessageHistory history = threadChannel.getHistoryFromBeginning(1).complete();
-            return history.isEmpty() ? Optional.empty() : Optional.of(history.getRetrievedHistory().get(0));
-        }
-
-        return Optional.empty();
+        return Util.getFirstMessage(this.getThreadId());
     }
 
     public static int getReactionCount(Message message, String emojiId) {

--- a/src/main/java/net/hypixel/nerdbot/command/ProfileCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/ProfileCommands.java
@@ -226,7 +226,7 @@ public class ProfileCommands extends ApplicationCommand {
         @AppOption @Optional Integer page,
         @AppOption(description = "Tags to filter for (comma separated).") @Optional String tags,
         @AppOption(description = "Words to filter title for.") @Optional String title,
-        @AppOption(description = "Show suggestions from a specific category.", autocomplete = "suggestion-types") @Optional Suggestion.ChannelType channelType
+        @AppOption(description = "Show suggestions from a specific category.", autocomplete = "suggestion-types") @Optional Suggestion.ChannelType type
     ) {
         event.deferReply(true).complete();
 
@@ -235,9 +235,9 @@ public class ProfileCommands extends ApplicationCommand {
 
         page = (page == null) ? 1 : page;
         final int pageNum = Math.max(page, 1);
-        channelType = (channelType == null ? Suggestion.ChannelType.NORMAL : channelType);
+        type = (type == null ? Suggestion.ChannelType.NORMAL : type);
 
-        List<Suggestion> suggestions = SuggestionCommands.getSuggestions(event.getMember().getIdLong(), tags, title, channelType);
+        List<Suggestion> suggestions = SuggestionCommands.getSuggestions(event.getMember().getIdLong(), tags, title, type);
 
         if (suggestions.isEmpty()) {
             TranslationManager.edit(event.getHook(), discordUser, "cache.suggestions.filtered_none_found");
@@ -245,7 +245,7 @@ public class ProfileCommands extends ApplicationCommand {
         }
 
         event.getHook().editOriginalEmbeds(
-            SuggestionCommands.buildSuggestionsEmbed(suggestions, tags, title, channelType, pageNum, false, true)
+            SuggestionCommands.buildSuggestionsEmbed(suggestions, tags, title, type, pageNum, false, true)
                 .setAuthor(event.getMember().getEffectiveName())
                 .setThumbnail(event.getMember().getEffectiveAvatarUrl())
                 .build()

--- a/src/main/java/net/hypixel/nerdbot/command/SuggestionCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/SuggestionCommands.java
@@ -365,15 +365,15 @@ public class SuggestionCommands extends ApplicationCommand {
         @AppOption @Optional Integer page,
         @AppOption(description = "Tags to filter for (comma separated).") @Optional String tags,
         @AppOption(description = "Words to filter title for.") @Optional String title,
-        @AppOption(description = "Show suggestions from a specific category.", autocomplete = "suggestion-types") @Optional Suggestion.ChannelType channelType
+        @AppOption(description = "Show suggestions from a specific category.", autocomplete = "suggestion-types") @Optional Suggestion.ChannelType type
     ) {
         event.deferReply(true).complete();
         page = (page == null) ? 1 : page;
         final int pageNum = Math.max(page, 1);
-        channelType = (channelType == null ? Suggestion.ChannelType.NORMAL : channelType);
+        type = (type == null ? Suggestion.ChannelType.NORMAL : type);
         boolean showRatio = member.getIdLong() == event.getMember().getIdLong() || event.getMember().hasPermission(Permission.MANAGE_PERMISSIONS);
 
-        List<Suggestion> suggestions = getSuggestions(member.getIdLong(), tags, title, channelType);
+        List<Suggestion> suggestions = getSuggestions(member.getIdLong(), tags, title, type);
 
         if (suggestions.isEmpty()) {
             TranslationManager.edit(event.getHook(), "cache.suggestions.filtered_none_found");
@@ -381,7 +381,7 @@ public class SuggestionCommands extends ApplicationCommand {
         }
 
         event.getHook().editOriginalEmbeds(
-            buildSuggestionsEmbed(suggestions, tags, title, channelType, pageNum, false, showRatio)
+            buildSuggestionsEmbed(suggestions, tags, title, type, pageNum, false, showRatio)
                 .setAuthor(member.getEffectiveName())
                 .setThumbnail(member.getEffectiveAvatarUrl())
                 .build()
@@ -398,21 +398,21 @@ public class SuggestionCommands extends ApplicationCommand {
         @AppOption @Optional Integer page,
         @AppOption(description = "Tags to filter for (comma separated).") @Optional String tags,
         @AppOption(description = "Words to filter title for.") @Optional String title,
-        @AppOption(description = "Show suggestions from a specific category.", autocomplete = "suggestion-types") @Optional Suggestion.ChannelType channelType
+        @AppOption(description = "Show suggestions from a specific category.", autocomplete = "suggestion-types") @Optional Suggestion.ChannelType type
     ) {
         event.deferReply(true).complete();
         page = (page == null) ? 1 : page;
         final int pageNum = Math.max(page, 1);
-        channelType = (channelType == null ? Suggestion.ChannelType.NORMAL : channelType);
+        type = (type == null ? Suggestion.ChannelType.NORMAL : type);
 
-        List<Suggestion> suggestions = getSuggestions(null, tags, title, channelType);
+        List<Suggestion> suggestions = getSuggestions(null, tags, title, type);
 
         if (suggestions.isEmpty()) {
             TranslationManager.edit(event.getHook(), "cache.suggestions.filtered_none_found");
             return;
         }
 
-        event.getHook().editOriginalEmbeds(buildSuggestionsEmbed(suggestions, tags, title, channelType, pageNum, true, true).build()).queue();
+        event.getHook().editOriginalEmbeds(buildSuggestionsEmbed(suggestions, tags, title, type, pageNum, true, true).build()).queue();
     }
 
     @AutocompletionHandler(name = "suggestion-types")

--- a/src/main/java/net/hypixel/nerdbot/curator/ForumChannelCurator.java
+++ b/src/main/java/net/hypixel/nerdbot/curator/ForumChannelCurator.java
@@ -161,7 +161,7 @@ public class ForumChannelCurator extends Curator<ForumChannel> {
                     ThreadChannelManager threadManager = thread.getManager();
 
                     // Upsert into database if already greenlit
-                    if (Util.hasTagByName(thread, suggestionConfig.getGreenlitTag()) || Util.hasTagByName(thread, suggestionConfig.getReviewedTag())) {
+                    if (Util.hasTagByName(thread, suggestionConfig.getGreenlitTag())) {
                         log.info("Thread '" + thread.getName() + "' (ID: " + thread.getId() + ") is already greenlit/reviewed!");
                         GreenlitMessage greenlitMessage = createGreenlitMessage(message, thread, agree, neutral, disagree);
                         database.getRepositoryManager().getRepository(GreenlitMessageRepository.class).cacheObject(greenlitMessage);

--- a/src/main/java/net/hypixel/nerdbot/util/Util.java
+++ b/src/main/java/net/hypixel/nerdbot/util/Util.java
@@ -6,6 +6,7 @@ import lombok.extern.log4j.Log4j2;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageHistory;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
@@ -173,6 +174,19 @@ public class Util {
         return threadChannel.getAppliedTags()
             .stream()
             .anyMatch(forumTag -> (ignoreCase ? forumTag.getName().equalsIgnoreCase(name) : forumTag.getName().equals(name)));
+    }
+
+    public static Optional<Message> getFirstMessage(String threadId) {
+        return getFirstMessage(NerdBotApp.getBot().getJDA().getThreadChannelById(threadId));
+    }
+
+    public static Optional<Message> getFirstMessage(ThreadChannel threadChannel) {
+        if (threadChannel != null) {
+            MessageHistory history = threadChannel.getHistoryFromBeginning(1).complete();
+            return history.isEmpty() ? Optional.empty() : Optional.of(history.getRetrievedHistory().get(0));
+        }
+
+        return Optional.empty();
     }
 
     public static String formatSize(long size) {


### PR DESCRIPTION
- Running /lock will run the greenlit process
- The greenlit curator will ignore the reviewed tag

This will allow suggestions that reach greenlit threshold but get locked to become greenlit