### PR TITLE
chore: bump SlashCommands to v1.0.11

### DIFF
--- a/discord-framework/pom.xml
+++ b/discord-framework/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.github.Aerhhh</groupId>
             <artifactId>SlashCommands</artifactId>
-            <version>v1.0.9</version>
+            <version>v1.0.11</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
This picks up the SlashCommands fix for the bug we hit today: the library used to bulk-overwrite global commands on boot, and Discord rejects any bulk overwrite that would remove an app's Entry Point command (error 50240). Since our app has one, every global command update had been failing quietly, which is how /gen ended up frozen on a months-old definition and then left behind as a duplicate once it moved to guild scope.

As of v1.0.11 the registrar retrieves what Discord actually has and diffs it against the scan. With only slash commands registered it still does the old atomic bulk overwrite; when an unmanaged command like the Entry Point is present it upserts and deletes individually instead, and it logs everything it removes or preserves so this failure can't hide in startup spam again. First boot on this version will delete the stranded global /gen by itself, no manual API cleanup needed.

Skipped v1.0.10 because that tag never built on JitPack. Dependabot had bumped git-commit-id-maven-plugin to 10.x, which needs Maven 3.9+, and JitPack's default Maven is older than that. The library now ships a Maven wrapper pinned to 3.9.9, so its releases keep building no matter what the plugin wants.