### PR TITLE
Migrate from MinecraftImageGenerator to Jigsaw

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ ENV COMMIT_SHA=${COMMIT_SHA}
 COPY --from=builder /app/app/target/NerdBot.jar /app/NerdBot.jar
 
 # Run the application
-ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -DBRANCH_NAME=${BRANCH_NAME} -DCOMMIT_SHA=${COMMIT_SHA} -jar NerdBot.jar"]
+ENTRYPOINT ["sh", "-c", "exec java --enable-preview ${JAVA_OPTS} -DBRANCH_NAME=${BRANCH_NAME} -DCOMMIT_SHA=${COMMIT_SHA} -jar NerdBot.jar"]

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -21,12 +21,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.Aerhhh.MinecraftImageGenerator</groupId>
+            <groupId>com.github.Aerhhh.jigsaw</groupId>
             <artifactId>jigsaw</artifactId>
             <version>feat~jigsaw-rewrite-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.github.Aerhhh.MinecraftImageGenerator</groupId>
+            <groupId>com.github.Aerhhh.jigsaw</groupId>
             <artifactId>jigsaw-skyblock</artifactId>
             <version>feat~jigsaw-rewrite-SNAPSHOT</version>
         </dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -21,14 +21,14 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.Aerhhh.MinecraftImageGenerator</groupId>
+            <groupId>net.aerh</groupId>
             <artifactId>jigsaw</artifactId>
-            <version>feat~jigsaw-rewrite-SNAPSHOT</version>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.github.Aerhhh.MinecraftImageGenerator</groupId>
+            <groupId>net.aerh</groupId>
             <artifactId>jigsaw-skyblock</artifactId>
-            <version>feat~jigsaw-rewrite-SNAPSHOT</version>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -21,14 +21,14 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>net.aerh</groupId>
+            <groupId>com.github.Aerhhh.MinecraftImageGenerator</groupId>
             <artifactId>jigsaw</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>feat~jigsaw-rewrite-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>net.aerh</groupId>
+            <groupId>com.github.Aerhhh.MinecraftImageGenerator</groupId>
             <artifactId>jigsaw-skyblock</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>feat~jigsaw-rewrite-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -22,8 +22,13 @@
         </dependency>
         <dependency>
             <groupId>com.github.Aerhhh.MinecraftImageGenerator</groupId>
-            <artifactId>MinecraftImageGenerator</artifactId>
-            <version>fix~nbt-text-component-parsing-SNAPSHOT</version>
+            <artifactId>jigsaw</artifactId>
+            <version>feat~jigsaw-rewrite-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.Aerhhh.MinecraftImageGenerator</groupId>
+            <artifactId>jigsaw-skyblock</artifactId>
+            <version>feat~jigsaw-rewrite-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/app/src/main/java/net/hypixel/nerdbot/app/Main.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/Main.java
@@ -31,8 +31,11 @@ public class Main {
             log.error("Failed to authenticate with Discord! Check your bot token.", exception);
         } catch (MongoException exception) {
             log.error("Failed to connect to MongoDB! Continuing without database connectivity.", exception);
-        } catch (RuntimeException exception) {
-            log.error("Unexpected runtime error during bot startup!", exception);
+        } catch (Exception exception) {
+            log.error("Unexpected error during bot startup!", exception);
+            System.exit(1);
+        } catch (Error error) {
+            log.error("Fatal error during bot startup!", error);
             System.exit(1);
         }
     }

--- a/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
@@ -23,10 +23,14 @@ import net.hypixel.nerdbot.discord.api.feature.SchedulableFeature;
 import net.hypixel.nerdbot.marmalade.functional.Result;
 import net.hypixel.nerdbot.discord.cache.MessageCache;
 import net.hypixel.nerdbot.discord.cache.suggestion.SuggestionCache;
+import net.hypixel.nerdbot.app.command.GeneratorCommands;
 import net.hypixel.nerdbot.discord.config.AlphaProjectConfigUpdater;
 import net.hypixel.nerdbot.discord.config.DiscordBotConfig;
 import net.hypixel.nerdbot.discord.config.FeatureConfig;
 import net.hypixel.nerdbot.discord.config.NerdBotConfig;
+import net.hypixel.nerdbot.discord.config.ResourcePackConfig;
+
+import java.nio.file.Path;
 import net.hypixel.nerdbot.marmalade.storage.database.Database;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.ReminderRepository;
@@ -228,6 +232,14 @@ public class SkyBlockNerdsBot extends AbstractDiscordBot {
 
         // Configure Sentry environment (auto-initialized via sentry.properties)
         SentryManager.configureEnvironment();
+
+        // Initialize resource pack engine manager
+        ResourcePackConfig rpConfig = config.getGeneratorConfig().getResourcePack();
+        GeneratorCommands.initializeEngineManager(
+            Path.of(rpConfig.getPackDirectory()),
+            rpConfig.getDefaultPack(),
+            rpConfig.isIncludeVanillaFallback()
+        );
     }
 
     @Override

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/AdminCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/AdminCommands.java
@@ -38,6 +38,7 @@ import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.requests.restaction.InviteAction;
 import net.dv8tion.jda.api.utils.FileUpload;
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
+import net.hypixel.nerdbot.app.command.GeneratorCommands;
 import net.hypixel.nerdbot.app.curator.ForumChannelCurator;
 import net.hypixel.nerdbot.app.listener.RoleRestrictedChannelListener;
 import net.hypixel.nerdbot.app.metrics.PrometheusMetrics;
