### PR TITLE
Rewrite BotFeature scheduling, adopt Result and Retry for HTTP

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
@@ -20,6 +20,7 @@ import net.hypixel.nerdbot.discord.AbstractDiscordBot;
 import net.hypixel.nerdbot.discord.api.feature.BotFeature;
 import net.hypixel.nerdbot.discord.api.feature.FeatureEventListener;
 import net.hypixel.nerdbot.discord.api.feature.SchedulableFeature;
+import net.hypixel.nerdbot.marmalade.functional.Result;
 import net.hypixel.nerdbot.discord.cache.MessageCache;
 import net.hypixel.nerdbot.discord.cache.suggestion.SuggestionCache;
 import net.hypixel.nerdbot.discord.config.AlphaProjectConfigUpdater;
@@ -115,46 +116,48 @@ public class SkyBlockNerdsBot extends AbstractDiscordBot {
 
             config.getFeatures().stream()
                 .filter(FeatureConfig::isEnabled)
-                .forEach(featureConfig -> {
-                    try {
-                        if (!isAllowed(featureConfig.getClassName())) {
-                            log.warn("Feature class {} not permitted by class allowlist", featureConfig.getClassName());
-                            return;
-                        }
-
-                        Class<?> clazz = Class.forName(featureConfig.getClassName());
-                        if (!BotFeature.class.isAssignableFrom(clazz)) {
-                            log.warn("Feature class {} does not implement BotFeature", featureConfig.getClassName());
-                            return;
-                        }
-
-                        BotFeature feature = (BotFeature) clazz.getDeclaredConstructor().newInstance();
-                        feature.setScheduleOverrides(featureConfig.getInitialDelayMs(), featureConfig.getPeriodMs());
-                        features.add(feature);
-                        log.info("Added feature from config: {}", featureConfig.getClassName());
-
-                        if (feature instanceof SchedulableFeature schedulable) {
-                            long defaultInitial = schedulable.defaultInitialDelayMs(config);
-                            long defaultPeriod = schedulable.defaultPeriodMs(config);
-
-                            Long overrideInitial = featureConfig.getInitialDelayMs();
-                            Long overridePeriod = featureConfig.getPeriodMs();
-                            long effectiveInitial = overrideInitial != null ? overrideInitial : defaultInitial;
-                            long effectivePeriod = overridePeriod != null ? overridePeriod : defaultPeriod;
-
-                            if (overrideInitial != null || overridePeriod != null) {
-                                log.info(
-                                    "Applying schedule override for {}: initialDelayMs={} (default {}), periodMs={} (default {})",
-                                    feature.getClass().getName(), effectiveInitial, defaultInitial, effectivePeriod, defaultPeriod
-                                );
-                            }
-
-                            feature.scheduleAtFixedRate(schedulable.buildTask(), defaultInitial, defaultPeriod);
-                        }
-                    } catch (Exception e) {
-                        log.warn("Failed to instantiate feature {}", featureConfig.getClassName(), e);
+                .forEach(featureConfig -> Result.of(() -> {
+                    if (!isAllowed(featureConfig.getClassName())) {
+                        log.warn("Feature class {} not permitted by class allowlist", featureConfig.getClassName());
+                        return null;
                     }
-                });
+
+                    Class<?> clazz = Class.forName(featureConfig.getClassName());
+                    if (!BotFeature.class.isAssignableFrom(clazz)) {
+                        log.warn("Feature class {} does not implement BotFeature", featureConfig.getClassName());
+                        return null;
+                    }
+
+                    BotFeature feature = (BotFeature) clazz.getDeclaredConstructor().newInstance();
+                    feature.setScheduleOverrides(featureConfig.getInitialDelayMs(), featureConfig.getPeriodMs());
+                    features.add(feature);
+                    log.info("Added feature from config: {}", featureConfig.getClassName());
+
+                    if (feature instanceof SchedulableFeature schedulable) {
+                        long defaultInitial = schedulable.defaultInitialDelayMs(config);
+                        long defaultPeriod = schedulable.defaultPeriodMs(config);
+
+                        Long overrideInitial = featureConfig.getInitialDelayMs();
+                        Long overridePeriod = featureConfig.getPeriodMs();
+                        long effectiveInitial = overrideInitial != null ? overrideInitial : defaultInitial;
+                        long effectivePeriod = overridePeriod != null ? overridePeriod : defaultPeriod;
+
+                        if (overrideInitial != null || overridePeriod != null) {
+                            log.info(
+                                "Applying schedule override for {}: initialDelayMs={} (default {}), periodMs={} (default {})",
+                                feature.getClass().getName(), effectiveInitial, defaultInitial, effectivePeriod, defaultPeriod
+                            );
+                        }
+
+                        String taskName = feature.getClass().getSimpleName() + "-task";
+                        feature.scheduleAtFixedRate(taskName, schedulable::executeTask, defaultInitial, defaultPeriod);
+                    }
+
+                    return null;
+                }).mapError(e -> {
+                    log.warn("Failed to instantiate feature {}", featureConfig.getClassName(), e);
+                    return e;
+                }));
         } else {
             log.info("No feature config present");
         }

--- a/app/src/main/java/net/hypixel/nerdbot/app/activity/ActivityPurgeFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/activity/ActivityPurgeFeature.java
@@ -3,17 +3,13 @@ package net.hypixel.nerdbot.app.activity;
 import lombok.extern.slf4j.Slf4j;
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
 import net.hypixel.nerdbot.discord.BotEnvironment;
-import net.hypixel.nerdbot.discord.api.bot.DiscordBot;
 import net.hypixel.nerdbot.discord.api.feature.BotFeature;
 import net.hypixel.nerdbot.discord.api.feature.SchedulableFeature;
 import net.hypixel.nerdbot.discord.config.NerdBotConfig;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
-import net.hypixel.nerdbot.discord.config.FeatureConfig;
-import net.hypixel.nerdbot.discord.util.DiscordBotEnvironment;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.TimerTask;
 
 @Slf4j
 public class ActivityPurgeFeature extends BotFeature implements SchedulableFeature {
@@ -23,24 +19,19 @@ public class ActivityPurgeFeature extends BotFeature implements SchedulableFeatu
     }
 
     @Override
-    public TimerTask buildTask() {
-        return new TimerTask() {
-            @Override
-            public void run() {
-                if (BotEnvironment.getBot().isReadOnly()) {
-                    log.warn("Bot is in read-only mode, skipping activity purge task!");
-                    return;
-                }
+    public void executeTask() {
+        if (BotEnvironment.getBot().isReadOnly()) {
+            log.warn("Bot is in read-only mode, skipping activity purge task!");
+            return;
+        }
 
-                DiscordUserRepository discordUserRepository = BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
-                int daysRequiredForVoteHistory = SkyBlockNerdsBot.config().getRoleConfig().getDaysRequiredForVoteHistory();
-                discordUserRepository.getAll().forEach(discordUser -> {
-                    if (discordUser.getLastActivity().purgeOldHistory(daysRequiredForVoteHistory)) {
-                        discordUserRepository.cacheObject(discordUser);
-                    }
-                });
+        DiscordUserRepository discordUserRepository = BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
+        int daysRequiredForVoteHistory = SkyBlockNerdsBot.config().getRoleConfig().getDaysRequiredForVoteHistory();
+        discordUserRepository.getAll().forEach(discordUser -> {
+            if (discordUser.getLastActivity().purgeOldHistory(daysRequiredForVoteHistory)) {
+                discordUserRepository.cacheObject(discordUser);
             }
-        };
+        });
     }
 
     @Override
@@ -55,6 +46,6 @@ public class ActivityPurgeFeature extends BotFeature implements SchedulableFeatu
 
     @Override
     public void onFeatureEnd() {
-        this.timer.cancel();
+        stopScheduledTask();
     }
 }

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/AdminCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/AdminCommands.java
@@ -572,16 +572,15 @@ public class AdminCommands {
 
                                 String scuffedUsername = Utils.getScuffedMinecraftIGN(member).orElseThrow();
                                 return HttpUtils.getMojangProfileAsync(scuffedUsername)
-                                    .thenAccept(mojangProfile -> {
-                                        if (mojangProfile != null) {
+                                    .thenAccept(result -> {
+                                        if (result.isSuccess()) {
+                                            MojangProfile mojangProfile = result.orElseGet(MojangProfile::new);
                                             mojangProfiles.add(mojangProfile);
                                             user.setMojangProfile(mojangProfile);
                                             log.info("Migrated {} [{}] ({}) to {} ({})", member.getEffectiveName(), member.getUser().getName(), member.getId(), mojangProfile.getUsername(), mojangProfile.getUniqueId());
+                                        } else {
+                                            log.error("Unable to migrate {} (ID: {})", member.getEffectiveName(), member.getId());
                                         }
-                                    })
-                                    .exceptionally(throwable -> {
-                                        log.error("Unable to migrate {} (ID: {})", member.getEffectiveName(), member.getId(), throwable);
-                                        return null;
                                     });
                             })
                     )

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/ProfileCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/ProfileCommands.java
@@ -122,10 +122,14 @@ public class ProfileCommands {
 
     public static CompletableFuture<MojangProfile> requestMojangProfileAsync(Member member, String username, boolean enforceSocial) {
         return HttpUtils.getMojangProfileAsync(username)
-            .thenCompose(mojangProfile -> {
-                if (mojangProfile == null) {
-                    return CompletableFuture.completedFuture(null);
+            .thenCompose(mojangResult -> {
+                if (mojangResult.isFailure()) {
+                    MojangProfile errorProfile = new MojangProfile();
+                    errorProfile.setErrorMessage("Failed to look up Minecraft profile for `" + username + "`");
+                    return CompletableFuture.completedFuture(errorProfile);
                 }
+
+                MojangProfile mojangProfile = mojangResult.orElseGet(MojangProfile::new);
 
                 if (mojangProfile.getErrorMessage() != null) {
                     MojangProfile errorProfile = new MojangProfile();
@@ -134,7 +138,15 @@ public class ProfileCommands {
                 }
 
                 return HttpUtils.getHypixelPlayerAsync(mojangProfile.getUniqueId())
-                    .thenApply(hypixelPlayerResponse -> {
+                    .thenApply(hypixelResult -> {
+                        if (hypixelResult.isFailure()) {
+                            MojangProfile errorProfile = new MojangProfile();
+                            errorProfile.setErrorMessage("Unable to look up `" + mojangProfile.getUsername() + "` on Hypixel");
+                            return errorProfile;
+                        }
+
+                        HypixelPlayerResponse hypixelPlayerResponse = hypixelResult.orElseGet(HypixelPlayerResponse::new);
+
                         if (!hypixelPlayerResponse.isSuccess()) {
                             MojangProfile errorProfile = new MojangProfile();
                             errorProfile.setErrorMessage("Unable to look up `" + mojangProfile.getUsername() + "`: " + hypixelPlayerResponse.getCause());

--- a/app/src/main/java/net/hypixel/nerdbot/app/feature/CurateFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/feature/CurateFeature.java
@@ -19,7 +19,6 @@ import net.hypixel.nerdbot.discord.util.DiscordBotEnvironment;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.TimerTask;
 
 @Slf4j
 public class CurateFeature extends BotFeature implements SchedulableFeature {
@@ -29,46 +28,41 @@ public class CurateFeature extends BotFeature implements SchedulableFeature {
     }
 
     @Override
-    public TimerTask buildTask() {
-        return new TimerTask() {
-            @Override
-            public void run() {
-                SuggestionConfig suggestionConfig = DiscordBotEnvironment.getBot().getConfig().getSuggestionConfig();
+    public void executeTask() {
+        SuggestionConfig suggestionConfig = DiscordBotEnvironment.getBot().getConfig().getSuggestionConfig();
 
-                if (suggestionConfig.getForumChannelId() == null) {
-                    log.info("Not running CurateFeature: forumChannelId missing in config");
-                    return;
-                }
+        if (suggestionConfig.getForumChannelId() == null) {
+            log.info("Not running CurateFeature: forumChannelId missing in config");
+            return;
+        }
 
-                Optional<ForumChannel> forumChannel = ChannelCache.getForumChannelById(suggestionConfig.getForumChannelId());
-                if (forumChannel.isEmpty()) {
-                    log.info("Not running CurateFeature: forumChannel not found for configured forumChannelId");
-                    return;
-                }
+        Optional<ForumChannel> forumChannel = ChannelCache.getForumChannelById(suggestionConfig.getForumChannelId());
+        if (forumChannel.isEmpty()) {
+            log.info("Not running CurateFeature: forumChannel not found for configured forumChannelId");
+            return;
+        }
 
-                BotEnvironment.EXECUTOR_SERVICE.execute(() -> {
-                    Database database = BotEnvironment.getBot().getDatabase();
-                    Curator<ForumChannel, ThreadChannel> forumChannelCurator = new ForumChannelCurator(BotEnvironment.getBot().isReadOnly());
-                    ForumChannel channel = forumChannel.get();
-                    log.info("Processing suggestion forum channel '{}' (ID: {})", channel.getName(), channel.getId());
+        BotEnvironment.EXECUTOR_SERVICE.execute(() -> {
+            Database database = BotEnvironment.getBot().getDatabase();
+            Curator<ForumChannel, ThreadChannel> forumChannelCurator = new ForumChannelCurator(BotEnvironment.getBot().isReadOnly());
+            ForumChannel channel = forumChannel.get();
+            log.info("Processing suggestion forum channel '{}' (ID: {})", channel.getName(), channel.getId());
 
-                    List<GreenlitMessage> result = forumChannelCurator.curate(channel);
-                    if (result.isEmpty()) {
-                        log.info("No new suggestions were greenlit from ID {} this time!", channel.getId());
-                    } else {
-                        log.info("Greenlit {} new suggestions from ID {}. Took {}ms!", result.size(), channel.getId(), forumChannelCurator.getEndTime() - forumChannelCurator.getStartTime());
-                    }
-
-                    result.forEach(greenlitMessage -> {
-                        GreenlitMessageRepository greenlitMessageRepository = database.getRepositoryManager().getRepository(GreenlitMessageRepository.class);
-                        greenlitMessageRepository.cacheObject(greenlitMessage);
-                        PrometheusMetrics.GREENLIT_SUGGESTION_LENGTH.labels(greenlitMessage.getMessageId(), String.valueOf(greenlitMessage.getSuggestionContent().length())).inc();
-                    });
-                    log.info("Inserted {} new greenlit messages into the database!", result.size());
-                    PrometheusMetrics.TOTAL_GREENLIT_MESSAGES_AMOUNT.inc(result.size());
-                });
+            List<GreenlitMessage> result = forumChannelCurator.curate(channel);
+            if (result.isEmpty()) {
+                log.info("No new suggestions were greenlit from ID {} this time!", channel.getId());
+            } else {
+                log.info("Greenlit {} new suggestions from ID {}. Took {}ms!", result.size(), channel.getId(), forumChannelCurator.getEndTime() - forumChannelCurator.getStartTime());
             }
-        };
+
+            result.forEach(greenlitMessage -> {
+                GreenlitMessageRepository greenlitMessageRepository = database.getRepositoryManager().getRepository(GreenlitMessageRepository.class);
+                greenlitMessageRepository.cacheObject(greenlitMessage);
+                PrometheusMetrics.GREENLIT_SUGGESTION_LENGTH.labels(greenlitMessage.getMessageId(), String.valueOf(greenlitMessage.getSuggestionContent().length())).inc();
+            });
+            log.info("Inserted {} new greenlit messages into the database!", result.size());
+            PrometheusMetrics.TOTAL_GREENLIT_MESSAGES_AMOUNT.inc(result.size());
+        });
     }
 
     @Override
@@ -83,6 +77,6 @@ public class CurateFeature extends BotFeature implements SchedulableFeature {
 
     @Override
     public void onFeatureEnd() {
-        this.timer.cancel();
+        stopScheduledTask();
     }
 }

--- a/app/src/main/java/net/hypixel/nerdbot/app/feature/ProfileUpdateFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/feature/ProfileUpdateFeature.java
@@ -11,16 +11,16 @@ import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.discord.api.feature.BotFeature;
 import net.hypixel.nerdbot.discord.api.feature.SchedulableFeature;
 import net.hypixel.nerdbot.discord.config.NerdBotConfig;
+import net.hypixel.nerdbot.marmalade.exception.HttpException;
+import net.hypixel.nerdbot.marmalade.functional.Result;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.stats.MojangProfile;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
 import net.hypixel.nerdbot.discord.util.DiscordUtils;
-import net.hypixel.nerdbot.discord.config.FeatureConfig;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
-import java.util.TimerTask;
 
 @Slf4j
 public class ProfileUpdateFeature extends BotFeature implements SchedulableFeature {
@@ -37,7 +37,14 @@ public class ProfileUpdateFeature extends BotFeature implements SchedulableFeatu
             return;
         }
 
-        MojangProfile mojangProfile = HttpUtils.getMojangProfile(existingProfile.getUniqueId());
+        Result<MojangProfile, HttpException> profileResult = HttpUtils.getMojangProfile(existingProfile.getUniqueId());
+        if (profileResult.isFailure()) {
+            log.warn("Failed to fetch Mojang profile for {} (UUID: {})", discordUser.getDiscordId(), existingProfile.getUniqueId());
+            return;
+        }
+
+        MojangProfile mojangProfile = profileResult.orElseGet(MojangProfile::new);
+
         if (mojangProfile.getUsername() == null || mojangProfile.getUsername().isBlank()) {
             log.warn("Skipping nickname update for {} (UUID: {}) because the Mojang username is missing",
                 discordUser.getDiscordId(),
@@ -81,29 +88,24 @@ public class ProfileUpdateFeature extends BotFeature implements SchedulableFeatu
     }
 
     @Override
-    public TimerTask buildTask() {
-        return new TimerTask() {
-            @Override
-            public void run() {
-                if (BotEnvironment.getBot().isReadOnly()) {
-                    log.info("Bot is in read-only mode, skipping profile update task!");
-                    return;
-                }
+    public void executeTask() {
+        if (BotEnvironment.getBot().isReadOnly()) {
+            log.info("Bot is in read-only mode, skipping profile update task!");
+            return;
+        }
 
-                if (!SkyBlockNerdsBot.config().isMojangForceNicknameUpdate()) {
-                    log.info("Forcefully updating nicknames is currently disabled!");
-                    return;
-                }
+        if (!SkyBlockNerdsBot.config().isMojangForceNicknameUpdate()) {
+            log.info("Forcefully updating nicknames is currently disabled!");
+            return;
+        }
 
-                DiscordUserRepository discordUserRepository = BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
-                long cacheTtlHours = SkyBlockNerdsBot.config().getMojangUsernameCacheTTL();
-                discordUserRepository.forEach(discordUser -> {
-                    if (discordUser.isProfileAssigned() && discordUser.getMojangProfile().requiresCacheUpdate(cacheTtlHours)) {
-                        updateNickname(discordUser);
-                    }
-                });
+        DiscordUserRepository discordUserRepository = BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
+        long cacheTtlHours = SkyBlockNerdsBot.config().getMojangUsernameCacheTTL();
+        discordUserRepository.forEach(discordUser -> {
+            if (discordUser.isProfileAssigned() && discordUser.getMojangProfile().requiresCacheUpdate(cacheTtlHours)) {
+                updateNickname(discordUser);
             }
-        };
+        });
     }
 
     @Override
@@ -118,6 +120,6 @@ public class ProfileUpdateFeature extends BotFeature implements SchedulableFeatu
 
     @Override
     public void onFeatureEnd() {
-        this.timer.cancel();
+        stopScheduledTask();
     }
 }

--- a/app/src/main/java/net/hypixel/nerdbot/app/feature/UserNominationFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/feature/UserNominationFeature.java
@@ -8,7 +8,6 @@ import net.hypixel.nerdbot.discord.api.feature.BotFeature;
 import net.hypixel.nerdbot.marmalade.format.TimeUtils;
 
 import java.time.Duration;
-import java.util.TimerTask;
 
 @Slf4j
 public class UserNominationFeature extends BotFeature {
@@ -35,25 +34,22 @@ public class UserNominationFeature extends BotFeature {
 
     @Override
     public void onFeatureStart() {
-        this.timer.scheduleAtFixedRate(new TimerTask() {
-            @Override
-            public void run() {
-                if (TimeUtils.isDayOfMonth(1) && SkyBlockNerdsBot.config().isNominationsEnabled()) {
-                    log.info("Running nomination check");
-                    nominateUsers();
-                }
+        scheduleAtFixedRate("UserNominationFeature-task", () -> {
+            if (TimeUtils.isDayOfMonth(1) && SkyBlockNerdsBot.config().isNominationsEnabled()) {
+                log.info("Running nomination check");
+                nominateUsers();
+            }
 
-                if (TimeUtils.isDayOfMonth(15) && SkyBlockNerdsBot.config().isInactivityCheckEnabled()) {
-                    log.info("Running inactivity check");
-                    findInactiveUsers();
-                    findInactiveUsersInRoleRestrictedChannels();
-                }
+            if (TimeUtils.isDayOfMonth(15) && SkyBlockNerdsBot.config().isInactivityCheckEnabled()) {
+                log.info("Running inactivity check");
+                findInactiveUsers();
+                findInactiveUsersInRoleRestrictedChannels();
             }
         }, 0, Duration.ofHours(1).toMillis());
     }
 
     @Override
     public void onFeatureEnd() {
-
+        stopScheduledTask();
     }
 }

--- a/app/src/main/java/net/hypixel/nerdbot/app/util/HttpUtils.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/util/HttpUtils.java
@@ -1,16 +1,17 @@
 package net.hypixel.nerdbot.app.util;
 
 import com.google.gson.JsonObject;
-import com.google.gson.JsonSyntaxException;
 import io.prometheus.client.Summary;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import net.hypixel.nerdbot.marmalade.functional.Pair;
 import net.hypixel.nerdbot.app.metrics.PrometheusMetrics;
+import net.hypixel.nerdbot.marmalade.functional.Result;
 import net.hypixel.nerdbot.marmalade.http.HttpClient;
 import net.hypixel.nerdbot.marmalade.UUIDUtils;
 import net.hypixel.nerdbot.marmalade.exception.HttpException;
 import net.hypixel.nerdbot.marmalade.json.HypixelPlayerResponse;
+import net.hypixel.nerdbot.marmalade.resilience.Retry;
 import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.stats.MojangProfile;
 import org.jetbrains.annotations.NotNull;
@@ -32,89 +33,98 @@ import java.util.concurrent.CompletableFuture;
 @UtilityClass
 public class HttpUtils {
 
-    public static MojangProfile getMojangProfile(String username) throws HttpException {
-        String mojangUrl = String.format("https://api.mojang.com/users/profiles/minecraft/%s", username);
+    private static final int RETRY_ATTEMPTS = 3;
+    private static final Duration RETRY_DELAY = Duration.ofMillis(500);
+    private static final double RETRY_BACKOFF = 2.0;
 
-        if (UUIDUtils.isUUID(username)) {
-            mojangUrl = String.format("https://sessionserver.mojang.com/session/minecraft/profile/%s", username);
-        }
+    public static Result<MojangProfile, HttpException> getMojangProfile(String username) {
+        String mojangUrl = buildMojangUrl(username);
 
-        try {
-            String body = HttpClient.getString(mojangUrl);
-            return BotEnvironment.GSON.fromJson(body, MojangProfile.class);
-        } catch (IOException | InterruptedException exception) {
-            throw new HttpException("Network error fetching profile for `" + username + "`", exception);
-        } catch (Exception exception) {
-            throw new HttpException("Failed to parse Mojang profile for `" + username + "`: " + exception.getMessage(), exception);
-        }
+        return Result.of(() -> Retry.<MojangProfile>of(() -> {
+                String body = HttpClient.getString(mojangUrl).orElseThrow();
+                return BotEnvironment.GSON.fromJson(body, MojangProfile.class);
+            })
+            .maxAttempts(RETRY_ATTEMPTS)
+            .delay(RETRY_DELAY)
+            .backoffMultiplier(RETRY_BACKOFF)
+            .retryOn(HttpException.class)
+            .execute()
+        );
     }
 
-    public static CompletableFuture<MojangProfile> getMojangProfileAsync(String username) {
-        String mojangUrl = String.format("https://api.mojang.com/users/profiles/minecraft/%s", username);
+    public static CompletableFuture<Result<MojangProfile, HttpException>> getMojangProfileAsync(String username) {
+        String mojangUrl = buildMojangUrl(username);
 
-        if (UUIDUtils.isUUID(username)) {
-            mojangUrl = String.format("https://sessionserver.mojang.com/session/minecraft/profile/%s", username);
-        }
-
-        return HttpClient.getStringAsync(mojangUrl)
-            .thenApply(body -> {
-                try {
-                    return BotEnvironment.GSON.fromJson(body, MojangProfile.class);
-                } catch (JsonSyntaxException exception) {
-                    throw new RuntimeException(new HttpException("Invalid JSON response from Mojang API for `" + username + "`", exception));
-                } catch (IllegalStateException exception) {
-                    throw new RuntimeException(new HttpException("Malformed Mojang profile data for `" + username + "`", exception));
-                }
+        return Retry.<MojangProfile>of(() -> {
+                String body = HttpClient.getString(mojangUrl).orElseThrow();
+                return BotEnvironment.GSON.fromJson(body, MojangProfile.class);
             })
-            .exceptionally(throwable -> {
-                if (throwable.getCause() instanceof HttpException) {
-                    throw new RuntimeException(throwable.getCause());
+            .maxAttempts(RETRY_ATTEMPTS)
+            .delay(RETRY_DELAY)
+            .backoffMultiplier(RETRY_BACKOFF)
+            .retryOn(HttpException.class)
+            .executeAsync()
+            .handle((profile, throwable) -> {
+                if (throwable != null) {
+                    Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
+                    if (cause instanceof HttpException httpException) {
+                        return Result.failure(httpException);
+                    }
+                    return Result.failure(new HttpException("Failed to fetch Mojang profile for `" + username + "`", cause));
                 }
-                throw new RuntimeException(new HttpException("Network error fetching profile for `" + username + "`", throwable));
+                return Result.success(profile);
             });
     }
 
     @NotNull
-    public static MojangProfile getMojangProfile(UUID uniqueId) throws HttpException {
+    public static Result<MojangProfile, HttpException> getMojangProfile(UUID uniqueId) {
         return getMojangProfile(uniqueId.toString());
     }
 
-    public static HypixelPlayerResponse getHypixelPlayer(UUID uniqueId) throws HttpException {
+    public static Result<HypixelPlayerResponse, HttpException> getHypixelPlayer(UUID uniqueId) {
         String url = String.format("https://api.hypixel.net/player?uuid=%s", uniqueId);
         Summary.Timer requestTimer = PrometheusMetrics.HTTP_REQUEST_LATENCY.labels(url).startTimer();
 
         try {
-            String hypixelApiKey = BotEnvironment.getHypixelAPIKey().map(UUID::toString).orElse("");
-            return BotEnvironment.GSON.fromJson(getHttpResponse(url, Pair.of("API-Key", hypixelApiKey)).body(), HypixelPlayerResponse.class);
-        } catch (Exception exception) {
-            throw new HttpException("Unable to locate Hypixel Player for `" + uniqueId + "`", exception);
+            return Result.of(() -> Retry.<HypixelPlayerResponse>of(() -> {
+                    String hypixelApiKey = BotEnvironment.getHypixelAPIKey().map(UUID::toString).orElse("");
+                    HttpResponse<String> response = getHttpResponse(url, Pair.of("API-Key", hypixelApiKey));
+                    return BotEnvironment.GSON.fromJson(response.body(), HypixelPlayerResponse.class);
+                })
+                .maxAttempts(RETRY_ATTEMPTS)
+                .delay(RETRY_DELAY)
+                .backoffMultiplier(RETRY_BACKOFF)
+                .execute()
+            );
         } finally {
             requestTimer.observeDuration();
         }
     }
 
-    public static CompletableFuture<HypixelPlayerResponse> getHypixelPlayerAsync(UUID uniqueId) {
+    public static CompletableFuture<Result<HypixelPlayerResponse, HttpException>> getHypixelPlayerAsync(UUID uniqueId) {
         String url = String.format("https://api.hypixel.net/player?uuid=%s", uniqueId);
         Summary.Timer requestTimer = PrometheusMetrics.HTTP_REQUEST_LATENCY.labels(url).startTimer();
 
         String hypixelApiKey = BotEnvironment.getHypixelAPIKey().map(UUID::toString).orElse("");
 
-        return getHttpResponseAsync(url, Pair.of("API-Key", hypixelApiKey))
-            .thenApply(response -> {
-                try {
-                    return BotEnvironment.GSON.fromJson(response.body(), HypixelPlayerResponse.class);
-                } catch (JsonSyntaxException exception) {
-                    throw new RuntimeException(new HttpException("Invalid JSON response from Hypixel API for `" + uniqueId + "`", exception));
-                } finally {
-                    requestTimer.observeDuration();
-                }
+        return Retry.<HypixelPlayerResponse>of(() -> {
+                HttpResponse<String> response = getHttpResponse(url, Pair.of("API-Key", hypixelApiKey));
+                return BotEnvironment.GSON.fromJson(response.body(), HypixelPlayerResponse.class);
             })
-            .exceptionally(throwable -> {
+            .maxAttempts(RETRY_ATTEMPTS)
+            .delay(RETRY_DELAY)
+            .backoffMultiplier(RETRY_BACKOFF)
+            .executeAsync()
+            .handle((player, throwable) -> {
                 requestTimer.observeDuration();
-                if (throwable.getCause() instanceof HttpException) {
-                    throw new RuntimeException(throwable.getCause());
+                if (throwable != null) {
+                    Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
+                    if (cause instanceof HttpException httpException) {
+                        return Result.failure(httpException);
+                    }
+                    return Result.failure(new HttpException("Failed to fetch Hypixel player for `" + uniqueId + "`", cause));
                 }
-                throw new RuntimeException(new HttpException("Network error while fetching Hypixel player data for `" + uniqueId + "`", throwable));
+                return Result.success(player);
             });
     }
 
@@ -151,7 +161,7 @@ public class HttpUtils {
      * Makes a simple HTTP request and returns JSON.
      * Delegates to core HttpClient.
      */
-    public static JsonObject makeHttpRequest(String url) throws IOException, InterruptedException {
+    public static Result<JsonObject, HttpException> makeHttpRequest(String url) {
         return HttpClient.getJson(url);
     }
 
@@ -159,7 +169,14 @@ public class HttpUtils {
      * Makes an asynchronous HTTP request and returns JSON.
      * Delegates to core HttpClient.
      */
-    public static CompletableFuture<JsonObject> makeHttpRequestAsync(String url) {
+    public static CompletableFuture<Result<JsonObject, HttpException>> makeHttpRequestAsync(String url) {
         return HttpClient.getJsonAsync(url);
+    }
+
+    private static String buildMojangUrl(String username) {
+        if (UUIDUtils.isUUID(username)) {
+            return String.format("https://sessionserver.mojang.com/session/minecraft/profile/%s", username);
+        }
+        return String.format("https://api.mojang.com/users/profiles/minecraft/%s", username);
     }
 }

--- a/discord-framework/src/main/java/net/hypixel/nerdbot/discord/api/feature/BotFeature.java
+++ b/discord-framework/src/main/java/net/hypixel/nerdbot/discord/api/feature/BotFeature.java
@@ -1,11 +1,13 @@
 package net.hypixel.nerdbot.discord.api.feature;
 
-import java.util.Timer;
-import java.util.TimerTask;
+import net.hypixel.nerdbot.marmalade.concurrent.ScheduledTask;
+import net.hypixel.nerdbot.marmalade.functional.ThrowingRunnable;
+
+import java.time.Duration;
 
 public abstract class BotFeature {
 
-    protected final Timer timer = new Timer();
+    protected ScheduledTask scheduledTask;
 
     private Long scheduleInitialDelayOverrideMs;
     private Long schedulePeriodOverrideMs;
@@ -19,9 +21,25 @@ public abstract class BotFeature {
         this.schedulePeriodOverrideMs = periodMs;
     }
 
-    public void scheduleAtFixedRate(TimerTask task, long defaultInitialDelayMs, long defaultPeriodMs) {
+    /**
+     * Schedules a recurring task backed by a {@link ScheduledTask}. Any checked exception thrown
+     * by {@code task} is propagated sneakily and caught by the ScheduledTask error handler.
+     *
+     * @param name the display name for the task thread
+     * @param task the work to execute on each tick
+     * @param defaultInitialDelayMs delay before the first execution, overridable via config
+     * @param defaultPeriodMs period between executions, overridable via config
+     */
+    public void scheduleAtFixedRate(String name, ThrowingRunnable<?> task, long defaultInitialDelayMs, long defaultPeriodMs) {
         long initialDelay = scheduleInitialDelayOverrideMs != null ? scheduleInitialDelayOverrideMs : defaultInitialDelayMs;
         long period = schedulePeriodOverrideMs != null ? schedulePeriodOverrideMs : defaultPeriodMs;
-        this.timer.scheduleAtFixedRate(task, initialDelay, period);
+        this.scheduledTask = ScheduledTask.create(name, ThrowingRunnable.sneaky(task), Duration.ofMillis(initialDelay), Duration.ofMillis(period));
+        this.scheduledTask.start();
+    }
+
+    public void stopScheduledTask() {
+        if (scheduledTask != null) {
+            scheduledTask.stop();
+        }
     }
 }

--- a/discord-framework/src/main/java/net/hypixel/nerdbot/discord/api/feature/SchedulableFeature.java
+++ b/discord-framework/src/main/java/net/hypixel/nerdbot/discord/api/feature/SchedulableFeature.java
@@ -1,20 +1,19 @@
 package net.hypixel.nerdbot.discord.api.feature;
 
-import java.util.TimerTask;
-
 import net.hypixel.nerdbot.discord.config.NerdBotConfig;
 
 /**
  * Implement on features that execute periodic tasks. The framework
- * will call these methods to build the task and determine default
- * scheduling, and will apply any per-feature overrides from config.
+ * will call executeTask() on a fixed schedule and handle error catching.
+ * Implement defaultInitialDelayMs() and defaultPeriodMs() to control timing.
  */
 public interface SchedulableFeature {
 
     /**
-     * Build the TimerTask that performs the feature's periodic task.
+     * Executes the feature's periodic task. Any exception thrown here is
+     * caught by the ScheduledTask framework and logged automatically.
      */
-    TimerTask buildTask();
+    void executeTask() throws Exception;
 
     /**
      * Default initial delay in milliseconds before the first run.
@@ -26,4 +25,3 @@ public interface SchedulableFeature {
      */
     long defaultPeriodMs(NerdBotConfig config);
 }
-


### PR DESCRIPTION
## Summary

- Replaced Timer-based scheduling in BotFeature with ScheduledTask from Marmalade
- Simplified SchedulableFeature interface from TimerTask buildTask() to void executeTask()
- Updated all SchedulableFeature implementations (ActivityPurge, Curate, ProfileUpdate, UserNomination)
- HttpUtils now returns Result types and wraps API calls with Retry (3 attempts, exponential backoff)
- SkyBlockNerdsBot feature loading uses Result.of() instead of try-catch in lambda

Depends on SkyBlock-Nerds/Marmalade#9