### PR TITLE
feat(generator): pack support for /gen text, dialogue and parse

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -571,9 +571,7 @@ public class GeneratorCommands {
                     .withMaxLineLength(maxLineLength)
                     .withScaleFactor(Math.min(2, MinecraftInventoryGenerator.getScaleFactor()))
                     .withRenderBorder(true);
-                // Hovered tooltips have no rarity, so they take the pack's default tooltip
-                // override (when present) plus the pack's text colors.
-                applyPackTheme(tooltipBuilder, packId, null, null);
+                applyPackTheme(tooltipBuilder, packId);
 
                 generatedObject.addGenerator(tooltipBuilder.build());
             }
@@ -603,6 +601,7 @@ public class GeneratorCommands {
         SlashCommandInteractionEvent event,
         @SlashOption(description = NBT_DESCRIPTION, required = false) String nbt,
         @SlashOption(description = "Upload a text file containing NBT data", required = false) Message.Attachment attachment,
+        @SlashOption(autocompleteId = "pack-ids", description = PACK_DESCRIPTION, required = false) String pack,
         @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden
     ) {
         if (shouldBlockGeneratorCommand(event)) {
@@ -625,9 +624,17 @@ public class GeneratorCommands {
 
         try {
             MinecraftNbtParser.ParsedNbt parsedNbt = MinecraftNbtParser.parse(nbtInput);
+            PackId packId = resolvePackOption(pack);
             GeneratorImageBuilder generatorImageBuilder = new GeneratorImageBuilder().withContext(context);
 
             parsedNbt.getGenerators().forEach(generator -> {
+                if (generator instanceof MinecraftTooltipGenerator.Builder tooltipBuilder) {
+                    // Themed before buildSlashCommand below so the emitted command round-trips the pack
+                    applyPackTheme(tooltipBuilder, packId);
+                } else if (generator instanceof MinecraftItemGenerator.Builder itemBuilder) {
+                    itemBuilder.withPack(packId);
+                }
+
                 generatorImageBuilder.addGenerator(generator.build());
             });
 
@@ -783,6 +790,7 @@ public class GeneratorCommands {
                 .isTextCentered(centered)
                 .hasFirstLinePadding(firstLinePadding)
                 .withRenderBorder(renderBorder);
+            requireBorderForTooltipStyle(tooltipStyle, renderBorder);
             applyPackTheme(tooltipBuilder, packId, tooltipStyle, itemRarity);
             MinecraftTooltipGenerator tooltipGenerator = tooltipBuilder.build();
 
@@ -861,6 +869,8 @@ public class GeneratorCommands {
         @SlashOption(description = PADDING_DESCRIPTION, required = false) Integer padding,
         @SlashOption(description = MAX_LINE_LENGTH_DESCRIPTION, required = false) Integer maxLineLength,
         @SlashOption(description = RENDER_BORDER_DESCRIPTION, required = false) Boolean renderBorder,
+        @SlashOption(autocompleteId = "pack-ids", description = PACK_DESCRIPTION, required = false) String pack,
+        @SlashOption(autocompleteId = "tooltip-styles", description = TOOLTIP_STYLE_DESCRIPTION, required = false) String tooltipStyle,
         @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden
     ) {
         if (shouldBlockGeneratorCommand(event)) {
@@ -880,18 +890,20 @@ public class GeneratorCommands {
         renderBorder = renderBorder != null && renderBorder;
 
         try {
+            PackId packId = resolvePackOption(pack);
             GeneratorImageBuilder generatorImageBuilder = new GeneratorImageBuilder().withContext(context);
-            MinecraftTooltipGenerator tooltipGenerator = new MinecraftTooltipGenerator.Builder()
+            MinecraftTooltipGenerator.Builder tooltipBuilder = new MinecraftTooltipGenerator.Builder()
                 .withItemLore(TextWrapper.stripActualNewlines(text))
                 .withAlpha(alpha)
                 .withPadding(padding)
                 .withMaxLineLength(maxLineLength)
                 .isTextCentered(centered)
                 .hasFirstLinePadding(false)
-                .withRenderBorder(renderBorder)
-                .build();
+                .withRenderBorder(renderBorder);
+            requireBorderForTooltipStyle(tooltipStyle, renderBorder);
+            applyPackTheme(tooltipBuilder, packId, tooltipStyle, null);
 
-            generatorImageBuilder.addGenerator(tooltipGenerator);
+            generatorImageBuilder.addGenerator(tooltipBuilder.build());
             GeneratedObject generatedObject = generatorImageBuilder.build();
 
             if (generatedObject.isAnimated()) {
@@ -919,6 +931,7 @@ public class GeneratorCommands {
         @SlashOption(description = "If the Abiphone symbol should be shown next to the dialogue", required = false) Boolean abiphone,
         @SlashOption(description = "Player head texture (username, URL, etc.)", required = false) String skinValue,
         @SlashOption(description = RENDER_BACKGROUND_DESCRIPTION, required = false) Boolean renderBackground,
+        @SlashOption(autocompleteId = "pack-ids", description = PACK_DESCRIPTION, required = false) String pack,
         @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden
     ) {
         if (shouldBlockGeneratorCommand(event)) {
@@ -944,6 +957,7 @@ public class GeneratorCommands {
                 .withMaxLineLength(maxLineLength)
                 .withRenderBorder(renderBackground)
                 .bypassMaxLineLength(true);
+            applyPackTheme(tooltipGenerator, resolvePackOption(pack));
 
             GeneratorImageBuilder generatorImageBuilder = new GeneratorImageBuilder().withContext(context)
                 .addGenerator(tooltipGenerator.build());
@@ -983,6 +997,7 @@ public class GeneratorCommands {
         @SlashOption(description = "If the Abiphone symbol should be shown next to the dialogue", required = false) Boolean abiphone,
         @SlashOption(description = "Player head texture (username, URL, etc.)", required = false) String skinValue,
         @SlashOption(description = RENDER_BACKGROUND_DESCRIPTION, required = false) Boolean renderBackground,
+        @SlashOption(autocompleteId = "pack-ids", description = PACK_DESCRIPTION, required = false) String pack,
         @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden
     ) {
         if (shouldBlockGeneratorCommand(event)) {
@@ -1008,6 +1023,7 @@ public class GeneratorCommands {
                 .withMaxLineLength(maxLineLength)
                 .withRenderBorder(renderBackground)
                 .bypassMaxLineLength(true);
+            applyPackTheme(tooltipGenerator, resolvePackOption(pack));
 
             GeneratorImageBuilder generatorImageBuilder = new GeneratorImageBuilder().withContext(context)
                 .addGenerator(tooltipGenerator.build());
@@ -1207,6 +1223,28 @@ public class GeneratorCommands {
      *
      * @throws GeneratorException If a tooltip style is given without a resource pack
      */
+    /**
+     * Rejects an explicit tooltip_style when the border is disabled: the library only draws
+     * theme sprites when the border is rendered, so the style would silently do nothing
+     * (while an invalid style would still error — loud beats inconsistent).
+     *
+     * @throws GeneratorException If a tooltip style is given while the border is disabled
+     */
+    private static void requireBorderForTooltipStyle(String tooltipStyle, boolean renderBorder) {
+        if (tooltipStyle != null && !tooltipStyle.isBlank() && !renderBorder) {
+            throw new GeneratorException("The tooltip_style option only renders with the border; set render_border: true too!");
+        }
+    }
+
+    /**
+     * Applies pack theming for tooltips that have no rarity and no tooltip_style option (plain
+     * text, dialogue, hovered inventory lore, parsed NBT previews): the pack's default tooltip
+     * override when present, plus the pack's text color remap.
+     */
+    private void applyPackTheme(MinecraftTooltipGenerator.Builder builder, PackId packId) {
+        applyPackTheme(builder, packId, null, null);
+    }
+
     private void applyPackTheme(MinecraftTooltipGenerator.Builder builder, PackId packId, String explicitStyle, Rarity rarity) {
         boolean hasExplicitStyle = explicitStyle != null && !explicitStyle.isBlank();
 

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -629,8 +629,9 @@ public class GeneratorCommands {
 
             parsedNbt.getGenerators().forEach(generator -> {
                 if (generator instanceof MinecraftTooltipGenerator.Builder tooltipBuilder) {
-                    // Themed before buildSlashCommand below so the emitted command round-trips the pack
-                    applyPackTheme(tooltipBuilder, packId);
+                    // Themed before buildSlashCommand below so the emitted command round-trips the
+                    // pack and the rarity-derived tooltip style, reproducing the preview exactly
+                    applyPackTheme(tooltipBuilder, packId, null, tooltipBuilder.getRarity());
                 } else if (generator instanceof MinecraftItemGenerator.Builder itemBuilder) {
                     itemBuilder.withPack(packId);
                 }


### PR DESCRIPTION
## What

`/gen text`, `/gen dialogue single`, `/gen dialogue multi` and `/gen parse` now support resource packs, closing the gap with the other generator commands:

- All four take an optional `pack` option (same `pack-ids` autocomplete) and resolve to the configured default pack when omitted, so with a default pack set these commands render pack-themed out of the box instead of always vanilla.
- `/gen text` also takes `tooltip_style` like `/gen item`. Since the library only draws theme sprites when the border is rendered, an explicit `tooltip_style` without `render_border: true` is now rejected with a clear error instead of silently doing nothing. `/gen item` had the same silent no-op when passing `render_border: false`, so it gets the same guard.
- `/gen parse` applies the pack to the parsed item and tooltip builders. The preview is themed with the parsed rarity's configured pack style, and since theming happens before `buildSlashCommand()`, the emitted command round-trips `pack:` and the rarity-derived `tooltip_style:` — running it reproduces the preview exactly.
- Tooltips with no rarity (text, dialogue, hovered inventory lore) now share an `applyPackTheme(builder, packId)` overload instead of copy-pasting `null, null` arguments and the same explanatory comment around each call site.

## Depends on

Aerhhh/MinecraftImageGenerator#41 (exposes the tooltip builder's parsed rarity). CI here stays red until that merges and JitPack rebuilds `master-SNAPSHOT`; verified green locally against the library branch build.

## Notes

- Dialogue renders always pick up the pack's text color remap; the default tooltip override additionally applies when `render_background: true`.
- Rebased on master to pick up #610's `imagegenerator.version` flip back to `master-SNAPSHOT`.