@@ -272,6 +273,7 @@ public class AdminCommands {
                 bot.loadConfig();
                 bot.getJDA().getPresence().setActivity(Activity.of(Activity.ActivityType.valueOf(bot.getConfig().getActivityType().name()), bot.getConfig().getActivity()));
                 PrometheusMetrics.setMetricsEnabled(SkyBlockNerdsBot.config().getMetricsConfig().isEnabled());
+                GeneratorCommands.reloadResourcePacks();
 
                 event.getHook().editOriginal("Reloaded the config file!").queue();
             })

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -726,8 +726,7 @@ public class GeneratorCommands {
                 } else {
                     ItemRequest.Builder itemBuilder = ItemRequest.builder()
                         .itemId(itemId)
-                        .enchanted(enchanted)
-                        .scale(10);
+                        .enchanted(enchanted);
 
                     if (durability != null && durability < 100) {
                         itemBuilder.durabilityPercent(durability / 100.0);

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -4,6 +4,8 @@ import com.google.gson.JsonParseException;
 import lombok.extern.slf4j.Slf4j;
 import net.aerh.jigsaw.api.Engine;
 import net.aerh.jigsaw.api.generator.GenerationContext;
+import net.aerh.jigsaw.core.resource.PackMetadata;
+import net.aerh.jigsaw.skyblock.engine.EngineManager;
 import net.aerh.jigsaw.api.generator.GeneratorResult;
 import net.aerh.jigsaw.api.nbt.ParsedItem;
 import net.aerh.jigsaw.core.generator.CompositeRequest;
@@ -45,7 +47,9 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -86,9 +90,41 @@ public class GeneratorCommands {
     private static final String DURABILITY_DESCRIPTION = "Item durability percentage (0-100, only shown if less than 100)";
     private static final String COLOR_DESCRIPTION = "The overlay color (e.g., red, blue, #FF0000)";
 
+    private static final String RESOURCE_PACK_DESCRIPTION = "Resource pack to use for textures";
+
     private static final boolean AUTO_HIDE_ON_ERROR = true;
 
-    private static final Engine ENGINE = Engine.builder().build();
+    private static EngineManager engineManager;
+
+    /**
+     * Initializes the engine manager with resource pack configuration.
+     * Must be called during bot startup before any commands are processed.
+     */
+    public static void initializeEngineManager(Path packDirectory, String defaultPack, boolean vanillaFallback) {
+        if (engineManager != null) {
+            engineManager.close();
+        }
+        engineManager = new EngineManager(packDirectory, defaultPack, vanillaFallback);
+    }
+
+    /**
+     * Reloads all resource packs from disk.
+     */
+    public static void reloadResourcePacks() {
+        if (engineManager != null) {
+            engineManager.reload();
+        }
+    }
+
+    /**
+     * Returns the engine manager. Falls back to a default instance if not yet initialized.
+     */
+    private static EngineManager getEngineManager() {
+        if (engineManager == null) {
+            engineManager = new EngineManager(Path.of("./resource-packs"), null, true);
+        }
+        return engineManager;
+    }
 
     @SlashCommand(name = BASE_COMMAND, subcommand = "display", description = "Display an item")
     public void generateItem(
@@ -99,6 +135,7 @@ public class GeneratorCommands {
         @SlashOption(description = "If the item should look as if it being hovered over", required = false) Boolean hoverEffect,
         @SlashOption(description = SKIN_VALUE_DESCRIPTION, required = false) String skinValue,
         @SlashOption(description = DURABILITY_DESCRIPTION, required = false) Integer durability,
+        @SlashOption(autocompleteId = "resource-packs", description = RESOURCE_PACK_DESCRIPTION, required = false) String resourcePack,
         @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden
     ) {
         if (shouldBlockGeneratorCommand(event)) {
@@ -138,7 +175,8 @@ public class GeneratorCommands {
                 compositeBuilder.add(itemBuilder.build());
             }
 
-            GeneratorResult result = ENGINE.render(compositeBuilder.build(), context);
+            Engine engine = getEngineManager().getEngine(resourcePack);
+            GeneratorResult result = engine.render(compositeBuilder.build(), context);
             sendResult(event, result, "item");
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         } catch (RenderException | ParseException exception) {
@@ -327,7 +365,7 @@ public class GeneratorCommands {
                 }
 
                 compositeBuilder.add(tooltipBuilder.build());
-                GeneratorResult result = ENGINE.render(compositeBuilder.build(), context);
+                GeneratorResult result = getEngineManager().getDefaultEngine().render(compositeBuilder.build(), context);
                 sendResult(event, result, "powerstone");
                 addCommandToUserHistory(event.getUser(), event.getCommandString());
             } catch (RenderException | ParseException | IllegalArgumentException exception) {
@@ -353,7 +391,7 @@ public class GeneratorCommands {
 
         event.deferReply(hidden).complete();
 
-        List<Map.Entry<String, BufferedImage>> results = ENGINE.sprites().searchAll(itemId);
+        List<Map.Entry<String, BufferedImage>> results = getEngineManager().getDefaultEngine().sprites().searchAll(itemId);
 
         if (results.isEmpty()) {
             event.getHook().editOriginal("No results found for that item!").queue();
@@ -398,7 +436,7 @@ public class GeneratorCommands {
                 .withInventoryString(recipe)
                 .build();
 
-            GeneratorResult result = ENGINE.render(inventoryRequest, context);
+            GeneratorResult result = getEngineManager().getDefaultEngine().render(inventoryRequest, context);
 
             event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(result.firstFrame()), "recipe.png")).queue();
             addCommandToUserHistory(event.getUser(), event.getCommandString());
@@ -421,6 +459,7 @@ public class GeneratorCommands {
         @SlashOption(description = INVENTORY_NAME_DESCRIPTION, required = false) String containerName,
         @SlashOption(description = RENDER_BORDER_DESCRIPTION, required = false) Boolean drawBorder,
         @SlashOption(description = MAX_LINE_LENGTH_DESCRIPTION, required = false) Integer maxLineLength,
+        @SlashOption(autocompleteId = "resource-packs", description = RESOURCE_PACK_DESCRIPTION, required = false) String resourcePack,
         @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden
     ) {
         if (shouldBlockGeneratorCommand(event)) {
@@ -466,7 +505,8 @@ public class GeneratorCommands {
                 compositeBuilder.add(tooltipRequest);
             }
 
-            GeneratorResult result = ENGINE.render(compositeBuilder.build(), context);
+            Engine engine = getEngineManager().getEngine(resourcePack);
+            GeneratorResult result = engine.render(compositeBuilder.build(), context);
             sendResult(event, result, "inventory");
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         } catch (RenderException | ParseException exception) {
@@ -506,7 +546,7 @@ public class GeneratorCommands {
         GenerationContext context = DiscordGenerationContext.fromEvent(event, hidden);
 
         try {
-            ParsedItem parsedItem = ENGINE.parseNbt(nbtInput);
+            ParsedItem parsedItem = getEngineManager().getDefaultEngine().parseNbt(nbtInput);
 
             // Build item request
             ItemRequest.Builder itemBuilder = ItemRequest.builder()
@@ -532,7 +572,7 @@ public class GeneratorCommands {
             }
             compositeBuilder.add(tooltipBuilder.build());
 
-            GeneratorResult result = ENGINE.render(compositeBuilder.build(), context);
+            GeneratorResult result = getEngineManager().getDefaultEngine().render(compositeBuilder.build(), context);
 
             String slashCommand = tooltipBuilder.buildSlashCommand();
             String commandItemId = parsedItem.itemId();
@@ -636,6 +676,7 @@ public class GeneratorCommands {
         @SlashOption(autocompleteId = "tooltip-side", description = TOOLTIP_SIDE_DESCRIPTION, required = false) String tooltipSide,
         @SlashOption(description = RENDER_BORDER_DESCRIPTION, required = false) Boolean renderBorder,
         @SlashOption(description = DURABILITY_DESCRIPTION, required = false) Integer durability,
+        @SlashOption(autocompleteId = "resource-packs", description = RESOURCE_PACK_DESCRIPTION, required = false) String resourcePack,
         @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden
     ) {
         if (shouldBlockGeneratorCommand(event)) {
@@ -685,7 +726,8 @@ public class GeneratorCommands {
                 } else {
                     ItemRequest.Builder itemBuilder = ItemRequest.builder()
                         .itemId(itemId)
-                        .enchanted(enchanted);
+                        .enchanted(enchanted)
+                        .scale(10);
 
                     if (durability != null && durability < 100) {
                         itemBuilder.durabilityPercent(durability / 100.0);
@@ -720,7 +762,8 @@ public class GeneratorCommands {
                 compositeBuilder.add(tooltipRequest);
             }
 
-            GeneratorResult result = ENGINE.render(compositeBuilder.build(), context);
+            Engine engine = getEngineManager().getEngine(resourcePack);
+            GeneratorResult result = engine.render(compositeBuilder.build(), context);
             sendResult(event, result, "item");
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         } catch (RenderException | ParseException | IllegalArgumentException exception) {
@@ -770,7 +813,7 @@ public class GeneratorCommands {
                 .renderBorder(renderBorder)
                 .build();
 
-            GeneratorResult result = ENGINE.render(tooltipRequest, context);
+            GeneratorResult result = getEngineManager().getDefaultEngine().render(tooltipRequest, context);
             sendResult(event, result, "text");
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         } catch (RenderException | ParseException exception) {
@@ -846,7 +889,7 @@ public class GeneratorCommands {
                 compositeBuilder.add(0, playerHeadRequest);
             }
 
-            GeneratorResult result = ENGINE.render(compositeBuilder.build(), context);
+            GeneratorResult result = getEngineManager().getDefaultEngine().render(compositeBuilder.build(), context);
             sendResult(event, result, "dialogue");
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         } catch (RenderException | ParseException exception) {
@@ -935,7 +978,7 @@ public class GeneratorCommands {
                 compositeBuilder.add(0, playerHeadRequest);
             }
 
-            GeneratorResult result = ENGINE.render(compositeBuilder.build(), context);
+            GeneratorResult result = getEngineManager().getDefaultEngine().render(compositeBuilder.build(), context);
             sendResult(event, result, "dialogue");
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         } catch (IllegalArgumentException exception) {
@@ -991,7 +1034,7 @@ public class GeneratorCommands {
     public List<Command.Choice> itemNames(CommandAutoCompleteInteractionEvent event) {
         String userInput = event.getFocusedOption().getValue().toLowerCase(Locale.ROOT);
 
-        return ENGINE.sprites().getAllSprites().keySet()
+        return getEngineManager().getDefaultEngine().sprites().getAllSprites().keySet()
             .stream()
             .filter(name -> name.toLowerCase(Locale.ROOT).contains(userInput))
             .limit(25)
@@ -1025,12 +1068,51 @@ public class GeneratorCommands {
     @SlashAutocompleteHandler(id = "overlay-colors")
     public List<Command.Choice> overlayColors(CommandAutoCompleteInteractionEvent event) {
         String userInput = event.getFocusedOption().getValue().toLowerCase(Locale.ROOT);
-        return ENGINE.overlayColors().getAllColorOptionNames().stream()
+        return getEngineManager().getDefaultEngine().overlayColors().getAllColorOptionNames().stream()
             .filter(name -> name.toLowerCase(Locale.ROOT).contains(userInput))
             .sorted()
             .limit(25)
             .map(name -> new Command.Choice(name, name))
             .toList();
+    }
+
+    @SlashAutocompleteHandler(id = "resource-packs")
+    public List<Command.Choice> resourcePacks(CommandAutoCompleteInteractionEvent event) {
+        String userInput = event.getFocusedOption().getValue().toLowerCase(Locale.ROOT);
+
+        return getEngineManager().availablePackNames().stream()
+            .filter(name -> name.contains(userInput))
+            .limit(25)
+            .map(name -> new Command.Choice(name, name))
+            .toList();
+    }
+
+    @SlashCommand(name = BASE_COMMAND, subcommand = "resource-packs", description = "List available resource packs")
+    public void listResourcePacks(
+        SlashCommandInteractionEvent event,
+        @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden
+    ) {
+        hidden = hidden == null ? getUserAutoHideSetting(event) : hidden;
+        event.deferReply(hidden).complete();
+
+        Collection<String> packNames = getEngineManager().availablePackNames();
+
+        if (packNames.isEmpty()) {
+            event.getHook().editOriginal("No resource packs loaded. Using vanilla textures only.").queue();
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder("**Loaded Resource Packs:**\n");
+        for (String name : packNames) {
+            getEngineManager().getPackMetadata(name).ifPresent(meta ->
+                sb.append("- **").append(name).append("** (format ")
+                  .append(meta.packFormat()).append(") - ")
+                  .append(meta.description().isBlank() ? "No description" : meta.description())
+                  .append("\n")
+            );
+        }
+
+        event.getHook().editOriginal(sb.toString()).queue();
     }
 
     /**

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -720,7 +720,7 @@ public class GeneratorCommands {
                 if (itemId.equalsIgnoreCase("player_head")) {
                     PlayerHeadRequest.Builder headBuilder = PlayerHeadRequest.fromBase64(
                         skinValue != null ? skinValue : ""
-                    ).scale(10);
+                    );
 
                     compositeBuilder.add(headBuilder.build());
                 } else {

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -11,10 +11,10 @@ import net.aerh.jigsaw.api.nbt.ParsedItem;
 import net.aerh.jigsaw.core.generator.CompositeRequest;
 import net.aerh.jigsaw.core.generator.InventoryRequest;
 import net.aerh.jigsaw.core.generator.ItemRequest;
-import net.aerh.jigsaw.core.generator.PlayerBodyRequest;
 import net.aerh.jigsaw.core.generator.PlayerHeadRequest;
-import net.aerh.jigsaw.core.generator.body.ArmorSlot;
-import net.aerh.jigsaw.core.generator.body.SkinModel;
+import net.aerh.jigsaw.core.generator.player.ArmorPiece;
+import net.aerh.jigsaw.core.generator.player.ArmorSet;
+import net.aerh.jigsaw.core.generator.player.PlayerModelRequest;
 import net.aerh.jigsaw.core.generator.TooltipRequest;
 import net.aerh.jigsaw.core.text.TextWrapper;
 import net.aerh.jigsaw.exception.JigsawException;
@@ -1155,13 +1155,10 @@ public class GeneratorCommands {
         GenerationContext context = DiscordGenerationContext.fromEvent(event, hidden);
 
         try {
-            SkinModel model = SkinModel.CLASSIC;
-            if (skinModel != null && skinModel.equalsIgnoreCase("slim")) {
-                model = SkinModel.SLIM;
-            }
+            boolean slim = skinModel != null && skinModel.equalsIgnoreCase("slim");
 
-            PlayerBodyRequest.Builder bodyBuilder = resolveBodySkin(skinValue)
-                    .skinModel(model)
+            PlayerModelRequest.Builder bodyBuilder = resolveBodySkin(skinValue)
+                    .slim(slim)
                     .scale(2);
 
             // Resolve optional dye color for leather armor
@@ -1170,11 +1167,13 @@ public class GeneratorCommands {
                 resolvedDyeColor = resolveBodyDyeColor(dyeColor);
             }
 
-            // Add armor pieces by material name
-            addArmorIfPresent(bodyBuilder, ArmorSlot.HELMET, helmet, resolvedDyeColor);
-            addArmorIfPresent(bodyBuilder, ArmorSlot.CHESTPLATE, chestplate, resolvedDyeColor);
-            addArmorIfPresent(bodyBuilder, ArmorSlot.LEGGINGS, leggings, resolvedDyeColor);
-            addArmorIfPresent(bodyBuilder, ArmorSlot.BOOTS, boots, resolvedDyeColor);
+            // Build armor set from individual pieces
+            ArmorSet.Builder armorBuilder = ArmorSet.builder();
+            addArmorIfPresent(armorBuilder, ArmorPiece.HELMET, helmet, resolvedDyeColor);
+            addArmorIfPresent(armorBuilder, ArmorPiece.CHESTPLATE, chestplate, resolvedDyeColor);
+            addArmorIfPresent(armorBuilder, ArmorPiece.LEGGINGS, leggings, resolvedDyeColor);
+            addArmorIfPresent(armorBuilder, ArmorPiece.BOOTS, boots, resolvedDyeColor);
+            bodyBuilder.armor(armorBuilder.build());
 
             Engine engine = getEngineManager().getEngine(resourcePack);
             GeneratorResult result = engine.render(bodyBuilder.build(), context);
@@ -1195,15 +1194,20 @@ public class GeneratorCommands {
      * Adds an armor piece to the body request if the material is specified.
      * Applies dye color only to leather armor pieces.
      */
-    private static void addArmorIfPresent(PlayerBodyRequest.Builder builder, ArmorSlot slot,
+    private static void addArmorIfPresent(ArmorSet.Builder armorBuilder, ArmorPiece piece,
                                            String material, Integer dyeColor) {
         if (material == null || material.isBlank()) return;
         material = material.toLowerCase(Locale.ROOT).trim();
 
+        switch (piece) {
+            case HELMET -> armorBuilder.helmet(material);
+            case CHESTPLATE -> armorBuilder.chestplate(material);
+            case LEGGINGS -> armorBuilder.leggings(material);
+            case BOOTS -> armorBuilder.boots(material);
+        }
+
         if (material.equals("leather") && dyeColor != null) {
-            builder.armor(slot, material, dyeColor);
-        } else {
-            builder.armor(slot, material);
+            armorBuilder.leatherDyeColor(dyeColor);
         }
     }
 
@@ -1231,22 +1235,22 @@ public class GeneratorCommands {
      * For usernames, looks up the UUID via Mojang API, then fetches the profile to get the
      * Base64 texture property.
      *
-     * @return a {@link PlayerBodyRequest.Builder} configured with the resolved skin source
+     * @return a {@link PlayerModelRequest.Builder} configured with the resolved skin source
      * @throws IllegalArgumentException if the username cannot be resolved
      */
-    private static PlayerBodyRequest.Builder resolveBodySkin(String skinValue) {
+    private static PlayerModelRequest.Builder resolveBodySkin(String skinValue) {
         if (skinValue == null || skinValue.isBlank()) {
             throw new IllegalArgumentException("Skin value must not be empty");
         }
 
         // If it starts with http, treat as direct URL
         if (skinValue.startsWith("http://") || skinValue.startsWith("https://")) {
-            return PlayerBodyRequest.fromUrl(skinValue);
+            return PlayerModelRequest.fromUrl(skinValue);
         }
 
         // If it looks like Base64 (long string, no spaces, contains typical chars), use as-is
         if (skinValue.length() > 64 && !skinValue.contains(" ")) {
-            return PlayerBodyRequest.fromBase64(skinValue);
+            return PlayerModelRequest.fromBase64(skinValue);
         }
 
         // Otherwise treat as a username - resolve via Mojang API
@@ -1273,7 +1277,7 @@ public class GeneratorCommands {
         for (var prop : properties) {
             var obj = prop.getAsJsonObject();
             if ("textures".equals(obj.get("name").getAsString())) {
-                return PlayerBodyRequest.fromBase64(obj.get("value").getAsString())
+                return PlayerModelRequest.fromBase64(obj.get("value").getAsString())
                         .playerName(skinValue);
             }
         }

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -1131,7 +1131,7 @@ public class GeneratorCommands {
     /**
      * Sends a GeneratorResult to the Discord channel, handling both static and animated images.
      */
-    @SlashCommand(name = BASE_COMMAND, subcommand = "body", description = "Render a full 3D player body with optional armor")
+    @SlashCommand(name = BASE_COMMAND, subcommand = "body", description = "Render a full 3D player body with optional armor", guildOnly = true)
     public void generateBody(
         SlashCommandInteractionEvent event,
         @SlashOption(description = SKIN_VALUE_DESCRIPTION) String skinValue,

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -432,7 +432,6 @@ public class GeneratorCommands {
                 .rows(3)
                 .slotsPerRow(3)
                 .drawBorder(false)
-                .drawTitle(false)
                 .drawBackground(renderBackground)
                 .withInventoryString(recipe)
                 .build();

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -720,7 +720,7 @@ public class GeneratorCommands {
                 if (itemId.equalsIgnoreCase("player_head")) {
                     PlayerHeadRequest.Builder headBuilder = PlayerHeadRequest.fromBase64(
                         skinValue != null ? skinValue : ""
-                    );
+                    ).scale(10);
 
                     compositeBuilder.add(headBuilder.build());
                 } else {

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -608,7 +608,7 @@ public class GeneratorCommands {
                 .setContent("Your NBT " + sourceLabel + " has been parsed into a slash command:" + System.lineSeparator() + "```" + System.lineSeparator() + slashCommand + "```");
 
             if (result.isAnimated()) {
-                builder.setFiles(FileUpload.fromData(((GeneratorResult.AnimatedImage) result).toGifBytes(), "parsed_nbt.gif"));
+                builder.setFiles(FileUpload.fromData(((GeneratorResult.AnimatedImage) result).toWebpBytes(), "parsed_nbt.webp"));
             } else {
                 builder.setFiles(FileUpload.fromData(ImageUtil.toFile(result.firstFrame()), "parsed_nbt.png"));
             }
@@ -1287,7 +1287,7 @@ public class GeneratorCommands {
 
     private void sendResult(SlashCommandInteractionEvent event, GeneratorResult result, String fileBaseName) throws IOException {
         if (result.isAnimated()) {
-            event.getHook().editOriginalAttachments(FileUpload.fromData(((GeneratorResult.AnimatedImage) result).toGifBytes(), fileBaseName + ".gif")).queue();
+            event.getHook().editOriginalAttachments(FileUpload.fromData(((GeneratorResult.AnimatedImage) result).toWebpBytes(), fileBaseName + ".webp")).queue();
         } else {
             event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(result.firstFrame()), fileBaseName + ".png")).queue();
         }

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -286,7 +286,7 @@ public class GeneratorCommands {
                     .lore(itemLore)
                     .alpha(alpha)
                     .padding(padding)
-                    .centeredText(false)
+                    .centered(false)
                     .firstLinePadding(true)
                     .renderBorder(true);
 
@@ -454,8 +454,8 @@ public class GeneratorCommands {
             compositeBuilder.add(inventoryBuilder.build());
 
             if (hoveredItemString != null && !hoveredItemString.isBlank()) {
-                TooltipRequest tooltipRequest = TooltipRequest.builder()
-                    .lines(splitLines(TextWrapper.stripActualNewlines(hoveredItemString)))
+                TooltipRequest tooltipRequest = SkyBlockTooltipBuilder.builder()
+                    .lore(TextWrapper.stripActualNewlines(hoveredItemString))
                     .alpha(TooltipRequest.DEFAULT_ALPHA)
                     .padding(TooltipRequest.DEFAULT_PADDING)
                     .firstLinePadding(false)
@@ -507,17 +507,34 @@ public class GeneratorCommands {
         GenerationContext context = DiscordGenerationContext.fromEvent(event, hidden);
 
         try {
-            GeneratorResult result = ENGINE.renderFromNbt(nbtInput, context);
-
-            // Also parse the NBT to extract data for the slash command
             ParsedItem parsedItem = ENGINE.parseNbt(nbtInput);
 
-            // Build a slash command from the parsed data
+            // Build item request
+            ItemRequest.Builder itemBuilder = ItemRequest.builder()
+                .itemId(parsedItem.itemId())
+                .enchanted(parsedItem.enchanted())
+                .scale(2);
+            parsedItem.dyeColor().ifPresent(itemBuilder::dyeColor);
+
+            // Build tooltip from lore
             SkyBlockTooltipBuilder.Builder tooltipBuilder = SkyBlockTooltipBuilder.builder();
             parsedItem.displayName().ifPresent(tooltipBuilder::name);
             if (!parsedItem.lore().isEmpty()) {
                 tooltipBuilder.lore(String.join("\\n", parsedItem.lore()));
             }
+
+            // Handle player heads
+            CompositeRequest.Builder compositeBuilder = CompositeRequest.builder();
+            if (parsedItem.base64Texture().isPresent() && !parsedItem.base64Texture().get().isBlank()) {
+                compositeBuilder.add(PlayerHeadRequest.fromBase64(parsedItem.base64Texture().get())
+                    .scale(2)
+                    .build());
+            } else {
+                compositeBuilder.add(itemBuilder.build());
+            }
+            compositeBuilder.add(tooltipBuilder.build());
+
+            GeneratorResult result = ENGINE.render(compositeBuilder.build(), context);
 
             String slashCommand = tooltipBuilder.buildSlashCommand();
             String commandItemId = parsedItem.itemId();
@@ -535,6 +552,10 @@ public class GeneratorCommands {
 
             if (parsedItem.enchanted()) {
                 slashCommand += " enchanted: True";
+            }
+
+            if (parsedItem.dyeColor().isPresent()) {
+                slashCommand += " color: #" + String.format("%06X", parsedItem.dyeColor().get() & 0xFFFFFF);
             }
 
             // Escape newlines in lore so the slash command is a single line
@@ -650,7 +671,7 @@ public class GeneratorCommands {
                 .alpha(alpha)
                 .padding(padding)
                 .maxLineLength(maxLineLength)
-                .centeredText(centered)
+                .centered(centered)
                 .firstLinePadding(firstLinePadding)
                 .renderBorder(renderBorder)
                 .build();
@@ -742,13 +763,12 @@ public class GeneratorCommands {
         renderBorder = renderBorder != null && renderBorder;
 
         try {
-            TooltipRequest tooltipRequest = TooltipRequest.builder()
-                .lines(splitLines(TextWrapper.stripActualNewlines(text)))
+            TooltipRequest tooltipRequest = SkyBlockTooltipBuilder.builder()
+                .lore(TextWrapper.stripActualNewlines(text))
                 .alpha(alpha)
                 .padding(padding)
                 .maxLineLength(maxLineLength)
-                .bypassMaxLineLength(true)
-                .centeredText(centered)
+                .centered(centered)
                 .firstLinePadding(false)
                 .renderBorder(renderBorder)
                 .build();
@@ -808,8 +828,8 @@ public class GeneratorCommands {
 
         dialogue = String.join("\n", lines);
 
-        TooltipRequest tooltipRequest = TooltipRequest.builder()
-            .lines(splitLines(dialogue))
+        TooltipRequest tooltipRequest = SkyBlockTooltipBuilder.builder()
+            .lore(dialogue)
             .alpha(0)
             .padding(TooltipRequest.DEFAULT_PADDING)
             .firstLinePadding(false)
@@ -898,8 +918,8 @@ public class GeneratorCommands {
 
             dialogue = String.join("\n", lines);
 
-            TooltipRequest tooltipRequest = TooltipRequest.builder()
-                .lines(splitLines(dialogue))
+            TooltipRequest tooltipRequest = SkyBlockTooltipBuilder.builder()
+                .lore(dialogue)
                 .alpha(0)
                 .padding(TooltipRequest.DEFAULT_PADDING)
                 .firstLinePadding(false)

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -279,7 +279,8 @@ public class GeneratorCommands {
             );
 
             try {
-                CompositeRequest.Builder compositeBuilder = CompositeRequest.builder();
+                CompositeRequest.Builder compositeBuilder = CompositeRequest.builder()
+                    .scaleFactor(2);
                 SkyBlockTooltipBuilder.Builder tooltipBuilder = SkyBlockTooltipBuilder.builder()
                     .name("&a" + powerName)
                     .rarity(Rarity.byName("none").orElse(null))
@@ -309,14 +310,13 @@ public class GeneratorCommands {
                     if (itemId.equalsIgnoreCase("player_head")) {
                         PlayerHeadRequest.Builder headBuilder = PlayerHeadRequest.fromBase64(
                             skinValue != null ? skinValue : ""
-                        ).scale(2);
+                        );
 
                         compositeBuilder.add(headBuilder.build());
                     } else {
                         ItemRequest.Builder itemBuilder = ItemRequest.builder()
                             .itemId(itemId)
-                            .enchanted(enchanted)
-                            .scale(2);
+                            .enchanted(enchanted);
 
                         if (color != null && !color.isBlank()) {
                             itemBuilder.color(color);
@@ -437,14 +437,14 @@ public class GeneratorCommands {
         maxLineLength = maxLineLength == null ? TooltipRequest.DEFAULT_MAX_LINE_LENGTH : maxLineLength;
 
         try {
-            CompositeRequest.Builder compositeBuilder = CompositeRequest.builder();
+            CompositeRequest.Builder compositeBuilder = CompositeRequest.builder()
+                .scaleFactor(2);
 
             InventoryRequest.Builder inventoryBuilder = InventoryRequest.builder()
                 .rows(rows)
                 .slotsPerRow(slotsPerRow)
                 .drawBorder(drawBorder)
                 .drawBackground(true)
-                .scale(2)
                 .withInventoryString(inventoryString);
 
             if (containerName != null && !containerName.isBlank()) {
@@ -460,7 +460,6 @@ public class GeneratorCommands {
                     .padding(TooltipRequest.DEFAULT_PADDING)
                     .firstLinePadding(false)
                     .maxLineLength(maxLineLength)
-                    .scaleFactor(2)
                     .renderBorder(true)
                     .build();
 
@@ -512,8 +511,7 @@ public class GeneratorCommands {
             // Build item request
             ItemRequest.Builder itemBuilder = ItemRequest.builder()
                 .itemId(parsedItem.itemId())
-                .enchanted(parsedItem.enchanted())
-                .scale(2);
+                .enchanted(parsedItem.enchanted());
             parsedItem.dyeColor().ifPresent(itemBuilder::dyeColor);
 
             // Build tooltip from lore
@@ -524,10 +522,10 @@ public class GeneratorCommands {
             }
 
             // Handle player heads
-            CompositeRequest.Builder compositeBuilder = CompositeRequest.builder();
+            CompositeRequest.Builder compositeBuilder = CompositeRequest.builder()
+                .scaleFactor(2);
             if (parsedItem.base64Texture().isPresent() && !parsedItem.base64Texture().get().isBlank()) {
                 compositeBuilder.add(PlayerHeadRequest.fromBase64(parsedItem.base64Texture().get())
-                    .scale(2)
                     .build());
             } else {
                 compositeBuilder.add(itemBuilder.build());
@@ -662,7 +660,8 @@ public class GeneratorCommands {
         durability = durability == null ? 100 : durability;
 
         try {
-            CompositeRequest.Builder compositeBuilder = CompositeRequest.builder();
+            CompositeRequest.Builder compositeBuilder = CompositeRequest.builder()
+                .scaleFactor(2);
             TooltipRequest tooltipRequest = SkyBlockTooltipBuilder.builder()
                 .name(itemName)
                 .rarity(Rarity.byName(rarity).orElse(null))
@@ -680,14 +679,13 @@ public class GeneratorCommands {
                 if (itemId.equalsIgnoreCase("player_head")) {
                     PlayerHeadRequest.Builder headBuilder = PlayerHeadRequest.fromBase64(
                         skinValue != null ? skinValue : ""
-                    ).scale(2);
+                    );
 
                     compositeBuilder.add(headBuilder.build());
                 } else {
                     ItemRequest.Builder itemBuilder = ItemRequest.builder()
                         .itemId(itemId)
-                        .enchanted(enchanted)
-                        .scale(2);
+                        .enchanted(enchanted);
 
                     if (durability != null && durability < 100) {
                         itemBuilder.durabilityPercent(durability / 100.0);
@@ -706,7 +704,6 @@ public class GeneratorCommands {
                     .rows(3)
                     .slotsPerRow(3)
                     .drawBorder(renderBorder)
-                    .scale(2)
                     .withInventoryString(recipe)
                     .build()
                 );
@@ -840,11 +837,11 @@ public class GeneratorCommands {
 
         try {
             CompositeRequest.Builder compositeBuilder = CompositeRequest.builder()
+                .scaleFactor(2)
                 .add(tooltipRequest);
 
             if (skinValue != null) {
                 PlayerHeadRequest playerHeadRequest = PlayerHeadRequest.fromBase64(skinValue)
-                    .scale(2)
                     .build();
                 compositeBuilder.add(0, playerHeadRequest);
             }
@@ -929,11 +926,11 @@ public class GeneratorCommands {
                 .build();
 
             CompositeRequest.Builder compositeBuilder = CompositeRequest.builder()
+                .scaleFactor(2)
                 .add(tooltipRequest);
 
             if (skinValue != null) {
                 PlayerHeadRequest playerHeadRequest = PlayerHeadRequest.fromBase64(skinValue)
-                    .scale(2)
                     .build();
                 compositeBuilder.add(0, playerHeadRequest);
             }

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -11,7 +11,10 @@ import net.aerh.jigsaw.api.nbt.ParsedItem;
 import net.aerh.jigsaw.core.generator.CompositeRequest;
 import net.aerh.jigsaw.core.generator.InventoryRequest;
 import net.aerh.jigsaw.core.generator.ItemRequest;
+import net.aerh.jigsaw.core.generator.PlayerBodyRequest;
 import net.aerh.jigsaw.core.generator.PlayerHeadRequest;
+import net.aerh.jigsaw.core.generator.body.ArmorSlot;
+import net.aerh.jigsaw.core.generator.body.SkinModel;
 import net.aerh.jigsaw.core.generator.TooltipRequest;
 import net.aerh.jigsaw.core.text.TextWrapper;
 import net.aerh.jigsaw.exception.JigsawException;
@@ -1128,6 +1131,100 @@ public class GeneratorCommands {
     /**
      * Sends a GeneratorResult to the Discord channel, handling both static and animated images.
      */
+    @SlashCommand(name = BASE_COMMAND, subcommand = "body", description = "Render a full 3D player body with optional armor")
+    public void generateBody(
+        SlashCommandInteractionEvent event,
+        @SlashOption(description = SKIN_VALUE_DESCRIPTION) String skinValue,
+        @SlashOption(description = "Skin model type (classic = thick arms, slim = thin arms)", required = false) String skinModel,
+        @SlashOption(description = "Helmet armor material (e.g., iron, diamond, netherite)", required = false) String helmet,
+        @SlashOption(description = "Chestplate armor material", required = false) String chestplate,
+        @SlashOption(description = "Leggings armor material", required = false) String leggings,
+        @SlashOption(description = "Boots armor material", required = false) String boots,
+        @SlashOption(autocompleteId = "overlay-colors", description = "Leather armor dye color (e.g., red, #FF0000)", required = false) String dyeColor,
+        @SlashOption(autocompleteId = "resource-packs", description = RESOURCE_PACK_DESCRIPTION, required = false) String resourcePack,
+        @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden
+    ) {
+        if (shouldBlockGeneratorCommand(event)) {
+            return;
+        }
+
+        hidden = hidden == null ? getUserAutoHideSetting(event) : hidden;
+        event.deferReply(hidden).complete();
+
+        GenerationContext context = DiscordGenerationContext.fromEvent(event, hidden);
+
+        try {
+            SkinModel model = SkinModel.CLASSIC;
+            if (skinModel != null && skinModel.equalsIgnoreCase("slim")) {
+                model = SkinModel.SLIM;
+            }
+
+            PlayerBodyRequest.Builder bodyBuilder = PlayerBodyRequest.fromBase64(skinValue)
+                    .skinModel(model)
+                    .scale(2);
+
+            // Resolve optional dye color for leather armor
+            Integer resolvedDyeColor = null;
+            if (dyeColor != null && !dyeColor.isBlank()) {
+                resolvedDyeColor = resolveBodyDyeColor(dyeColor);
+            }
+
+            // Add armor pieces by material name
+            addArmorIfPresent(bodyBuilder, ArmorSlot.HELMET, helmet, resolvedDyeColor);
+            addArmorIfPresent(bodyBuilder, ArmorSlot.CHESTPLATE, chestplate, resolvedDyeColor);
+            addArmorIfPresent(bodyBuilder, ArmorSlot.LEGGINGS, leggings, resolvedDyeColor);
+            addArmorIfPresent(bodyBuilder, ArmorSlot.BOOTS, boots, resolvedDyeColor);
+
+            Engine engine = getEngineManager().getEngine(resourcePack);
+            GeneratorResult result = engine.render(bodyBuilder.build(), context);
+            sendResult(event, result, "body");
+            addCommandToUserHistory(event.getUser(), event.getCommandString());
+        } catch (RenderException | ParseException exception) {
+            event.getHook().editOriginal(exception.getMessage()).queue();
+            log.error("Encountered an error while generating a player body", exception);
+        } catch (IOException exception) {
+            event.getHook().editOriginal("An error occurred while generating that body render!").queue();
+            log.error("Encountered an error while generating a player body", exception);
+        } catch (IllegalArgumentException exception) {
+            event.getHook().editOriginal("Invalid input: " + exception.getMessage()).queue();
+        }
+    }
+
+    /**
+     * Adds an armor piece to the body request if the material is specified.
+     * Applies dye color only to leather armor pieces.
+     */
+    private static void addArmorIfPresent(PlayerBodyRequest.Builder builder, ArmorSlot slot,
+                                           String material, Integer dyeColor) {
+        if (material == null || material.isBlank()) return;
+        material = material.toLowerCase(Locale.ROOT).trim();
+
+        if (material.equals("leather") && dyeColor != null) {
+            builder.armor(slot, material, dyeColor);
+        } else {
+            builder.armor(slot, material);
+        }
+    }
+
+    /**
+     * Resolves a dye color from a named color or hex string, matching the item dye system.
+     */
+    private static int resolveBodyDyeColor(String nameOrHex) {
+        nameOrHex = nameOrHex.trim();
+        if (nameOrHex.startsWith("#")) {
+            try {
+                return Integer.parseInt(nameOrHex.substring(1), 16);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid hex color: " + nameOrHex);
+            }
+        }
+        net.aerh.jigsaw.api.text.ChatColor color = net.aerh.jigsaw.api.text.ChatColor.byName(nameOrHex);
+        if (color != null) {
+            return color.color().getRGB() & 0xFFFFFF;
+        }
+        throw new IllegalArgumentException("Unknown color: " + nameOrHex);
+    }
+
     private void sendResult(SlashCommandInteractionEvent event, GeneratorResult result, String fileBaseName) throws IOException {
         if (result.isAnimated()) {
             event.getHook().editOriginalAttachments(FileUpload.fromData(((GeneratorResult.AnimatedImage) result).toGifBytes(), fileBaseName + ".gif")).queue();

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -2,26 +2,24 @@ package net.hypixel.nerdbot.app.command;
 
 import com.google.gson.JsonParseException;
 import lombok.extern.slf4j.Slf4j;
-import net.aerh.imagegenerator.Generator;
-import net.aerh.imagegenerator.builder.ClassBuilder;
-import net.aerh.imagegenerator.context.GenerationContext;
-import net.aerh.imagegenerator.data.PowerStrength;
-import net.aerh.imagegenerator.data.Rarity;
-import net.aerh.imagegenerator.data.Stat;
-import net.aerh.imagegenerator.exception.GeneratorException;
-import net.aerh.imagegenerator.exception.NbtParseException;
-import net.aerh.imagegenerator.exception.TooManyTexturesException;
-import net.aerh.imagegenerator.image.GeneratorImageBuilder;
-import net.aerh.imagegenerator.image.MinecraftTooltip;
-import net.aerh.imagegenerator.impl.MinecraftInventoryGenerator;
-import net.aerh.imagegenerator.impl.MinecraftItemGenerator;
-import net.aerh.imagegenerator.impl.MinecraftNbtParser;
-import net.aerh.imagegenerator.impl.MinecraftPlayerHeadGenerator;
-import net.aerh.imagegenerator.impl.tooltip.MinecraftTooltipGenerator;
-import net.aerh.imagegenerator.item.GeneratedObject;
-import net.aerh.imagegenerator.spritesheet.OverlayLoader;
-import net.aerh.imagegenerator.spritesheet.Spritesheet;
-import net.aerh.imagegenerator.text.wrapper.TextWrapper;
+import net.aerh.jigsaw.api.Engine;
+import net.aerh.jigsaw.api.generator.GenerationContext;
+import net.aerh.jigsaw.api.generator.GeneratorResult;
+import net.aerh.jigsaw.api.nbt.ParsedItem;
+import net.aerh.jigsaw.core.generator.CompositeRequest;
+import net.aerh.jigsaw.core.generator.InventoryRequest;
+import net.aerh.jigsaw.core.generator.ItemRequest;
+import net.aerh.jigsaw.core.generator.PlayerHeadRequest;
+import net.aerh.jigsaw.core.generator.TooltipRequest;
+import net.aerh.jigsaw.core.text.TextWrapper;
+import net.aerh.jigsaw.exception.JigsawException;
+import net.aerh.jigsaw.exception.ParseException;
+import net.aerh.jigsaw.exception.RenderException;
+import net.aerh.jigsaw.skyblock.data.PowerStrength;
+import net.aerh.jigsaw.skyblock.data.Rarity;
+import net.aerh.jigsaw.skyblock.data.Stat;
+import net.aerh.jigsaw.skyblock.tooltip.SkyBlockTooltipBuilder;
+import net.aerh.jigsaw.skyblock.tooltip.TooltipSide;
 import net.aerh.slashcommands.api.annotations.SlashAutocompleteHandler;
 import net.aerh.slashcommands.api.annotations.SlashCommand;
 import net.aerh.slashcommands.api.annotations.SlashOption;
@@ -62,7 +60,6 @@ public class GeneratorCommands {
     public static final String BASE_COMMAND = "gen";
 
     private static final String ITEM_DESCRIPTION = "The ID of the item to display";
-    private static final String EXTRA_DATA_DESCRIPTION = "The extra modifiers to change the item";
     private static final String ENCHANTED_DESCRIPTION = "Whether or not the item should be enchanted";
     private static final String NAME_DESCRIPTION = "The name of the item";
     private static final String RARITY_DESCRIPTION = "The rarity of the item";
@@ -91,11 +88,12 @@ public class GeneratorCommands {
 
     private static final boolean AUTO_HIDE_ON_ERROR = true;
 
+    private static final Engine ENGINE = Engine.builder().build();
+
     @SlashCommand(name = BASE_COMMAND, subcommand = "display", description = "Display an item")
     public void generateItem(
         SlashCommandInteractionEvent event,
         @SlashOption(autocompleteId = "item-names", description = ITEM_DESCRIPTION) String itemId,
-        @SlashOption(description = EXTRA_DATA_DESCRIPTION, required = false) String data,
         @SlashOption(autocompleteId = "overlay-colors", description = COLOR_DESCRIPTION, required = false) String color,
         @SlashOption(description = ENCHANTED_DESCRIPTION, required = false) Boolean enchanted,
         @SlashOption(description = "If the item should look as if it being hovered over", required = false) Boolean hoverEffect,
@@ -118,38 +116,32 @@ public class GeneratorCommands {
         durability = durability == null ? 100 : durability;
 
         try {
-            GeneratorImageBuilder item = new GeneratorImageBuilder().withContext(context);
+            CompositeRequest.Builder compositeBuilder = CompositeRequest.builder();
 
             if (itemId.equalsIgnoreCase("player_head") && skinValue != null) {
-                item.addGenerator(new MinecraftPlayerHeadGenerator.Builder()
-                    .withSkin(skinValue)
-                    .build());
+                compositeBuilder.add(PlayerHeadRequest.fromBase64(skinValue).scale(10).build());
             } else {
-                MinecraftItemGenerator.Builder itemBuilder = new MinecraftItemGenerator.Builder()
-                    .withItem(itemId)
-                    .withData(data)
-                    .withColor(color)
-                    .isEnchanted(enchanted)
-                    .withHoverEffect(hoverEffect)
-                    .isBigImage();
+                ItemRequest.Builder itemBuilder = ItemRequest.builder()
+                    .itemId(itemId)
+                    .enchanted(enchanted)
+                    .hovered(hoverEffect)
+                    .scale(10);
 
-                if (durability != null) {
-                    itemBuilder.withDurability(durability);
+                if (durability != null && durability < 100) {
+                    itemBuilder.durabilityPercent(durability / 100.0);
                 }
 
-                item.addGenerator(itemBuilder.build());
+                if (color != null && !color.isBlank()) {
+                    itemBuilder.color(color);
+                }
+
+                compositeBuilder.add(itemBuilder.build());
             }
 
-            GeneratedObject generatedObject = item.build();
-
-            if (generatedObject.isAnimated()) {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(generatedObject.getGifData(), "item.gif")).queue();
-            } else {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "item.png")).queue();
-            }
-
+            GeneratorResult result = ENGINE.render(compositeBuilder.build(), context);
+            sendResult(event, result, "item");
             addCommandToUserHistory(event.getUser(), event.getCommandString());
-        } catch (GeneratorException exception) {
+        } catch (RenderException | ParseException exception) {
             event.getHook().editOriginal(exception.getMessage()).queue();
             log.error("Encountered an error while generating an item display", exception);
         } catch (IOException exception) {
@@ -186,8 +178,8 @@ public class GeneratorCommands {
 
         GenerationContext context = DiscordGenerationContext.fromEvent(event, hidden);
 
-        alpha = alpha == null ? MinecraftTooltip.DEFAULT_ALPHA : alpha;
-        padding = padding == null ? MinecraftTooltip.DEFAULT_PADDING : padding;
+        alpha = alpha == null ? TooltipRequest.DEFAULT_ALPHA : alpha;
+        padding = padding == null ? TooltipRequest.DEFAULT_PADDING : padding;
         enchanted = enchanted != null && enchanted;
 
         Function<String, Map<String, Integer>> parseStatsToMap = stats -> {
@@ -207,7 +199,7 @@ public class GeneratorCommands {
                 String[] stat = entry.split(":");
 
                 if (stat.length != 2 || stat[0].trim().isEmpty() || stat[1].trim().isEmpty()) {
-                    throw new GeneratorException("Stat `" + entry + "` is using an invalid format. Use `stat:value` and separate multiple entries with commas (e.g., `health:-50,damage:10`)");
+                    throw new IllegalArgumentException("Stat `" + entry + "` is using an invalid format. Use `stat:value` and separate multiple entries with commas (e.g., `health:-50,damage:10`)");
                 }
 
                 String statName = stat[0].trim();
@@ -217,7 +209,7 @@ public class GeneratorCommands {
                 try {
                     statValue = Integer.parseInt(stat[1].trim());
                 } catch (NumberFormatException e) {
-                    throw new GeneratorException("Invalid number for stat `" + statName + "`: " + stat[1].trim() + ". Use `stat:value` (e.g., `health:-50`)");
+                    throw new IllegalArgumentException("Invalid number for stat `" + statName + "`: " + stat[1].trim() + ". Use `stat:value` (e.g., `health:-50`)");
                 }
 
                 map.merge(statName, statValue, Integer::sum);
@@ -233,13 +225,13 @@ public class GeneratorCommands {
             for (Map.Entry<String, Integer> entry : scalingStatsMap.entrySet()) {
                 String statName = entry.getKey();
                 Integer basePower = entry.getValue();
-                Stat stat = Stat.byName(statName);
+                Optional<Stat> stat = Stat.byName(statName);
 
-                if (stat == null) {
-                    throw new GeneratorException("`" + statName + "` is not a valid stat");
+                if (stat.isEmpty()) {
+                    throw new IllegalArgumentException("`" + statName + "` is not a valid stat");
                 }
 
-                scalingStatsFormatted.append(String.format("%%%%%s:%s%%%%\\n", statName, StringUtils.COMMA_SEPARATED_FORMAT.format(calculatePowerStoneStat(stat, basePower, magicalPower))));
+                scalingStatsFormatted.append(String.format("%%%%%s:%s%%%%\\n", statName, StringUtils.COMMA_SEPARATED_FORMAT.format(calculatePowerStoneStat(stat.get(), basePower, magicalPower))));
             }
 
             if (!scalingStatsFormatted.isEmpty()) {
@@ -254,10 +246,10 @@ public class GeneratorCommands {
             for (Map.Entry<String, Integer> entry : bonusStats.entrySet()) {
                 String statName = entry.getKey();
                 Integer statAmount = entry.getValue();
-                Stat stat = Stat.byName(statName);
+                Optional<Stat> stat = Stat.byName(statName);
 
-                if (stat == null) {
-                    throw new GeneratorException("'" + statName + "' is not a valid stat");
+                if (stat.isEmpty()) {
+                    throw new IllegalArgumentException("'" + statName + "' is not a valid stat");
                 }
 
                 bonusStatsFormatted.append(String.format("%%%%%s:%s%%%%\\n", statName, StringUtils.COMMA_SEPARATED_FORMAT.format(statAmount)));
@@ -278,27 +270,28 @@ public class GeneratorCommands {
                     "\\n" +
                     (selected == null || selected ? "&aPower is selected!" : "&eClick to select power!");
 
+            Optional<PowerStrength> resolvedPowerStrength = PowerStrength.byName(powerStrength);
             String itemLore = String.format(itemLoreTemplate,
-                PowerStrength.byName(powerStrength) == null ? powerStrength : PowerStrength.byName(powerStrength).getFormattedDisplay(),
+                resolvedPowerStrength.isEmpty() ? powerStrength : resolvedPowerStrength.get().formattedDisplay(),
                 scalingStatsFormatted,
                 bonusStatsFormatted,
                 StringUtils.COMMA_SEPARATED_FORMAT.format(magicalPower)
             );
 
             try {
-                GeneratorImageBuilder generatorImageBuilder = new GeneratorImageBuilder().withContext(context);
-                MinecraftTooltipGenerator.Builder tooltipGenerator = new MinecraftTooltipGenerator.Builder()
-                    .withName("&a" + powerName)
-                    .withRarity(Rarity.byName("none"))
-                    .withItemLore(itemLore)
-                    .withAlpha(alpha)
-                    .withPadding(padding)
-                    .isTextCentered(false)
-                    .hasFirstLinePadding(true)
-                    .withRenderBorder(true);
+                CompositeRequest.Builder compositeBuilder = CompositeRequest.builder();
+                SkyBlockTooltipBuilder.Builder tooltipBuilder = SkyBlockTooltipBuilder.builder()
+                    .name("&a" + powerName)
+                    .rarity(Rarity.byName("none").orElse(null))
+                    .lore(itemLore)
+                    .alpha(alpha)
+                    .padding(padding)
+                    .centeredText(false)
+                    .firstLinePadding(true)
+                    .renderBorder(true);
 
                 if (includeGenCommand != null && includeGenCommand) {
-                    String slashCommand = tooltipGenerator.buildSlashCommand();
+                    String slashCommand = tooltipBuilder.buildSlashCommand();
 
                     // I hate this, but it works *for now*. Should probably replace it later
                     if (itemId != null && !itemId.isBlank()) {
@@ -314,42 +307,37 @@ public class GeneratorCommands {
 
                 if (itemId != null) {
                     if (itemId.equalsIgnoreCase("player_head")) {
-                        MinecraftPlayerHeadGenerator.Builder generator = new MinecraftPlayerHeadGenerator.Builder()
-                            .withScale(-2);
+                        PlayerHeadRequest.Builder headBuilder = PlayerHeadRequest.fromBase64(
+                            skinValue != null ? skinValue : ""
+                        ).scale(2);
 
-                        if (skinValue != null) {
-                            generator.withSkin(skinValue);
+                        compositeBuilder.add(headBuilder.build());
+                    } else {
+                        ItemRequest.Builder itemBuilder = ItemRequest.builder()
+                            .itemId(itemId)
+                            .enchanted(enchanted)
+                            .scale(2);
+
+                        if (color != null && !color.isBlank()) {
+                            itemBuilder.color(color);
                         }
 
-                        generatorImageBuilder.addGenerator(generator.build());
-                    } else {
-                        generatorImageBuilder.addGenerator(new MinecraftItemGenerator.Builder()
-                            .withItem(itemId)
-                            .withColor(color)
-                            .isEnchanted(enchanted)
-                            .isBigImage()
-                            .build());
+                        compositeBuilder.add(itemBuilder.build());
                     }
                 }
 
-                generatorImageBuilder.addGenerator(tooltipGenerator.build());
-                GeneratedObject generatedObject = generatorImageBuilder.build();
-
-                if (generatedObject.isAnimated()) {
-                    event.getHook().editOriginalAttachments(FileUpload.fromData(generatedObject.getGifData(), "powerstone.gif")).queue();
-                } else {
-                    event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "powerstone.png")).queue();
-                }
-
+                compositeBuilder.add(tooltipBuilder.build());
+                GeneratorResult result = ENGINE.render(compositeBuilder.build(), context);
+                sendResult(event, result, "powerstone");
                 addCommandToUserHistory(event.getUser(), event.getCommandString());
-            } catch (GeneratorException | IllegalArgumentException exception) {
+            } catch (RenderException | ParseException | IllegalArgumentException exception) {
                 event.getHook().editOriginal(exception.getMessage()).queue();
                 log.error("Encountered an error while generating a Power Stone", exception);
             } catch (IOException exception) {
                 event.getHook().editOriginal("An error occurred while generating that Power Stone!").queue();
                 log.error("Encountered an error while generating a Power Stone", exception);
             }
-        } catch (GeneratorException exception) {
+        } catch (IllegalArgumentException exception) {
             event.getHook().editOriginal(exception.getMessage()).queue();
             log.error("Encountered an error while generating a Power Stone", exception);
         }
@@ -365,7 +353,7 @@ public class GeneratorCommands {
 
         event.deferReply(hidden).complete();
 
-        List<Map.Entry<String, BufferedImage>> results = Spritesheet.searchForTexture(itemId);
+        List<Map.Entry<String, BufferedImage>> results = ENGINE.sprites().searchAll(itemId);
 
         if (results.isEmpty()) {
             event.getHook().editOriginal("No results found for that item!").queue();
@@ -402,19 +390,19 @@ public class GeneratorCommands {
         renderBackground = renderBackground == null || renderBackground;
 
         try {
-            GeneratedObject generatedObject = new GeneratorImageBuilder().withContext(context)
-                .addGenerator(new MinecraftInventoryGenerator.Builder()
-                    .withRows(3)
-                    .withSlotsPerRow(3)
-                    .drawBorder(false)
-                    .drawBackground(renderBackground)
-                    .withInventoryString(recipe)
-                    .build())
+            InventoryRequest inventoryRequest = InventoryRequest.builder()
+                .rows(3)
+                .slotsPerRow(3)
+                .drawBorder(false)
+                .drawBackground(renderBackground)
+                .withInventoryString(recipe)
                 .build();
 
-            event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "recipe.png")).queue();
+            GeneratorResult result = ENGINE.render(inventoryRequest, context);
+
+            event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(result.firstFrame()), "recipe.png")).queue();
             addCommandToUserHistory(event.getUser(), event.getCommandString());
-        } catch (GeneratorException exception) {
+        } catch (RenderException | ParseException exception) {
             event.getHook().editOriginal(exception.getMessage()).queue();
             log.error("Encountered an error while generating a recipe", exception);
         } catch (IOException exception) {
@@ -446,45 +434,43 @@ public class GeneratorCommands {
         GenerationContext context = DiscordGenerationContext.fromEvent(event, hidden);
 
         drawBorder = drawBorder == null || drawBorder;
-        boolean animateGlint = DiscordBotEnvironment.getBot().getConfig().getGeneratorConfig().getInventory().isAnimateGlint();
-        maxLineLength = maxLineLength == null ? MinecraftTooltipGenerator.DEFAULT_MAX_LINE_LENGTH : maxLineLength;
+        maxLineLength = maxLineLength == null ? TooltipRequest.DEFAULT_MAX_LINE_LENGTH : maxLineLength;
 
         try {
-            GeneratorImageBuilder generatedObject = new GeneratorImageBuilder().withContext(context)
-                .addGenerator(new MinecraftInventoryGenerator.Builder()
-                    .withRows(rows)
-                    .withSlotsPerRow(slotsPerRow)
-                    .drawBorder(drawBorder)
-                    .drawBackground(true)
-                    .withAnimateGlint(animateGlint)
-                    .withContainerTitle(containerName)
-                    .withInventoryString(inventoryString)
-                    .build());
+            CompositeRequest.Builder compositeBuilder = CompositeRequest.builder();
+
+            InventoryRequest.Builder inventoryBuilder = InventoryRequest.builder()
+                .rows(rows)
+                .slotsPerRow(slotsPerRow)
+                .drawBorder(drawBorder)
+                .drawBackground(true)
+                .scale(2)
+                .withInventoryString(inventoryString);
+
+            if (containerName != null && !containerName.isBlank()) {
+                inventoryBuilder.title(containerName);
+            }
+
+            compositeBuilder.add(inventoryBuilder.build());
 
             if (hoveredItemString != null && !hoveredItemString.isBlank()) {
-                MinecraftTooltipGenerator tooltipGenerator = new MinecraftTooltipGenerator.Builder()
-                    .withItemLore(TextWrapper.stripActualNewlines(hoveredItemString))
-                    .withAlpha(MinecraftTooltip.DEFAULT_ALPHA)
-                    .withPadding(MinecraftTooltip.DEFAULT_PADDING)
-                    .hasFirstLinePadding(false)
-                    .withMaxLineLength(maxLineLength)
-                    .withScaleFactor(Math.min(2, MinecraftInventoryGenerator.getScaleFactor()))
-                    .withRenderBorder(true)
+                TooltipRequest tooltipRequest = TooltipRequest.builder()
+                    .lines(splitLines(TextWrapper.stripActualNewlines(hoveredItemString)))
+                    .alpha(TooltipRequest.DEFAULT_ALPHA)
+                    .padding(TooltipRequest.DEFAULT_PADDING)
+                    .firstLinePadding(false)
+                    .maxLineLength(maxLineLength)
+                    .scaleFactor(2)
+                    .renderBorder(true)
                     .build();
 
-                generatedObject.addGenerator(tooltipGenerator);
+                compositeBuilder.add(tooltipRequest);
             }
 
-            GeneratedObject finalObject = generatedObject.build();
-
-            if (finalObject.isAnimated()) {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(finalObject.getGifData(), "inventory.gif")).queue();
-            } else {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(finalObject.getImage()), "inventory.png")).queue();
-            }
-
+            GeneratorResult result = ENGINE.render(compositeBuilder.build(), context);
+            sendResult(event, result, "inventory");
             addCommandToUserHistory(event.getUser(), event.getCommandString());
-        } catch (GeneratorException exception) {
+        } catch (RenderException | ParseException exception) {
             event.getHook().editOriginal(exception.getMessage()).queue();
             log.error("Encountered an error while generating an inventory", exception);
         } catch (IOException exception) {
@@ -521,27 +507,20 @@ public class GeneratorCommands {
         GenerationContext context = DiscordGenerationContext.fromEvent(event, hidden);
 
         try {
-            MinecraftNbtParser.ParsedNbt parsedNbt = MinecraftNbtParser.parse(nbtInput);
-            GeneratorImageBuilder generatorImageBuilder = new GeneratorImageBuilder().withContext(context);
+            GeneratorResult result = ENGINE.renderFromNbt(nbtInput, context);
 
-            parsedNbt.getGenerators().forEach(generator -> {
-                generatorImageBuilder.addGenerator(generator.build());
-            });
+            // Also parse the NBT to extract data for the slash command
+            ParsedItem parsedItem = ENGINE.parseNbt(nbtInput);
 
-            GeneratedObject generatedObject = generatorImageBuilder.build();
-
-            Optional<ClassBuilder<? extends Generator>> tooltipGenerator = parsedNbt.getGenerators()
-                .stream()
-                .filter(gen -> gen instanceof MinecraftTooltipGenerator.Builder)
-                .findFirst();
-            if (tooltipGenerator.isEmpty()) {
-                event.getHook().editOriginal("An error occurred.").queue();
-                log.error("An error occurred while parsing the NBT string, there doesnt seem to be a tooltip but no nbt parser exception occurred.");
-                return;
+            // Build a slash command from the parsed data
+            SkyBlockTooltipBuilder.Builder tooltipBuilder = SkyBlockTooltipBuilder.builder();
+            parsedItem.displayName().ifPresent(tooltipBuilder::name);
+            if (!parsedItem.lore().isEmpty()) {
+                tooltipBuilder.lore(String.join("\\n", parsedItem.lore()));
             }
 
-            String slashCommand = ((MinecraftTooltipGenerator.Builder) tooltipGenerator.get()).buildSlashCommand();
-            String commandItemId = parsedNbt.getParsedItemId();
+            String slashCommand = tooltipBuilder.buildSlashCommand();
+            String commandItemId = parsedItem.itemId();
 
             if (commandItemId != null && !commandItemId.isBlank()) {
                 if (commandItemId.startsWith("minecraft:")) {
@@ -550,11 +529,11 @@ public class GeneratorCommands {
                 slashCommand += " item_id: " + commandItemId;
             }
 
-            if (parsedNbt.getBase64Texture() != null && !parsedNbt.getBase64Texture().isBlank()) {
-                slashCommand += " skin_value: " + parsedNbt.getBase64Texture();
+            if (parsedItem.base64Texture().isPresent() && !parsedItem.base64Texture().get().isBlank()) {
+                slashCommand += " skin_value: " + parsedItem.base64Texture().get();
             }
 
-            if (parsedNbt.isEnchanted()) {
+            if (parsedItem.enchanted()) {
                 slashCommand += " enchanted: True";
             }
 
@@ -565,10 +544,10 @@ public class GeneratorCommands {
             MessageEditBuilder builder = new MessageEditBuilder()
                 .setContent("Your NBT " + sourceLabel + " has been parsed into a slash command:" + System.lineSeparator() + "```" + System.lineSeparator() + slashCommand + "```");
 
-            if (generatedObject.isAnimated()) {
-                builder.setFiles(FileUpload.fromData(generatedObject.getGifData(), "parsed_nbt.gif"));
+            if (result.isAnimated()) {
+                builder.setFiles(FileUpload.fromData(((GeneratorResult.AnimatedImage) result).toGifBytes(), "parsed_nbt.gif"));
             } else {
-                builder.setFiles(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "parsed_nbt.png"));
+                builder.setFiles(FileUpload.fromData(ImageUtil.toFile(result.firstFrame()), "parsed_nbt.png"));
             }
 
             event.getHook().editOriginal(builder.build()).queue();
@@ -578,9 +557,7 @@ public class GeneratorCommands {
         } catch (IOException exception) {
             event.getHook().editOriginal("An error occurred while parsing the NBT!").queue();
             log.error("Encountered an error while parsing NBT", exception);
-        } catch (TooManyTexturesException exception) {
-            event.getHook().editOriginal(exception.getMessage()).queue();
-        } catch (GeneratorException | NbtParseException exception) {
+        } catch (RenderException | ParseException exception) {
             event.getHook().editOriginal(exception.getMessage()).queue();
             log.error("Encountered an error while parsing NBT", exception);
         }
@@ -654,86 +631,81 @@ public class GeneratorCommands {
 
         type = type == null ? "" : type;
         rarity = rarity == null ? "none" : rarity;
-        alpha = alpha == null ? MinecraftTooltip.DEFAULT_ALPHA : alpha;
-        padding = padding == null ? MinecraftTooltip.DEFAULT_PADDING : padding;
+        alpha = alpha == null ? TooltipRequest.DEFAULT_ALPHA : alpha;
+        padding = padding == null ? TooltipRequest.DEFAULT_PADDING : padding;
         centered = centered != null && centered;
         enchanted = enchanted != null && enchanted;
         firstLinePadding = firstLinePadding == null || firstLinePadding;
-        maxLineLength = maxLineLength == null ? MinecraftTooltipGenerator.DEFAULT_MAX_LINE_LENGTH : maxLineLength;
+        maxLineLength = maxLineLength == null ? TooltipRequest.DEFAULT_MAX_LINE_LENGTH : maxLineLength;
         renderBorder = renderBorder == null || renderBorder;
         durability = durability == null ? 100 : durability;
 
         try {
-            GeneratorImageBuilder generatorImageBuilder = new GeneratorImageBuilder().withContext(context);
-            MinecraftTooltipGenerator tooltipGenerator = new MinecraftTooltipGenerator.Builder()
-                .withName(itemName)
-                .withRarity(Rarity.byName(rarity))
-                .withItemLore(TextWrapper.stripActualNewlines(itemLore))
-                .withType(type)
-                .withAlpha(alpha)
-                .withPadding(padding)
-                .withMaxLineLength(maxLineLength)
-                .isTextCentered(centered)
-                .hasFirstLinePadding(firstLinePadding)
-                .withRenderBorder(renderBorder)
+            CompositeRequest.Builder compositeBuilder = CompositeRequest.builder();
+            TooltipRequest tooltipRequest = SkyBlockTooltipBuilder.builder()
+                .name(itemName)
+                .rarity(Rarity.byName(rarity).orElse(null))
+                .lore(TextWrapper.stripActualNewlines(itemLore))
+                .type(type)
+                .alpha(alpha)
+                .padding(padding)
+                .maxLineLength(maxLineLength)
+                .centeredText(centered)
+                .firstLinePadding(firstLinePadding)
+                .renderBorder(renderBorder)
                 .build();
 
             if (itemId != null) {
                 if (itemId.equalsIgnoreCase("player_head")) {
-                    MinecraftPlayerHeadGenerator.Builder generator = new MinecraftPlayerHeadGenerator.Builder()
-                        .withScale(-2);
+                    PlayerHeadRequest.Builder headBuilder = PlayerHeadRequest.fromBase64(
+                        skinValue != null ? skinValue : ""
+                    ).scale(2);
 
-                    if (skinValue != null) {
-                        generator.withSkin(skinValue);
-                    }
-
-                    generatorImageBuilder.addGenerator(generator.build());
+                    compositeBuilder.add(headBuilder.build());
                 } else {
-                    MinecraftItemGenerator.Builder itemBuilder = new MinecraftItemGenerator.Builder()
-                        .withItem(itemId)
-                        .withColor(color)
-                        .isEnchanted(enchanted)
-                        .isBigImage();
+                    ItemRequest.Builder itemBuilder = ItemRequest.builder()
+                        .itemId(itemId)
+                        .enchanted(enchanted)
+                        .scale(2);
 
-                    if (durability != null) {
-                        itemBuilder.withDurability(durability);
+                    if (durability != null && durability < 100) {
+                        itemBuilder.durabilityPercent(durability / 100.0);
                     }
 
-                    generatorImageBuilder.addGenerator(itemBuilder.build());
+                    if (color != null && !color.isBlank()) {
+                        itemBuilder.color(color);
+                    }
+
+                    compositeBuilder.add(itemBuilder.build());
                 }
             }
 
             if (recipe != null && !recipe.isBlank()) {
-                generatorImageBuilder.addGenerator(0, new MinecraftInventoryGenerator.Builder()
-                    .withRows(3)
-                    .withSlotsPerRow(3)
+                compositeBuilder.add(0, InventoryRequest.builder()
+                    .rows(3)
+                    .slotsPerRow(3)
                     .drawBorder(renderBorder)
+                    .scale(2)
                     .withInventoryString(recipe)
                     .build()
-                ).build();
+                );
             }
 
             try {
-                if (tooltipSide != null && MinecraftTooltipGenerator.TooltipSide.valueOf(tooltipSide.toUpperCase()) == MinecraftTooltipGenerator.TooltipSide.LEFT) {
-                    generatorImageBuilder.addGenerator(0, tooltipGenerator);
+                if (tooltipSide != null && TooltipSide.valueOf(tooltipSide.toUpperCase()) == TooltipSide.LEFT) {
+                    compositeBuilder.add(0, tooltipRequest);
                 } else {
-                    generatorImageBuilder.addGenerator(tooltipGenerator);
+                    compositeBuilder.add(tooltipRequest);
                 }
             } catch (IllegalArgumentException ignored) {
                 // Fallback to default side if an invalid value was provided
-                generatorImageBuilder.addGenerator(tooltipGenerator);
+                compositeBuilder.add(tooltipRequest);
             }
 
-            GeneratedObject generatedObject = generatorImageBuilder.build();
-
-            if (generatedObject.isAnimated()) {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(generatedObject.getGifData(), "item.gif")).queue();
-            } else {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "item.png")).queue();
-            }
-
+            GeneratorResult result = ENGINE.render(compositeBuilder.build(), context);
+            sendResult(event, result, "item");
             addCommandToUserHistory(event.getUser(), event.getCommandString());
-        } catch (GeneratorException | IllegalArgumentException exception) {
+        } catch (RenderException | ParseException | IllegalArgumentException exception) {
             event.getHook().editOriginal(exception.getMessage()).queue();
             log.error("Encountered an error while generating an item display", exception);
         } catch (IOException exception) {
@@ -765,33 +737,26 @@ public class GeneratorCommands {
 
         centered = centered != null && centered;
         alpha = alpha == null ? 0 : alpha;
-        padding = padding == null ? MinecraftTooltip.DEFAULT_PADDING : padding;
-        maxLineLength = maxLineLength == null ? MinecraftTooltipGenerator.DEFAULT_MAX_LINE_LENGTH * 3 : maxLineLength;
+        padding = padding == null ? TooltipRequest.DEFAULT_PADDING : padding;
+        maxLineLength = maxLineLength == null ? TooltipRequest.DEFAULT_MAX_LINE_LENGTH * 3 : maxLineLength;
         renderBorder = renderBorder != null && renderBorder;
 
         try {
-            GeneratorImageBuilder generatorImageBuilder = new GeneratorImageBuilder().withContext(context);
-            MinecraftTooltipGenerator tooltipGenerator = new MinecraftTooltipGenerator.Builder()
-                .withItemLore(TextWrapper.stripActualNewlines(text))
-                .withAlpha(alpha)
-                .withPadding(padding)
-                .withMaxLineLength(maxLineLength)
-                .isTextCentered(centered)
-                .hasFirstLinePadding(false)
-                .withRenderBorder(renderBorder)
+            TooltipRequest tooltipRequest = TooltipRequest.builder()
+                .lines(splitLines(TextWrapper.stripActualNewlines(text)))
+                .alpha(alpha)
+                .padding(padding)
+                .maxLineLength(maxLineLength)
+                .bypassMaxLineLength(true)
+                .centeredText(centered)
+                .firstLinePadding(false)
+                .renderBorder(renderBorder)
                 .build();
 
-            generatorImageBuilder.addGenerator(tooltipGenerator);
-            GeneratedObject generatedObject = generatorImageBuilder.build();
-
-            if (generatedObject.isAnimated()) {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(generatedObject.getGifData(), "text.gif")).queue();
-            } else {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "text.png")).queue();
-            }
-
+            GeneratorResult result = ENGINE.render(tooltipRequest, context);
+            sendResult(event, result, "text");
             addCommandToUserHistory(event.getUser(), event.getCommandString());
-        } catch (GeneratorException exception) {
+        } catch (RenderException | ParseException exception) {
             event.getHook().editOriginal(exception.getMessage()).queue();
             log.error("Encountered an error while generating text", exception);
         } catch (IOException exception) {
@@ -843,37 +808,31 @@ public class GeneratorCommands {
 
         dialogue = String.join("\n", lines);
 
-        MinecraftTooltipGenerator.Builder tooltipGenerator = new MinecraftTooltipGenerator.Builder()
-            .withItemLore(dialogue)
-            .withAlpha(0)
-            .withPadding(MinecraftTooltip.DEFAULT_PADDING)
-            .hasFirstLinePadding(false)
-            .withMaxLineLength(maxLineLength)
-            .withRenderBorder(renderBackground)
-            .bypassMaxLineLength(true);
+        TooltipRequest tooltipRequest = TooltipRequest.builder()
+            .lines(splitLines(dialogue))
+            .alpha(0)
+            .padding(TooltipRequest.DEFAULT_PADDING)
+            .firstLinePadding(false)
+            .maxLineLength(maxLineLength)
+            .bypassMaxLineLength(true)
+            .renderBorder(renderBackground)
+            .build();
 
         try {
-            GeneratorImageBuilder generatorImageBuilder = new GeneratorImageBuilder().withContext(context)
-                .addGenerator(tooltipGenerator.build());
+            CompositeRequest.Builder compositeBuilder = CompositeRequest.builder()
+                .add(tooltipRequest);
 
             if (skinValue != null) {
-                MinecraftPlayerHeadGenerator playerHeadGenerator = new MinecraftPlayerHeadGenerator.Builder()
-                    .withSkin(skinValue)
-                    .withScale(-2)
+                PlayerHeadRequest playerHeadRequest = PlayerHeadRequest.fromBase64(skinValue)
+                    .scale(2)
                     .build();
-                generatorImageBuilder.addGenerator(0, playerHeadGenerator);
+                compositeBuilder.add(0, playerHeadRequest);
             }
 
-            GeneratedObject generatedObject = generatorImageBuilder.build();
-
-            if (generatedObject.isAnimated()) {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(generatedObject.getGifData(), "dialogue.gif")).queue();
-            } else {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "dialogue.png")).queue();
-            }
-
+            GeneratorResult result = ENGINE.render(compositeBuilder.build(), context);
+            sendResult(event, result, "dialogue");
             addCommandToUserHistory(event.getUser(), event.getCommandString());
-        } catch (GeneratorException exception) {
+        } catch (RenderException | ParseException exception) {
             event.getHook().editOriginal(exception.getMessage()).queue();
             log.error("Encountered an error while generating dialogue", exception);
         } catch (IOException exception) {
@@ -933,42 +892,39 @@ public class GeneratorCommands {
                         }
                     }
                 } catch (NumberFormatException exception) {
-                    throw new GeneratorException("Invalid NPC name index found in dialogue: " + split[0] + " (line " + (i + 1) + ")");
+                    throw new IllegalArgumentException("Invalid NPC name index found in dialogue: " + split[0] + " (line " + (i + 1) + ")");
                 }
             }
 
             dialogue = String.join("\n", lines);
 
-            MinecraftTooltipGenerator.Builder tooltipGenerator = new MinecraftTooltipGenerator.Builder()
-                .withItemLore(dialogue)
-                .withAlpha(0)
-                .withPadding(MinecraftTooltip.DEFAULT_PADDING)
-                .hasFirstLinePadding(false)
-                .withMaxLineLength(maxLineLength)
-                .withRenderBorder(renderBackground)
-                .bypassMaxLineLength(true);
+            TooltipRequest tooltipRequest = TooltipRequest.builder()
+                .lines(splitLines(dialogue))
+                .alpha(0)
+                .padding(TooltipRequest.DEFAULT_PADDING)
+                .firstLinePadding(false)
+                .maxLineLength(maxLineLength)
+                .bypassMaxLineLength(true)
+                .renderBorder(renderBackground)
+                .build();
 
-            GeneratorImageBuilder generatorImageBuilder = new GeneratorImageBuilder().withContext(context)
-                .addGenerator(tooltipGenerator.build());
+            CompositeRequest.Builder compositeBuilder = CompositeRequest.builder()
+                .add(tooltipRequest);
 
             if (skinValue != null) {
-                MinecraftPlayerHeadGenerator playerHeadGenerator = new MinecraftPlayerHeadGenerator.Builder()
-                    .withSkin(skinValue)
-                    .withScale(-2)
+                PlayerHeadRequest playerHeadRequest = PlayerHeadRequest.fromBase64(skinValue)
+                    .scale(2)
                     .build();
-                generatorImageBuilder.addGenerator(0, playerHeadGenerator);
+                compositeBuilder.add(0, playerHeadRequest);
             }
 
-            GeneratedObject generatedObject = generatorImageBuilder.build();
-
-            if (generatedObject.isAnimated()) {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(generatedObject.getGifData(), "dialogue.gif")).queue();
-            } else {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "dialogue.png")).queue();
-            }
-
+            GeneratorResult result = ENGINE.render(compositeBuilder.build(), context);
+            sendResult(event, result, "dialogue");
             addCommandToUserHistory(event.getUser(), event.getCommandString());
-        } catch (GeneratorException exception) {
+        } catch (IllegalArgumentException exception) {
+            event.getHook().editOriginal(exception.getMessage()).queue();
+            log.error("Encountered an error while generating dialogue", exception);
+        } catch (RenderException | ParseException exception) {
             event.getHook().editOriginal(exception.getMessage()).queue();
             log.error("Encountered an error while generating dialogue", exception);
         } catch (IOException exception) {
@@ -1018,7 +974,7 @@ public class GeneratorCommands {
     public List<Command.Choice> itemNames(CommandAutoCompleteInteractionEvent event) {
         String userInput = event.getFocusedOption().getValue().toLowerCase(Locale.ROOT);
 
-        return Spritesheet.getImageMap().keySet()
+        return ENGINE.sprites().getAllSprites().keySet()
             .stream()
             .filter(name -> name.toLowerCase(Locale.ROOT).contains(userInput))
             .limit(25)
@@ -1041,8 +997,8 @@ public class GeneratorCommands {
     public List<Command.Choice> tooltipSide(CommandAutoCompleteInteractionEvent event) {
         String userInput = event.getFocusedOption().getValue().toLowerCase(Locale.ROOT);
 
-        return Arrays.stream(MinecraftTooltipGenerator.TooltipSide.values())
-            .map(MinecraftTooltipGenerator.TooltipSide::name)
+        return Arrays.stream(TooltipSide.values())
+            .map(TooltipSide::name)
             .filter(side -> side.toLowerCase(Locale.ROOT).contains(userInput))
             .limit(25)
             .map(side -> new Command.Choice(side, side))
@@ -1052,14 +1008,36 @@ public class GeneratorCommands {
     @SlashAutocompleteHandler(id = "overlay-colors")
     public List<Command.Choice> overlayColors(CommandAutoCompleteInteractionEvent event) {
         String userInput = event.getFocusedOption().getValue().toLowerCase(Locale.ROOT);
-
-        return OverlayLoader.getInstance().getAllColorOptionNames()
-            .stream()
+        return ENGINE.overlayColors().getAllColorOptionNames().stream()
             .filter(name -> name.toLowerCase(Locale.ROOT).contains(userInput))
             .sorted()
             .limit(25)
             .map(name -> new Command.Choice(name, name))
             .toList();
+    }
+
+    /**
+     * Splits a string containing newlines (both literal {@code \n} and the escape sequence {@code \\n})
+     * into a list of individual lines suitable for {@link TooltipRequest.Builder#lines(List)}.
+     */
+    private static List<String> splitLines(String text) {
+        if (text == null || text.isEmpty()) {
+            return List.of();
+        }
+        // Normalize escaped newlines to actual newlines, then split
+        String normalized = text.replace("\\n", "\n");
+        return Arrays.asList(normalized.split("\n", -1));
+    }
+
+    /**
+     * Sends a GeneratorResult to the Discord channel, handling both static and animated images.
+     */
+    private void sendResult(SlashCommandInteractionEvent event, GeneratorResult result, String fileBaseName) throws IOException {
+        if (result.isAnimated()) {
+            event.getHook().editOriginalAttachments(FileUpload.fromData(((GeneratorResult.AnimatedImage) result).toGifBytes(), fileBaseName + ".gif")).queue();
+        } else {
+            event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(result.firstFrame()), fileBaseName + ".png")).queue();
+        }
     }
 
     /**
@@ -1153,7 +1131,7 @@ public class GeneratorCommands {
      * @return The calculated stat value
      */
     private double calculatePowerStoneStat(Stat stat, int basePower, int magicalPower) {
-        double statMultiplier = stat.getPowerScalingMultiplier() != null ? stat.getPowerScalingMultiplier() : 1;
+        double statMultiplier = stat.powerScalingMultiplier() != null ? stat.powerScalingMultiplier() : 1;
         double logValue = Math.log(1 + (0.0019 * magicalPower));
         double magnitude = Math.pow(Math.abs(logValue), 1.2);
         double signedFactor = Math.signum(logValue) * magnitude;

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -432,6 +432,7 @@ public class GeneratorCommands {
                 .rows(3)
                 .slotsPerRow(3)
                 .drawBorder(false)
+                .drawTitle(false)
                 .drawBackground(renderBackground)
                 .withInventoryString(recipe)
                 .build();

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -36,6 +36,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
+import net.hypixel.nerdbot.app.util.HttpUtils;
 import net.hypixel.nerdbot.app.generation.DiscordGenerationContext;
 import net.hypixel.nerdbot.discord.config.channel.ChannelConfig;
 import net.hypixel.nerdbot.discord.util.DiscordBotEnvironment;
@@ -1134,7 +1135,7 @@ public class GeneratorCommands {
     @SlashCommand(name = BASE_COMMAND, subcommand = "body", description = "Render a full 3D player body with optional armor", guildOnly = true)
     public void generateBody(
         SlashCommandInteractionEvent event,
-        @SlashOption(description = SKIN_VALUE_DESCRIPTION) String skinValue,
+        @SlashOption(description = "The skin to render (username, skin URL, or Base64 texture)") String skinValue,
         @SlashOption(description = "Skin model type (classic = thick arms, slim = thin arms)", required = false) String skinModel,
         @SlashOption(description = "Helmet armor material (e.g., iron, diamond, netherite)", required = false) String helmet,
         @SlashOption(description = "Chestplate armor material", required = false) String chestplate,
@@ -1159,7 +1160,7 @@ public class GeneratorCommands {
                 model = SkinModel.SLIM;
             }
 
-            PlayerBodyRequest.Builder bodyBuilder = PlayerBodyRequest.fromBase64(skinValue)
+            PlayerBodyRequest.Builder bodyBuilder = resolveBodySkin(skinValue)
                     .skinModel(model)
                     .scale(2);
 
@@ -1223,6 +1224,61 @@ public class GeneratorCommands {
             return color.color().getRGB() & 0xFFFFFF;
         }
         throw new IllegalArgumentException("Unknown color: " + nameOrHex);
+    }
+
+    /**
+     * Resolves a skin value that may be a Base64 texture, a skin URL, or a player username.
+     * For usernames, looks up the UUID via Mojang API, then fetches the profile to get the
+     * Base64 texture property.
+     *
+     * @return a {@link PlayerBodyRequest.Builder} configured with the resolved skin source
+     * @throws IllegalArgumentException if the username cannot be resolved
+     */
+    private static PlayerBodyRequest.Builder resolveBodySkin(String skinValue) {
+        if (skinValue == null || skinValue.isBlank()) {
+            throw new IllegalArgumentException("Skin value must not be empty");
+        }
+
+        // If it starts with http, treat as direct URL
+        if (skinValue.startsWith("http://") || skinValue.startsWith("https://")) {
+            return PlayerBodyRequest.fromUrl(skinValue);
+        }
+
+        // If it looks like Base64 (long string, no spaces, contains typical chars), use as-is
+        if (skinValue.length() > 64 && !skinValue.contains(" ")) {
+            return PlayerBodyRequest.fromBase64(skinValue);
+        }
+
+        // Otherwise treat as a username - resolve via Mojang API
+        var profileResult = HttpUtils.getMojangProfile(skinValue);
+        if (profileResult.isFailure() || profileResult.orElse(null) == null) {
+            throw new IllegalArgumentException("Could not find Minecraft player: " + skinValue);
+        }
+
+        var profile = profileResult.orElse(null);
+        if (profile.getUniqueId() == null) {
+            throw new IllegalArgumentException("Could not find Minecraft player: " + skinValue);
+        }
+
+        // Fetch full profile with textures from session server
+        String sessionUrl = "https://sessionserver.mojang.com/session/minecraft/profile/"
+                + profile.getUniqueId().toString().replace("-", "");
+        var sessionResult = net.hypixel.nerdbot.marmalade.http.HttpClient.getString(sessionUrl);
+        if (sessionResult.isFailure()) {
+            throw new IllegalArgumentException("Could not fetch skin for player: " + skinValue);
+        }
+
+        com.google.gson.JsonObject sessionJson = com.google.gson.JsonParser.parseString(sessionResult.orElseThrow()).getAsJsonObject();
+        var properties = sessionJson.getAsJsonArray("properties");
+        for (var prop : properties) {
+            var obj = prop.getAsJsonObject();
+            if ("textures".equals(obj.get("name").getAsString())) {
+                return PlayerBodyRequest.fromBase64(obj.get("value").getAsString())
+                        .playerName(skinValue);
+            }
+        }
+
+        throw new IllegalArgumentException("Could not find skin texture for player: " + skinValue);
     }
 
     private void sendResult(SlashCommandInteractionEvent event, GeneratorResult result, String fileBaseName) throws IOException {

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -873,7 +873,6 @@ public class GeneratorCommands {
             .padding(TooltipRequest.DEFAULT_PADDING)
             .firstLinePadding(false)
             .maxLineLength(maxLineLength)
-            .bypassMaxLineLength(true)
             .renderBorder(renderBackground)
             .build();
 
@@ -963,7 +962,6 @@ public class GeneratorCommands {
                 .padding(TooltipRequest.DEFAULT_PADDING)
                 .firstLinePadding(false)
                 .maxLineLength(maxLineLength)
-                .bypassMaxLineLength(true)
                 .renderBorder(renderBackground)
                 .build();
 

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -438,7 +438,7 @@ public class GeneratorCommands {
 
             GeneratorResult result = getEngineManager().getDefaultEngine().render(inventoryRequest, context);
 
-            event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(result.firstFrame()), "recipe.png")).queue();
+            sendResult(event, result, "recipe");
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         } catch (RenderException | ParseException exception) {
             event.getHook().editOriginal(exception.getMessage()).queue();

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -129,7 +129,7 @@ public class GeneratorCommands {
         return engineManager;
     }
 
-    @SlashCommand(name = BASE_COMMAND, subcommand = "display", description = "Display an item")
+    @SlashCommand(name = BASE_COMMAND, subcommand = "display", description = "Display an item", guildOnly = true)
     public void generateItem(
         SlashCommandInteractionEvent event,
         @SlashOption(autocompleteId = "item-names", description = ITEM_DESCRIPTION) String itemId,
@@ -191,7 +191,7 @@ public class GeneratorCommands {
         }
     }
 
-    @SlashCommand(name = BASE_COMMAND, subcommand = "powerstone", description = "Generate an image of a Power Stone")
+    @SlashCommand(name = BASE_COMMAND, subcommand = "powerstone", description = "Generate an image of a Power Stone", guildOnly = true)
     public void generatePowerstone(
         SlashCommandInteractionEvent event,
         @SlashOption(description = "The name of your Power Stone") String powerName,
@@ -384,7 +384,7 @@ public class GeneratorCommands {
         }
     }
 
-    @SlashCommand(name = BASE_COMMAND, subcommand = "search", description = "Search for an item")
+    @SlashCommand(name = BASE_COMMAND, subcommand = "search", description = "Search for an item", guildOnly = true)
     public void searchItem(SlashCommandInteractionEvent event, @SlashOption(description = "The ID of the item to search for") String itemId, @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden) {
         if (shouldBlockGeneratorCommand(event)) {
             return;
@@ -411,7 +411,7 @@ public class GeneratorCommands {
         event.getHook().editOriginal(message.toString()).queue();
     }
 
-    @SlashCommand(name = BASE_COMMAND, subcommand = "recipe", description = "Generate a recipe")
+    @SlashCommand(name = BASE_COMMAND, subcommand = "recipe", description = "Generate a recipe", guildOnly = true)
     public void generateRecipe(
         SlashCommandInteractionEvent event,
         @SlashOption(description = RECIPE_STRING_DESCRIPTION) String recipe,
@@ -452,7 +452,7 @@ public class GeneratorCommands {
         }
     }
 
-    @SlashCommand(name = BASE_COMMAND, subcommand = "inventory", description = "Generate an inventory")
+    @SlashCommand(name = BASE_COMMAND, subcommand = "inventory", description = "Generate an inventory", guildOnly = true)
     public void generateInventory(
         SlashCommandInteractionEvent event,
         @SlashOption(description = INVENTORY_ROWS_DESCRIPTION) int rows,
@@ -523,7 +523,7 @@ public class GeneratorCommands {
 
     private static final int MAX_ATTACHMENT_SIZE_BYTES = 64 * 1024; // 64 KB
 
-    @SlashCommand(name = BASE_COMMAND, subcommand = "parse", description = "Parse an NBT string (JSON or SNBT format)")
+    @SlashCommand(name = BASE_COMMAND, subcommand = "parse", description = "Parse an NBT string (JSON or SNBT format)", guildOnly = true)
     public void parseNbtString(
         SlashCommandInteractionEvent event,
         @SlashOption(description = NBT_DESCRIPTION, required = false) String nbt,
@@ -659,7 +659,7 @@ public class GeneratorCommands {
         return nbtText;
     }
 
-    @SlashCommand(name = BASE_COMMAND, subcommand = "item", description = "Generate a full item image. Supports displaying items, recipes, tooltips & more")
+    @SlashCommand(name = BASE_COMMAND, subcommand = "item", description = "Generate a full item image. Supports displaying items, recipes, tooltips & more", guildOnly = true)
     public void generateTooltip(
         SlashCommandInteractionEvent event,
         @SlashOption(description = NAME_DESCRIPTION) String itemName,
@@ -777,7 +777,7 @@ public class GeneratorCommands {
         }
     }
 
-    @SlashCommand(name = BASE_COMMAND, subcommand = "text", description = "Generate some text")
+    @SlashCommand(name = BASE_COMMAND, subcommand = "text", description = "Generate some text", guildOnly = true)
     public void generateText(
         SlashCommandInteractionEvent event,
         @SlashOption(description = TEXT_DESCRIPTION) String text,
@@ -827,7 +827,7 @@ public class GeneratorCommands {
         }
     }
 
-    @SlashCommand(name = BASE_COMMAND, group = "dialogue", subcommand = "single", description = "Generate dialogue for a single NPC")
+    @SlashCommand(name = BASE_COMMAND, group = "dialogue", subcommand = "single", description = "Generate dialogue for a single NPC", guildOnly = true)
     public void generateSingleDialogue(
         SlashCommandInteractionEvent event,
         @SlashOption(description = "Name of your NPC") String npcName,
@@ -902,7 +902,7 @@ public class GeneratorCommands {
         }
     }
 
-    @SlashCommand(name = BASE_COMMAND, group = "dialogue", subcommand = "multi", description = "Generate dialogue for multiple NPCs")
+    @SlashCommand(name = BASE_COMMAND, group = "dialogue", subcommand = "multi", description = "Generate dialogue for multiple NPCs", guildOnly = true)
     public void generateMultiDialogue(
         SlashCommandInteractionEvent event,
         @SlashOption(description = "Names of your NPCs, separated by a comma") String npcNames,
@@ -993,7 +993,7 @@ public class GeneratorCommands {
         }
     }
 
-    @SlashCommand(name = BASE_COMMAND, subcommand = "history", description = "View your command history")
+    @SlashCommand(name = BASE_COMMAND, subcommand = "history", description = "View your command history", guildOnly = true)
     public void viewHistory(SlashCommandInteractionEvent event) {
         event.deferReply(true).complete();
 
@@ -1087,7 +1087,7 @@ public class GeneratorCommands {
             .toList();
     }
 
-    @SlashCommand(name = BASE_COMMAND, subcommand = "resource-packs", description = "List available resource packs")
+    @SlashCommand(name = BASE_COMMAND, subcommand = "resource-packs", description = "List available resource packs", guildOnly = true)
     public void listResourcePacks(
         SlashCommandInteractionEvent event,
         @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden

--- a/app/src/main/java/net/hypixel/nerdbot/app/generation/DiscordGenerationContext.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/generation/DiscordGenerationContext.java
@@ -2,15 +2,8 @@ package net.hypixel.nerdbot.app.generation;
 
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.hypixel.nerdbot.discord.config.channel.ChannelConfig;
-import net.hypixel.nerdbot.discord.util.DiscordBotEnvironment;
-import net.aerh.imagegenerator.context.GenerationContext;
-import net.aerh.imagegenerator.context.GenerationFeedback;
-import net.hypixel.nerdbot.discord.config.FunConfig;
-import net.hypixel.nerdbot.marmalade.format.TimeUtils;
-
-import java.time.ZoneId;
-import java.util.Arrays;
+import net.aerh.jigsaw.api.generator.GenerationContext;
+import net.aerh.jigsaw.api.generator.GenerationFeedback;
 
 @UtilityClass
 public class DiscordGenerationContext {
@@ -25,21 +18,8 @@ public class DiscordGenerationContext {
             }
         };
 
-        String channelId = event.getChannel().getId();
-
-        // Determine if April Fools mode should be enabled for this channel
-        FunConfig funConfig = DiscordBotEnvironment.getBot().getConfig().getFunConfig();
-        ZoneId zoneId = funConfig.getAprilFoolsTimezone() != null
-            ? ZoneId.of(funConfig.getAprilFoolsTimezone())
-            : ZoneId.systemDefault();
-
-        boolean aprilFools = false;
-        if (TimeUtils.isAprilFirst(zoneId)) {
-            ChannelConfig channelConfig = DiscordBotEnvironment.getBot().getConfig().getChannelConfig();
-            aprilFools = Arrays.stream(channelConfig.getAprilFoolsGenChannelIds())
-                .anyMatch(id -> id.equalsIgnoreCase(channelId));
-        }
-
-        return new GenerationContext(channelId, feedback, aprilFools);
+        return GenerationContext.builder()
+            .feedback(feedback)
+            .build();
     }
 }

--- a/discord-framework/pom.xml
+++ b/discord-framework/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.github.Aerhhh</groupId>
             <artifactId>SlashCommands</artifactId>
-            <version>v1.0.8</version>
+            <version>v1.0.9</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/discord-framework/pom.xml
+++ b/discord-framework/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.github.Aerhhh</groupId>
             <artifactId>SlashCommands</artifactId>
-            <version>v1.0.9</version>
+            <version>v1.0.8</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/discord-framework/pom.xml
+++ b/discord-framework/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.github.Aerhhh</groupId>
             <artifactId>SlashCommands</artifactId>
-            <version>v1.0.7</version>
+            <version>v1.0.8</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/discord-framework/src/main/java/net/hypixel/nerdbot/discord/config/GeneratorConfig.java
+++ b/discord-framework/src/main/java/net/hypixel/nerdbot/discord/config/GeneratorConfig.java
@@ -40,6 +40,11 @@ public class GeneratorConfig {
      */
     private GeneralConfig general = new GeneralConfig();
 
+    /**
+     * Resource pack configuration
+     */
+    private ResourcePackConfig resourcePack = new ResourcePackConfig();
+
     @Getter
     @Setter
     @ToString

--- a/discord-framework/src/main/java/net/hypixel/nerdbot/discord/config/ResourcePackConfig.java
+++ b/discord-framework/src/main/java/net/hypixel/nerdbot/discord/config/ResourcePackConfig.java
@@ -1,0 +1,29 @@
+package net.hypixel.nerdbot.discord.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class ResourcePackConfig {
+
+    /**
+     * Directory to scan for resource pack zip files.
+     * Each zip's filename (minus extension) becomes its pack name.
+     */
+    private String packDirectory = "./resource-packs";
+
+    /**
+     * Name of the default resource pack to use when a user doesn't specify one.
+     * Null means vanilla atlas only.
+     */
+    private String defaultPack = null;
+
+    /**
+     * Whether to chain the built-in vanilla texture atlas as fallback behind resource packs.
+     * Almost always true since most packs only override textures, not models.
+     */
+    private boolean includeVanillaFallback = true;
+}

--- a/example-config.json
+++ b/example-config.json
@@ -162,135 +162,10 @@
   "badgeConfig": {
     "badges": [
       {
-        "id": "april_fools_2024_most_messages",
-        "name": "Horse Whisperer (2024)",
-        "emoji": "🃏"
-      },
-      {
-        "id": "artist",
-        "name": "Artist",
-        "emoji": "🎨"
-      },
-      {
-        "id": "bot_contributor",
-        "name": "Bot Contributor",
-        "emoji": "🤖"
-      },
-      {
-        "id": "brainstorm_minions",
-        "name": "Minion Brainstorm",
-        "tiers": [
-          {
-            "name": "Tier 1",
-            "emoji": "🏅",
-            "tier": 1
-          },
-          {
-            "name": "Tier 2",
-            "emoji": "⭐",
-            "tier": 2
-          },
-          {
-            "name": "Tier 3",
-            "emoji": "🌟",
-            "tier": 3
-          }
-        ]
-      },
-      {
-        "id": "brainstorm_mobs",
-        "name": "Mob Brainstorm",
-        "tiers": [
-          {
-            "name": "Tier 1",
-            "emoji": "🏅",
-            "tier": 1
-          },
-          {
-            "name": "Tier 2",
-            "emoji": "⭐",
-            "tier": 2
-          },
-          {
-            "name": "Tier 3",
-            "emoji": "🌟",
-            "tier": 3
-          }
-        ]
-      },
-      {
-        "id": "brainstorm_shen_special_items",
-        "name": "Shen's Special Items Brainstorm",
-        "tiers": [
-          {
-            "name": "Tier 1",
-            "emoji": "🏅",
-            "tier": 1
-          },
-          {
-            "name": "Tier 2",
-            "emoji": "⭐",
-            "tier": 2
-          },
-          {
-            "name": "Tier 3",
-            "emoji": "🌟",
-            "tier": 3
-          }
-        ]
-      },
-      {
-        "id": "contest_november_tag_art",
-        "name": "November 2023 Art Contest",
-        "tiers": [
-          {
-            "name": "Tier 1",
-            "emoji": "🏅",
-            "tier": 1
-          },
-          {
-            "name": "Tier 2",
-            "emoji": "⭐",
-            "tier": 2
-          }
-        ]
-      },
-      {
-        "id": "project_better_mayors",
-        "name": "Better Mayors Project",
-        "tiers": [
-          {
-            "name": "Tier 1",
-            "emoji": "🏅",
-            "tier": 1
-          },
-          {
-            "name": "Tier 2",
-            "emoji": "⭐",
-            "tier": 2
-          },
-          {
-            "name": "Tier 3",
-            "emoji": "🌟",
-            "tier": 3
-          },
-          {
-            "name": "Tier 5",
-            "emoji": "💫",
-            "tier": 5
-          }
-        ]
-      },
-      {
-        "id": "wiki_contributor",
-        "name": "Wiki Contributor",
-        "emoji": "📖"
-      },
-        {
-            "id": "project_healing_revamp",
-            "name": "Healing Revamp Project",
-            "emoji": "⚕\uFE0F"
-        }
+        "id": "1234567890123456789",
+        "name": "example_value",
+        "emoji": "example_value"
+      }
     ]
   },
   "funConfig": {
@@ -346,8 +221,8 @@
       "includeErrorDetails": true
     },
     "resourcePack": {
-      "packDirectory": "./resource-packs",
-      "defaultPack": null,
+      "packDirectory": "example_value",
+      "defaultPack": "example_value",
       "includeVanillaFallback": true
     }
   },

--- a/example-config.json
+++ b/example-config.json
@@ -162,10 +162,135 @@
   "badgeConfig": {
     "badges": [
       {
-        "id": "1234567890123456789",
-        "name": "example_value",
-        "emoji": "example_value"
-      }
+        "id": "april_fools_2024_most_messages",
+        "name": "Horse Whisperer (2024)",
+        "emoji": "🃏"
+      },
+      {
+        "id": "artist",
+        "name": "Artist",
+        "emoji": "🎨"
+      },
+      {
+        "id": "bot_contributor",
+        "name": "Bot Contributor",
+        "emoji": "🤖"
+      },
+      {
+        "id": "brainstorm_minions",
+        "name": "Minion Brainstorm",
+        "tiers": [
+          {
+            "name": "Tier 1",
+            "emoji": "🏅",
+            "tier": 1
+          },
+          {
+            "name": "Tier 2",
+            "emoji": "⭐",
+            "tier": 2
+          },
+          {
+            "name": "Tier 3",
+            "emoji": "🌟",
+            "tier": 3
+          }
+        ]
+      },
+      {
+        "id": "brainstorm_mobs",
+        "name": "Mob Brainstorm",
+        "tiers": [
+          {
+            "name": "Tier 1",
+            "emoji": "🏅",
+            "tier": 1
+          },
+          {
+            "name": "Tier 2",
+            "emoji": "⭐",
+            "tier": 2
+          },
+          {
+            "name": "Tier 3",
+            "emoji": "🌟",
+            "tier": 3
+          }
+        ]
+      },
+      {
+        "id": "brainstorm_shen_special_items",
+        "name": "Shen's Special Items Brainstorm",
+        "tiers": [
+          {
+            "name": "Tier 1",
+            "emoji": "🏅",
+            "tier": 1
+          },
+          {
+            "name": "Tier 2",
+            "emoji": "⭐",
+            "tier": 2
+          },
+          {
+            "name": "Tier 3",
+            "emoji": "🌟",
+            "tier": 3
+          }
+        ]
+      },
+      {
+        "id": "contest_november_tag_art",
+        "name": "November 2023 Art Contest",
+        "tiers": [
+          {
+            "name": "Tier 1",
+            "emoji": "🏅",
+            "tier": 1
+          },
+          {
+            "name": "Tier 2",
+            "emoji": "⭐",
+            "tier": 2
+          }
+        ]
+      },
+      {
+        "id": "project_better_mayors",
+        "name": "Better Mayors Project",
+        "tiers": [
+          {
+            "name": "Tier 1",
+            "emoji": "🏅",
+            "tier": 1
+          },
+          {
+            "name": "Tier 2",
+            "emoji": "⭐",
+            "tier": 2
+          },
+          {
+            "name": "Tier 3",
+            "emoji": "🌟",
+            "tier": 3
+          },
+          {
+            "name": "Tier 5",
+            "emoji": "💫",
+            "tier": 5
+          }
+        ]
+      },
+      {
+        "id": "wiki_contributor",
+        "name": "Wiki Contributor",
+        "emoji": "📖"
+      },
+        {
+            "id": "project_healing_revamp",
+            "name": "Healing Revamp Project",
+            "emoji": "⚕\uFE0F"
+        }
     ]
   },
   "funConfig": {
@@ -219,6 +344,11 @@
       "minScaleFactor": 1,
       "debugLogging": true,
       "includeErrorDetails": true
+    },
+    "resourcePack": {
+      "packDirectory": "./resource-packs",
+      "defaultPack": null,
+      "includeVanillaFallback": true
     }
   },
   "activityType": "PLAYING",

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -32,12 +32,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.Aerhhh.MinecraftImageGenerator</groupId>
+            <groupId>com.github.Aerhhh.jigsaw</groupId>
             <artifactId>jigsaw</artifactId>
             <version>feat~jigsaw-rewrite-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.github.Aerhhh.MinecraftImageGenerator</groupId>
+            <groupId>com.github.Aerhhh.jigsaw</groupId>
             <artifactId>jigsaw-skyblock</artifactId>
             <version>feat~jigsaw-rewrite-SNAPSHOT</version>
         </dependency>

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -32,9 +32,14 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.Aerhhh</groupId>
-            <artifactId>MinecraftImageGenerator</artifactId>
-            <version>master-SNAPSHOT</version>
+            <groupId>com.github.Aerhhh.MinecraftImageGenerator</groupId>
+            <artifactId>jigsaw</artifactId>
+            <version>feat~jigsaw-rewrite-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.Aerhhh.MinecraftImageGenerator</groupId>
+            <artifactId>jigsaw-skyblock</artifactId>
+            <version>feat~jigsaw-rewrite-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Migrates from MinecraftImageGenerator to the new Jigsaw library (`jigsaw` core + `jigsaw-skyblock` module).

All 10 slash commands rewritten to use `Engine.render(RenderRequest)` with typed request objects. Composite rendering uses `CompositeRequest` with sub-requests and horizontal layout with vertical centering. Tooltip formatting goes through `SkyBlockTooltipBuilder` for stat/flavor placeholder resolution.

NBT parse command now renders item + tooltip composite (not just the item sprite) and includes dye color hex in the generated slash command. Dialogue commands use `bypassMaxLineLength` to prevent wrapping. All commands use `SkyBlockTooltipBuilder` where user text may contain `%%placeholder%%` patterns.

Removed the `data` slash command parameter (covered by named color support on `ItemRequest.color(String)`). Removed April Fools logic.

Blocked on Aerhhh/MinecraftImageGenerator#22 being merged.