### PR TITLE
Add Suggestion#canSee

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/cache/suggestion/Suggestion.java
+++ b/src/main/java/net/hypixel/nerdbot/cache/suggestion/Suggestion.java
@@ -3,6 +3,8 @@ package net.hypixel.nerdbot.cache.suggestion;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
@@ -136,6 +138,11 @@ public class Suggestion {
 
     void setExpired() {
         this.expired = true;
+    }
+
+    public boolean canSee(Member member) {
+        ThreadChannel threadChannel = NerdBotApp.getBot().getJDA().getThreadChannelById(this.getThreadId());
+        return threadChannel != null && member.hasPermission(threadChannel, Permission.VIEW_CHANNEL);
     }
 
     @Getter

--- a/src/main/java/net/hypixel/nerdbot/command/ProfileCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/ProfileCommands.java
@@ -250,7 +250,7 @@ public class ProfileCommands extends ApplicationCommand {
         }
 
         event.getHook().editOriginalEmbeds(
-            SuggestionCommands.buildSuggestionsEmbed(suggestions, tags, title, type, pageNum, false, true)
+            SuggestionCommands.buildSuggestionsEmbed(event.getMember(), suggestions, tags, title, type, pageNum, false, true)
                 .setAuthor(event.getMember().getEffectiveName())
                 .setThumbnail(event.getMember().getEffectiveAvatarUrl())
                 .build()


### PR DESCRIPTION
Adds a permission check to suggestion viewing and filtering so Members or New Members cannot see other rank-specific suggestions, etc.