### PR TITLE
Use Marmalade utilities - EmbedFactory, Pair, TimeUtils

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/AdminCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/AdminCommands.java
@@ -10,6 +10,7 @@ import net.aerh.slashcommands.api.annotations.SlashComponentHandler;
 import net.aerh.slashcommands.api.annotations.SlashOption;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.hypixel.nerdbot.marmalade.discord.EmbedFactory;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Invite;
@@ -1148,9 +1149,7 @@ public class AdminCommands {
         boolean onlyNew = newMembersOnly != null && newMembersOnly;
         if (onlyNew) {
             NominationSweepReport report = NominationService.getInstance().runNewMemberNominationSweep();
-            EmbedBuilder eb = new EmbedBuilder()
-                .setTitle("Nomination Sweep Complete (New Member)")
-                .setColor(Color.GREEN)
+            EmbedBuilder eb = EmbedFactory.success("Nomination Sweep Complete (New Member)", null)
                 .addField("Scanned", String.valueOf(report.scanned()), true)
                 .addField("Eligible", String.valueOf(report.eligible()), true)
                 .addField("Nominated", String.valueOf(report.nominated()), true)
@@ -1162,9 +1161,7 @@ public class AdminCommands {
             event.replyEmbeds(eb.build()).queue();
         } else {
             NominationSweepReport report = NominationService.getInstance().runMemberNominationSweep();
-            EmbedBuilder eb = new EmbedBuilder()
-                .setTitle("Nomination Sweep Complete (Member)")
-                .setColor(Color.GREEN)
+            EmbedBuilder eb = EmbedFactory.success("Nomination Sweep Complete (Member)", null)
                 .addField("Scanned", String.valueOf(report.scanned()), true)
                 .addField("Eligible", String.valueOf(report.eligible()), true)
                 .addField("Nominated", String.valueOf(report.nominated()), true)

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/InfoCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/InfoCommands.java
@@ -24,8 +24,8 @@ import net.hypixel.nerdbot.discord.util.StringUtils;
 import net.hypixel.nerdbot.discord.util.Utils;
 import net.hypixel.nerdbot.discord.util.pagination.PaginatedResponse;
 import net.hypixel.nerdbot.discord.util.pagination.PaginationManager;
+import net.hypixel.nerdbot.marmalade.discord.EmbedFactory;
 
-import java.awt.Color;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -118,9 +118,7 @@ public class InfoCommands {
     }
 
     private EmbedBuilder buildGreenlitEmbed(List<GreenlitMessage> greenlitMessages) {
-        EmbedBuilder embedBuilder = new EmbedBuilder();
-        embedBuilder.setColor(Color.GREEN)
-            .setTitle("Greenlit Suggestions");
+        EmbedBuilder embedBuilder = EmbedFactory.success("Greenlit Suggestions", null);
 
         for (GreenlitMessage message : greenlitMessages) {
             String title = StringUtils.truncate(message.getSuggestionTitle(), 100);

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/ProfileCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/ProfileCommands.java
@@ -10,6 +10,7 @@ import net.aerh.slashcommands.api.annotations.SlashComponentHandler;
 import net.aerh.slashcommands.api.annotations.SlashOption;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
+import net.hypixel.nerdbot.marmalade.discord.EmbedFactory;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.Role;
@@ -223,8 +224,7 @@ public class ProfileCommands {
         int promotionComments = roleConfig.getMinimumCommentsRequiredForPromotion();
 
         // General Activity
-        embeds.add(new EmbedBuilder().setColor(Color.GREEN)
-            .setTitle("General Activity")
+        embeds.add(EmbedFactory.success("General Activity", null)
             // General
             .addField("Last Seen", lastActivity.toRelativeTimestamp(LastActivity::getLastGlobalActivity), true)
             .addField("General Voice Chat", lastActivity.toRelativeTimestamp(LastActivity::getLastVoiceChannelJoinDate), true)
@@ -578,11 +578,8 @@ public class ProfileCommands {
                                 event.getHook().editOriginal(String.format("Updated your Mojang profile to %s (`%s`)", mojangProfile.getUsername(), mojangProfile.getUniqueId())).queue();
 
                                 ChannelCache.sendToLogChannel(
-                                    new EmbedBuilder()
-                                        .setTitle("Mojang Profile Link")
-                                        .setDescription(member.getAsMention() + " has linked their Mojang Profile.")
+                                    EmbedFactory.success("Mojang Profile Link", member.getAsMention() + " has linked their Mojang Profile.")
                                         .setThumbnail(member.getEffectiveAvatarUrl())
-                                        .setColor(Color.GREEN)
                                         .addField("Username", mojangProfile.getUsername(), false)
                                         .addField(
                                             "UUID / SkyCrypt",

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/ReminderCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/ReminderCommands.java
@@ -33,8 +33,8 @@ import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.ReminderRepository;
 import net.hypixel.nerdbot.discord.util.StringUtils;
+import net.hypixel.nerdbot.marmalade.discord.EmbedFactory;
 
-import java.awt.Color;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -324,11 +324,8 @@ public class ReminderCommands {
                             // Send confirmation DM
                             try {
                                 PrivateChannel privateChannel = member.getUser().openPrivateChannel().complete();
-                                EmbedBuilder embedBuilder = new EmbedBuilder()
-                                    .setDescription(finalDescription)
-                                    .setTimestamp(Instant.now())
-                                    .setFooter(reminder.getUuid().toString())
-                                    .setColor(Color.GREEN);
+                                EmbedBuilder embedBuilder = EmbedFactory.success(null, finalDescription)
+                                    .setFooter(reminder.getUuid().toString());
 
                                 privateChannel.sendMessage("Reminder set for: " + DiscordTimestamp.toLongDateTime(finalDate.getTime()))
                                     .addEmbeds(embedBuilder.build())

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/ReminderCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/ReminderCommands.java
@@ -34,10 +34,12 @@ import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepo
 import net.hypixel.nerdbot.marmalade.storage.database.repository.ReminderRepository;
 import net.hypixel.nerdbot.discord.util.StringUtils;
 import net.hypixel.nerdbot.marmalade.discord.EmbedFactory;
+import net.hypixel.nerdbot.marmalade.format.TimeUtils;
 
-import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -51,6 +53,10 @@ import java.util.regex.Pattern;
 public class ReminderCommands {
 
     private static final Pattern DURATION = Pattern.compile("((\\d+)w)?((\\d+)d)?((\\d+)h)?((\\d+)m)?((\\d+)s)?");
+
+    // Readable date format used in the reminder selection menu - e.g. "Apr 02, 2026 at 3:45 PM UTC"
+    private static final DateTimeFormatter REMINDER_DATE_FORMAT = DateTimeFormatter.ofPattern("MMM dd, yyyy 'at' h:mm a z")
+        .withZone(ZoneId.of("UTC"));
 
     /**
      * Parse a time string in the format of {@code 1w2d3h4m5s} into a Date
@@ -445,8 +451,7 @@ public class ReminderCommands {
             int globalIndex = (page - 1) * remindersPerPage + i + 1;
 
             // Use plain text date format instead of Discord timestamp for selection menu
-            SimpleDateFormat dateFormat = new SimpleDateFormat("MMM dd, yyyy 'at' h:mm a z");
-            String readableDate = dateFormat.format(reminder.getTime());
+            String readableDate = TimeUtils.format(Instant.ofEpochMilli(reminder.getTime()), REMINDER_DATE_FORMAT);
 
             String optionLabel = "#" + globalIndex + " - " + readableDate;
             String optionDescription = StringUtils.truncate(reminder.getDescription(), 50);

--- a/app/src/main/java/net/hypixel/nerdbot/app/curator/ForumChannelCurator.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/curator/ForumChannelCurator.java
@@ -14,7 +14,7 @@ import net.dv8tion.jda.api.entities.channel.forums.BaseForumTag;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.managers.channel.concrete.ThreadChannelManager;
-import net.dv8tion.jda.internal.utils.tuple.Pair;
+import net.hypixel.nerdbot.marmalade.functional.Pair;
 import net.hypixel.nerdbot.app.metrics.PrometheusMetrics;
 import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.discord.cache.EmojiCache;
@@ -171,7 +171,7 @@ public class ForumChannelCurator extends Curator<ForumChannel, ThreadChannel> {
                                 .findFirst()
                                 .orElse(0)
                         ))
-                        .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+                        .collect(Collectors.toMap(Pair::first, Pair::second));
 
                     int agree = votes.get(emojiConfig.getAgreeEmojiId());
                     int neutral = votes.get(emojiConfig.getNeutralEmojiId());

--- a/app/src/main/java/net/hypixel/nerdbot/app/listener/ModLogListener.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/listener/ModLogListener.java
@@ -35,14 +35,12 @@ public class ModLogListener {
     public void onJoin(GuildMemberJoinEvent event) {
         Member member = event.getMember();
         String roles = member.getRoles().stream().map(Role::getName).reduce((a, b) -> a + ", " + b).orElse("None");
-        MessageEmbed messageEmbed = getDefaultEmbed()
-            .setTitle("Member joined")
+        MessageEmbed messageEmbed = EmbedFactory.success("Member joined", null)
             .addField("Member ID", member.getId(), false)
             .addField("Member Name", member.getEffectiveName(), false)
             .addField("Join Date", member.getTimeJoined().toString(), false)
             .addField("Member Roles", roles, false)
             .setThumbnail(member.getAvatarUrl())
-            .setColor(Color.GREEN)
             .build();
 
         ChannelCache.sendToLogChannel(messageEmbed);
@@ -87,11 +85,8 @@ public class ModLogListener {
     @SubscribeEvent
     public void onGuildUnban(GuildUnbanEvent event) {
         User member = event.getUser();
-        MessageEmbed messageEmbed = getDefaultEmbed()
-            .setTitle("Member unbanned")
-            .setDescription(member.getAsMention())
+        MessageEmbed messageEmbed = EmbedFactory.success("Member unbanned", member.getAsMention())
             .setThumbnail(member.getAvatarUrl())
-            .setColor(Color.GREEN)
             .build();
 
         ChannelCache.sendToLogChannel(messageEmbed);
@@ -101,9 +96,7 @@ public class ModLogListener {
     public void onInviteCreate(GuildInviteCreateEvent event) {
         User member = event.getInvite().getInviter();
         Invite invite = event.getInvite();
-        MessageEmbed messageEmbed = getDefaultEmbed()
-            .setTitle("Invite created")
-            .setDescription("Created by " + member.getAsMention()
+        MessageEmbed messageEmbed = EmbedFactory.success("Invite created", "Created by " + member.getAsMention()
                 + "\n\nInvite URL: " + invite.getUrl()
                 + "\nTime created: " + invite.getTimeCreated()
                 + "\nChannel: " + invite.getChannel().getName()
@@ -111,7 +104,6 @@ public class ModLogListener {
                 + "\nMax Age: " + LocalTime.ofSecondOfDay(Math.min(86_399, invite.getMaxAge())).toString()
                 + "\nTemporary? " + (invite.isTemporary() ? "Yes" : "No"))
             .setThumbnail(member.getAvatarUrl())
-            .setColor(Color.GREEN)
             .build();
 
         ChannelCache.sendToLogChannel(messageEmbed);
@@ -137,11 +129,8 @@ public class ModLogListener {
             stringBuilder.append(" • ").append(role.getName()).append("\n");
         }
 
-        MessageEmbed messageEmbed = getDefaultEmbed()
-            .setTitle("Role(s) added")
-            .setDescription(stringBuilder.toString())
+        MessageEmbed messageEmbed = EmbedFactory.success("Role(s) added", stringBuilder.toString())
             .setThumbnail(member.getAvatarUrl())
-            .setColor(Color.GREEN)
             .build();
 
         ChannelCache.sendToLogChannel(messageEmbed);

--- a/app/src/main/java/net/hypixel/nerdbot/app/util/HttpUtils.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/util/HttpUtils.java
@@ -5,7 +5,7 @@ import com.google.gson.JsonSyntaxException;
 import io.prometheus.client.Summary;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
-import net.dv8tion.jda.internal.utils.tuple.Pair;
+import net.hypixel.nerdbot.marmalade.functional.Pair;
 import net.hypixel.nerdbot.app.metrics.PrometheusMetrics;
 import net.hypixel.nerdbot.marmalade.http.HttpClient;
 import net.hypixel.nerdbot.marmalade.UUIDUtils;
@@ -124,7 +124,7 @@ public class HttpUtils {
      */
     private static HttpResponse<String> getHttpResponse(String url, Pair<String, String>... headers) throws IOException, InterruptedException {
         HttpRequest.Builder builder = HttpRequest.newBuilder().uri(URI.create(url)).GET();
-        Arrays.stream(headers).forEach(h -> builder.header(h.getLeft(), h.getRight()));
+        Arrays.stream(headers).forEach(h -> builder.header(h.first(), h.second()));
 
         HttpRequest request = builder.build();
         log.info("Sending HTTP request to {} with {} header(s)", url, headers.length);
@@ -138,7 +138,7 @@ public class HttpUtils {
             .uri(URI.create(url))
             .timeout(Duration.ofSeconds(30))
             .GET();
-        Arrays.stream(headers).forEach(h -> builder.header(h.getLeft(), h.getRight()));
+        Arrays.stream(headers).forEach(h -> builder.header(h.first(), h.second()));
 
         HttpRequest request = builder.build();
         log.info("Sending async HTTP request to {} with {} header(s)", url, headers.length);


### PR DESCRIPTION
## Summary

- Replaced EmbedBuilder boilerplate with EmbedFactory presets across ModLogListener, ProfileCommands, AdminCommands, InfoCommands, ReminderCommands, ForumChannelCurator
- Migrated from JDA's internal Pair to Marmalade's Pair in HttpUtils and ForumChannelCurator
- Replaced legacy SimpleDateFormat with TimeUtils in ReminderCommands