### PR TITLE
Fix NPE in /gen history and clean up the response

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -36,6 +36,12 @@
             <artifactId>latex2unicode_2.13</artifactId>
             <version>0.3.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.12.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -89,6 +95,12 @@
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                     </transformers>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
             </plugin>
 
             <plugin>

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -25,7 +25,6 @@ import net.aerh.imagegenerator.text.wrapper.TextWrapper;
 import net.aerh.slashcommands.api.annotations.SlashAutocompleteHandler;
 import net.aerh.slashcommands.api.annotations.SlashCommand;
 import net.aerh.slashcommands.api.annotations.SlashOption;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
@@ -43,12 +42,12 @@ import net.hypixel.nerdbot.marmalade.io.FileUtils;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.generator.GeneratorHistory;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
+import org.jetbrains.annotations.Nullable;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -982,21 +981,15 @@ public class GeneratorCommands {
     public void viewHistory(SlashCommandInteractionEvent event) {
         event.deferReply(true).complete();
 
-        List<EmbedBuilder> embedBuilders = new ArrayList<>();
-        DiscordUserRepository discordUserRepository = DiscordBotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
+        List<String> history = getCommandHistory(findDiscordUser(event.getUser()));
 
-        if (discordUserRepository.findById(event.getUser().getId()).isSuccess()) {
-            List<String> history = discordUserRepository.findById(event.getUser().getId()).orElse(null).getGeneratorHistory().getCommandHistory();
-            embedBuilders.addAll(history.stream()
-                .map(s -> new EmbedBuilder().setDescription(s))
-                .toList()
-            );
-        } else {
-            embedBuilders.add(new EmbedBuilder().setTitle("No history found"));
+        if (history.isEmpty()) {
+            event.getHook().editOriginal("No history found").queue();
+            return;
         }
 
         try {
-            File file = FileUtils.createTempFile("generator_history.txt", String.join("\n\n", embedBuilders.stream().map(EmbedBuilder::getDescriptionBuilder).toList()));
+            File file = FileUtils.createTempFile("generator_history.txt", String.join("\n\n", history));
             event.getHook().editOriginalAttachments(FileUpload.fromData(file)).queue();
         } catch (IOException e) {
             event.getHook().editOriginal("An error occurred while fetching your generator command history!").queue();
@@ -1071,21 +1064,50 @@ public class GeneratorCommands {
      * @param command The command to add
      */
     private void addCommandToUserHistory(User user, String command) {
-        DiscordUserRepository discordUserRepository = DiscordBotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
+        DiscordUser discordUser = findDiscordUser(user);
 
-        if (discordUserRepository == null) {
+        if (discordUser == null) {
             return;
         }
 
-        if (discordUserRepository.findById(user.getId()).isSuccess()) {
-            DiscordUser discordUser = discordUserRepository.findById(user.getId()).orElse(null);
-
-            if (discordUser.getGeneratorHistory() == null) {
-                discordUser.setGeneratorHistory(new GeneratorHistory());
-            }
-
-            discordUser.getGeneratorHistory().addCommand(command);
+        if (discordUser.getGeneratorHistory() == null) {
+            discordUser.setGeneratorHistory(new GeneratorHistory());
         }
+
+        discordUser.getGeneratorHistory().addCommand(command);
+    }
+
+    /**
+     * Finds the {@link DiscordUser} for the given {@link User}.
+     *
+     * @param user The {@link User} to look up
+     *
+     * @return The {@link DiscordUser}, or {@code null} if the repository is unavailable or the user is not in the database
+     */
+    @Nullable
+    private static DiscordUser findDiscordUser(User user) {
+        DiscordUserRepository discordUserRepository = DiscordBotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
+
+        if (discordUserRepository == null) {
+            return null;
+        }
+
+        return discordUserRepository.findById(user.getId()).orElse(null);
+    }
+
+    /**
+     * Gets the generator command history of the given {@link DiscordUser}.
+     *
+     * @param discordUser The {@link DiscordUser} to get the history of
+     *
+     * @return The list of commands, or an empty list if the user is {@code null} or has no history yet
+     */
+    static List<String> getCommandHistory(@Nullable DiscordUser discordUser) {
+        if (discordUser == null || discordUser.getGeneratorHistory() == null) {
+            return List.of();
+        }
+
+        return discordUser.getGeneratorHistory().getCommandHistory();
     }
 
     /**

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/GeneratorCommandsTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/GeneratorCommandsTest.java
@@ -1,0 +1,43 @@
+package net.hypixel.nerdbot.app.command;
+
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.generator.GeneratorHistory;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GeneratorCommandsTest {
+
+    @Test
+    void getCommandHistoryReturnsEmptyListForNullUser() {
+        assertTrue(GeneratorCommands.getCommandHistory(null).isEmpty());
+    }
+
+    @Test
+    void getCommandHistoryReturnsEmptyListForUserWithoutHistory() {
+        DiscordUser discordUser = new DiscordUser();
+
+        assertTrue(GeneratorCommands.getCommandHistory(discordUser).isEmpty());
+    }
+
+    @Test
+    void getCommandHistoryReturnsEmptyListForUserWithEmptyHistory() {
+        DiscordUser discordUser = new DiscordUser();
+        discordUser.setGeneratorHistory(new GeneratorHistory());
+
+        assertTrue(GeneratorCommands.getCommandHistory(discordUser).isEmpty());
+    }
+
+    @Test
+    void getCommandHistoryReturnsStoredCommands() {
+        DiscordUser discordUser = new DiscordUser();
+        discordUser.setGeneratorHistory(new GeneratorHistory());
+        discordUser.getGeneratorHistory().addCommand("/gen item id:stick");
+        discordUser.getGeneratorHistory().addCommand("/gen text text:hello");
+
+        assertEquals(List.of("/gen item id:stick", "/gen text text:hello"), GeneratorCommands.getCommandHistory(discordUser));
+    }
+}


### PR DESCRIPTION
## What

`/gen history` could throw an NPE instead of showing "No history found".

`viewHistory` called `findById(...).orElse(null)` and then immediately dereferenced the result, and it also assumed `getGeneratorHistory()` was non-null. So a user whose lookup came back null, or who simply hadn't generated anything yet, got an NPE. `addCommandToUserHistory` already guarded that same field, so the two methods disagreed on whether the history could be null.

## Changes

- Moved the user lookup into `findDiscordUser` and the history read into `getCommandHistory`, both returning safe empties, and reused them in `addCommandToUserHistory` so the null handling lives in one spot instead of being duplicated (and inconsistent).
- Collapsed the double `findById` call in `viewHistory` down to one.
- Removed the `EmbedBuilder` round-trip. Those embeds were never actually sent as embeds — only their descriptions got joined into the attached text file — so the "No history found" branch, which set a title rather than a description, ended up writing an empty file. That case now just edits the reply with the message.
- Added the `junit-jupiter` dependency and surefire plugin to the app module (it had no test setup) plus a test covering the `getCommandHistory` cases: null user, null history, empty history, and populated history.

## Testing

`mvn -pl app test` passes (4/4).
