### PR TITLE
Add /gen symbols and validate glyph data at boot

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
@@ -1,6 +1,7 @@
 package net.hypixel.nerdbot.app;
 
 import lombok.extern.slf4j.Slf4j;
+import net.aerh.imagegenerator.data.PackGlyphIndex;
 import net.aerh.imagegenerator.pack.PackRepository;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Activity;
@@ -205,6 +206,14 @@ public class SkyBlockNerdsBot extends AbstractDiscordBot {
 
         // Register resource packs with the image generator
         resourcePackService.registerConfiguredPacks(config.getGeneratorConfig().getResourcePacks());
+
+        // Validate glyph override data (icons.json/stats.json, including any external override
+        // files) now instead of on the first /gen parse that needs it
+        try {
+            PackGlyphIndex.fromRegistries();
+        } catch (IllegalStateException e) {
+            log.error("Glyph override data failed validation; /gen parse will reject NBT input until the data is fixed", e);
+        }
 
         // Update forum IDs for alpha/project channels
         AlphaProjectConfigUpdater.updateForumIds(config, true, true, jda.getForumChannels());

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -26,11 +26,13 @@ import net.aerh.imagegenerator.text.TextColorRemap;
 import net.aerh.imagegenerator.text.wrapper.TextWrapper;
 import net.aerh.slashcommands.api.annotations.SlashAutocompleteHandler;
 import net.aerh.slashcommands.api.annotations.SlashCommand;
+import net.aerh.slashcommands.api.annotations.SlashComponentHandler;
 import net.aerh.slashcommands.api.annotations.SlashOption;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.utils.FileUpload;
@@ -38,9 +40,12 @@ import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
 import net.hypixel.nerdbot.app.generation.DiscordGenerationContext;
 import net.hypixel.nerdbot.app.generation.pack.ResourcePackService;
+import net.hypixel.nerdbot.app.util.GlyphListing;
 import net.hypixel.nerdbot.discord.config.channel.ChannelConfig;
 import net.hypixel.nerdbot.discord.util.DiscordBotEnvironment;
 import net.hypixel.nerdbot.discord.util.StringUtils;
+import net.hypixel.nerdbot.discord.util.pagination.PaginatedResponse;
+import net.hypixel.nerdbot.discord.util.pagination.PaginationManager;
 import net.hypixel.nerdbot.marmalade.functional.Pair;
 import net.hypixel.nerdbot.marmalade.image.ImageUtil;
 import net.hypixel.nerdbot.marmalade.io.FileUtils;
@@ -430,6 +435,46 @@ public class GeneratorCommands {
             }
 
             message.append(line);
+        }
+    }
+
+    private static final int SYMBOLS_PER_PAGE = 20;
+
+    @SlashCommand(name = BASE_COMMAND, subcommand = "symbols", description = "List the placeholder names usable in generator text", guildOnly = true)
+    public void listSymbols(
+        SlashCommandInteractionEvent event,
+        @SlashOption(description = "Only show names containing this text", required = false) String filter,
+        @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden
+    ) {
+        if (shouldBlockGeneratorCommand(event)) {
+            return;
+        }
+
+        hidden = hidden == null ? getUserAutoHideSetting(event) : hidden;
+        event.deferReply(hidden).complete();
+
+        List<String> rows = GlyphListing.buildRows(filter);
+
+        if (rows.isEmpty()) {
+            event.getHook().editOriginal("No placeholders match `" + filter + "`!").queue();
+            return;
+        }
+
+        PaginatedResponse<String> pagination = PaginatedResponse.forText(rows, SYMBOLS_PER_PAGE, GlyphListing::buildPage, "gen-symbols-page");
+        pagination.sendMessage(event);
+
+        event.getHook().retrieveOriginal().queue(message ->
+            PaginationManager.registerPagination(message.getId(), pagination)
+        );
+    }
+
+    @SlashComponentHandler(id = "gen-symbols-pagination", patterns = {"gen-symbols-page:*"})
+    public void handleSymbolsPagination(ButtonInteractionEvent event) {
+        event.deferEdit().queue();
+
+        if (!PaginationManager.handleButtonInteraction(event)) {
+            log.warn("Could not find symbols pagination for message ID: {}", event.getMessageId());
+            event.getHook().editOriginal("This pagination has expired. Please run the command again.").queue();
         }
     }
 

--- a/app/src/main/java/net/hypixel/nerdbot/app/util/GlyphListing.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/util/GlyphListing.java
@@ -1,0 +1,94 @@
+package net.hypixel.nerdbot.app.util;
+
+import net.aerh.imagegenerator.data.Icon;
+import net.aerh.imagegenerator.data.Stat;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Builds the text rows for {@code /gen symbols}: every icon and stat placeholder with its base
+ * character and any pack-specific override characters.
+ * <p>
+ * Pack glyphs live in the Unicode private use area, so Discord's own font renders them as empty
+ * boxes; those are printed as {@code U+XXXX} codepoints instead. The generated images render them
+ * fine because the glyphs are baked into the generator's fonts.
+ */
+public final class GlyphListing {
+
+    private GlyphListing() {
+    }
+
+    /**
+     * Builds one row per icon and stat placeholder, alphabetically by name.
+     *
+     * @param filter optional case-insensitive substring to match against placeholder names
+     *
+     * @return the matching rows, possibly empty
+     */
+    public static List<String> buildRows(@Nullable String filter) {
+        List<String> rows = new ArrayList<>();
+
+        for (Icon icon : Icon.getIcons()) {
+            if (matches(icon.getName(), filter)) {
+                rows.add(row(icon.getName(), icon.getIcon(), icon.getPackOverrides()));
+            }
+        }
+
+        for (Stat stat : Stat.getStats()) {
+            if (matches(stat.getName(), filter)) {
+                rows.add(row(stat.getName(), stat.getIcon(), stat.getPackOverrides()));
+            }
+        }
+
+        rows.sort(String.CASE_INSENSITIVE_ORDER);
+        return rows;
+    }
+
+    /**
+     * Joins a page of rows under a short usage header.
+     *
+     * @param rows the rows for the current page
+     *
+     * @return the page text
+     */
+    public static String buildPage(List<String> rows) {
+        return "Use `%%name%%` in generator text. Pack glyphs are shown as codepoints because"
+            + " Discord cannot display them; generated images can.\n"
+            + String.join("\n", rows);
+    }
+
+    private static boolean matches(@Nullable String name, @Nullable String filter) {
+        if (name == null) {
+            return false;
+        }
+        if (filter == null || filter.isBlank()) {
+            return true;
+        }
+        return name.toLowerCase(Locale.ROOT).contains(filter.trim().toLowerCase(Locale.ROOT));
+    }
+
+    private static String row(String name, @Nullable String baseCharacter, @Nullable Map<String, String> packOverrides) {
+        StringBuilder row = new StringBuilder("`%%").append(name).append("%%` ").append(printable(baseCharacter));
+
+        if (packOverrides != null) {
+            packOverrides.forEach((packId, character) ->
+                row.append(" (").append(packId).append(": ").append(printable(character)).append(")"));
+        }
+
+        return row.toString();
+    }
+
+    private static String printable(@Nullable String character) {
+        if (character == null || character.isEmpty()) {
+            return "?";
+        }
+
+        int codePoint = character.codePointAt(0);
+        boolean unrenderable = (codePoint >= 0xE000 && codePoint <= 0xF8FF) || codePoint == 0x12DE;
+        return unrenderable ? "U+%04X".formatted(codePoint) : character;
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/util/GlyphListingTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/util/GlyphListingTest.java
@@ -1,0 +1,64 @@
+package net.hypixel.nerdbot.app.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GlyphListingTest {
+
+    private static String rowFor(String name) {
+        return GlyphListing.buildRows(null).stream()
+            .filter(row -> row.startsWith("`%%" + name + "%%`"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no row for " + name));
+    }
+
+    @Test
+    void statRowsShowBaseCharAndPackOverrideCodepoint() {
+        String row = rowFor("strength");
+
+        assertTrue(row.contains("\u2741"), row);
+        assertTrue(row.contains("hypixel:skyblock"), row);
+        assertTrue(row.contains("U+E00D"), row);
+    }
+
+    @Test
+    void packOnlyGlyphsShowCodepointsInsteadOfTofu() {
+        assertEquals("`%%mob_undead%%` U+E084", rowFor("mob_undead"));
+        assertEquals("`%%hypixel_staff%%` U+12DE", rowFor("hypixel_staff"));
+    }
+
+    @Test
+    void classicCharactersShowThemselves() {
+        assertEquals("`%%dot%%` \u2022", rowFor("dot"));
+    }
+
+    @Test
+    void filterNarrowsByNameCaseInsensitively() {
+        List<String> rows = GlyphListing.buildRows("FORTUNE");
+
+        assertFalse(rows.isEmpty());
+        assertTrue(rows.stream().allMatch(row -> row.toLowerCase().contains("fortune")), rows.toString());
+        assertTrue(GlyphListing.buildRows("definitely_not_a_placeholder").isEmpty());
+    }
+
+    @Test
+    void rowsAreSortedByName() {
+        List<String> rows = GlyphListing.buildRows(null);
+        List<String> sorted = rows.stream().sorted(String.CASE_INSENSITIVE_ORDER).toList();
+
+        assertEquals(sorted, rows);
+    }
+
+    @Test
+    void pageJoinsRowsUnderTheUsageHeader() {
+        String page = GlyphListing.buildPage(List.of("row one", "row two"));
+
+        assertTrue(page.startsWith("Use `%%name%%`"), page);
+        assertTrue(page.endsWith("row one\nrow two"), page);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <java.version>25</java.version>
         <lombok.version>1.18.46</lombok.version>
-        <imagegenerator.version>resource-pack-tooltips-SNAPSHOT</imagegenerator.version>
+        <imagegenerator.version>feat~glyph-pack-overrides-SNAPSHOT</imagegenerator.version>
         <editorconfig.encoding>UTF-8</editorconfig.encoding>
         <maven.compiler.release>${java.version}</maven.compiler.release>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <java.version>25</java.version>
         <lombok.version>1.18.46</lombok.version>
-        <imagegenerator.version>feat~glyph-pack-overrides-SNAPSHOT</imagegenerator.version>
+        <imagegenerator.version>master-SNAPSHOT</imagegenerator.version>
         <editorconfig.encoding>UTF-8</editorconfig.encoding>
         <maven.compiler.release>${java.version}</maven.compiler.release>
     </properties>


### PR DESCRIPTION
## What this does

Companion to Aerhhh/MinecraftImageGenerator#39, which added pack-conditional icon overrides and named placeholders for all the pack font glyphs. Two pieces here:

- `/gen symbols [filter]` lists every icon and stat placeholder with its base character and any pack override, 20 per page with the usual pagination buttons. Pack glyphs print as codepoints because Discord's own font renders them as empty boxes; the images the generator produces render them fine. The filter is a case-insensitive contains on the name, so `/gen symbols filter:fortune` shows just the fortune family.

```
`%%arrow_left%%` U+E060
`%%dot%%` •
`%%strength%%` ❁ (hypixel:skyblock: U+E00D)
```

- Startup runs the library's glyph data validation right after pack registration. A bad external icons.json or stats.json now produces one loud error in the log at boot (and a clear per-command error on `/gen parse`) instead of an uncaught exception on the first command that needed the data.

## Dependency note

The pom pins `feat~glyph-pack-overrides-SNAPSHOT` while the library PR is open, same drill as the current `resource-pack-tooltips-SNAPSHOT` pin. Swap it once the library side merges.

## Testing

45 tests, 0 failures. The listing builder is covered directly: override rows show the pack ID and codepoint, pack-only glyphs fall back to codepoints, classic characters print as themselves, filtering and sort order, and the page header. Verified the full build resolves and compiles against the branch snapshot through JitPack.
