### PR TITLE
fix(generator): reject malformed dialogue input instead of crashing

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -935,34 +935,16 @@ public class GeneratorCommands {
         maxLineLength = maxLineLength == null ? 91 : maxLineLength;
         renderBackground = renderBackground != null && renderBackground;
 
-        String[] lines = dialogue.split("\\\\n");
-        for (int i = 0; i < lines.length; i++) {
-            lines[i] = "&e[NPC] " + npcName + "&f: " + (abiphone ? "&b%%ABIPHONE%%&f " : "") + lines[i];
-            String line = lines[i];
-
-            if (line.contains("{options:")) {
-                String[] split = line.split("\\{options: ?");
-                lines[i] = split[0];
-                String[] options = split[1].replace("}", "").split(", ");
-                lines[i] += "\n&eSelect an option: &f";
-                for (String option : options) {
-                    lines[i] += "&a" + option + "&f ";
-                }
-            }
-        }
-
-        dialogue = String.join("\n", lines);
-
-        MinecraftTooltipGenerator.Builder tooltipGenerator = new MinecraftTooltipGenerator.Builder()
-            .withItemLore(dialogue)
-            .withAlpha(0)
-            .withPadding(MinecraftTooltip.DEFAULT_PADDING)
-            .hasFirstLinePadding(false)
-            .withMaxLineLength(maxLineLength)
-            .withRenderBorder(renderBackground)
-            .bypassMaxLineLength(true);
-
         try {
+            MinecraftTooltipGenerator.Builder tooltipGenerator = new MinecraftTooltipGenerator.Builder()
+                .withItemLore(buildSingleDialogue(npcName, dialogue, abiphone))
+                .withAlpha(0)
+                .withPadding(MinecraftTooltip.DEFAULT_PADDING)
+                .hasFirstLinePadding(false)
+                .withMaxLineLength(maxLineLength)
+                .withRenderBorder(renderBackground)
+                .bypassMaxLineLength(true);
+
             GeneratorImageBuilder generatorImageBuilder = new GeneratorImageBuilder().withContext(context)
                 .addGenerator(tooltipGenerator.build());
 
@@ -1018,39 +1000,8 @@ public class GeneratorCommands {
         renderBackground = renderBackground != null && renderBackground;
 
         try {
-            String[] lines = dialogue.split("\\\\n");
-            String[] names = npcNames.split(", ?");
-
-            for (int i = 0; i < lines.length; i++) {
-                String[] split = lines[i].split(", ?", 2);
-                try {
-                    int index = Integer.parseInt(split[0]);
-
-                    if (index >= names.length) {
-                        index = names.length - 1;
-                    }
-
-                    lines[i] = "&e[NPC] " + names[index] + "&f: " + (abiphone ? "&b%%ABIPHONE%%&f " : "") + split[1];
-                    String line = lines[i];
-
-                    if (line.contains("{options:")) {
-                        String[] split2 = line.split("\\{options: ?");
-                        lines[i] = split2[0];
-                        String[] options = split2[1].replace("}", "").split(", ?");
-                        lines[i] += "\n&eSelect an option: &f";
-                        for (String option : options) {
-                            lines[i] += "&a" + option + "&f ";
-                        }
-                    }
-                } catch (NumberFormatException exception) {
-                    throw new GeneratorException("Invalid NPC name index found in dialogue: " + split[0] + " (line " + (i + 1) + ")");
-                }
-            }
-
-            dialogue = String.join("\n", lines);
-
             MinecraftTooltipGenerator.Builder tooltipGenerator = new MinecraftTooltipGenerator.Builder()
-                .withItemLore(dialogue)
+                .withItemLore(buildMultiDialogue(npcNames, dialogue, abiphone))
                 .withAlpha(0)
                 .withPadding(MinecraftTooltip.DEFAULT_PADDING)
                 .hasFirstLinePadding(false)
@@ -1085,6 +1036,72 @@ public class GeneratorCommands {
             event.getHook().editOriginal("An error occurred while generating the dialogue!").queue();
             log.error("Encountered an error while generating dialogue", exception);
         }
+    }
+
+    static String buildSingleDialogue(String npcName, String dialogue, boolean abiphone) {
+        String[] lines = dialogue.split("\\\\n");
+
+        for (int i = 0; i < lines.length; i++) {
+            lines[i] = expandDialogueOptions(npcDialogueLine(npcName, abiphone, lines[i]), i + 1);
+        }
+
+        return String.join("\n", lines);
+    }
+
+    static String buildMultiDialogue(String npcNames, String dialogue, boolean abiphone) {
+        String[] lines = dialogue.split("\\\\n");
+        String[] names = npcNames.split(", ?");
+
+        for (int i = 0; i < lines.length; i++) {
+            String[] split = lines[i].split(", ?", 2);
+
+            if (split.length < 2) {
+                throw new GeneratorException("Each line must start with an NPC index followed by a comma (line " + (i + 1) + ")! Example: 0, Hello!");
+            }
+
+            int index;
+            try {
+                index = Integer.parseInt(split[0]);
+            } catch (NumberFormatException exception) {
+                throw new GeneratorException("Invalid NPC name index found in dialogue: " + split[0] + " (line " + (i + 1) + ")");
+            }
+
+            if (index < 0) {
+                throw new GeneratorException("Invalid NPC name index found in dialogue: " + split[0] + " (line " + (i + 1) + ")");
+            }
+
+            if (index >= names.length) {
+                index = names.length - 1;
+            }
+
+            lines[i] = expandDialogueOptions(npcDialogueLine(names[index], abiphone, split[1]), i + 1);
+        }
+
+        return String.join("\n", lines);
+    }
+
+    private static String npcDialogueLine(String npcName, boolean abiphone, String text) {
+        return "&e[NPC] " + npcName + "&f: " + (abiphone ? "&b%%ABIPHONE%%&f " : "") + text;
+    }
+
+    private static String expandDialogueOptions(String line, int lineNumber) {
+        if (!line.contains("{options:")) {
+            return line;
+        }
+
+        String[] split = line.split("\\{options: ?");
+
+        if (split.length < 2 || split[1].replace("}", "").isBlank()) {
+            throw new GeneratorException("Malformed {options: ...} block in dialogue (line " + lineNumber + ")! Expected format: {options: Option 1, Option 2}");
+        }
+
+        StringBuilder result = new StringBuilder(split[0]).append("\n&eSelect an option: &f");
+
+        for (String option : split[1].replace("}", "").split(", ?")) {
+            result.append("&a").append(option).append("&f ");
+        }
+
+        return result.toString();
     }
 
     @SlashCommand(name = BASE_COMMAND, subcommand = "history", description = "View your command history", guildOnly = true)

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/GeneratorCommandsTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/GeneratorCommandsTest.java
@@ -1,5 +1,6 @@
 package net.hypixel.nerdbot.app.command;
 
+import net.aerh.imagegenerator.exception.GeneratorException;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.generator.GeneratorHistory;
 import org.junit.jupiter.api.Test;
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GeneratorCommandsTest {
@@ -39,5 +41,114 @@ class GeneratorCommandsTest {
         discordUser.getGeneratorHistory().addCommand("/gen text text:hello");
 
         assertEquals(List.of("/gen item id:stick", "/gen text text:hello"), GeneratorCommands.getCommandHistory(discordUser));
+    }
+
+    @Test
+    void buildSingleDialoguePrefixesEachLineWithNpcName() {
+        assertEquals(
+            "&e[NPC] Steve&f: Hello\n&e[NPC] Steve&f: Bye",
+            GeneratorCommands.buildSingleDialogue("Steve", "Hello\\nBye", false)
+        );
+    }
+
+    @Test
+    void buildSingleDialogueIncludesAbiphoneSymbolWhenEnabled() {
+        assertEquals(
+            "&e[NPC] Steve&f: &b%%ABIPHONE%%&f Hello",
+            GeneratorCommands.buildSingleDialogue("Steve", "Hello", true)
+        );
+    }
+
+    @Test
+    void buildSingleDialogueExpandsOptionsBlock() {
+        assertEquals(
+            "&e[NPC] Steve&f: Hi \n&eSelect an option: &f&aYes&f &aNo&f ",
+            GeneratorCommands.buildSingleDialogue("Steve", "Hi {options: Yes, No}", false)
+        );
+    }
+
+    @Test
+    void buildSingleDialogueRejectsOptionsBlockWithNothingAfterMarker() {
+        GeneratorException exception = assertThrows(GeneratorException.class,
+            () -> GeneratorCommands.buildSingleDialogue("Steve", "Hello {options:", false));
+
+        assertEquals("Malformed {options: ...} block in dialogue (line 1)! Expected format: {options: Option 1, Option 2}", exception.getMessage());
+    }
+
+    @Test
+    void buildSingleDialogueRejectsEmptyOptionsBlock() {
+        assertThrows(GeneratorException.class, () -> GeneratorCommands.buildSingleDialogue("Steve", "Hello {options:}", false));
+    }
+
+    @Test
+    void buildSingleDialogueReportsLineNumberOfMalformedOptionsBlock() {
+        GeneratorException exception = assertThrows(GeneratorException.class,
+            () -> GeneratorCommands.buildSingleDialogue("Steve", "Hello\\nBye {options:", false));
+
+        assertTrue(exception.getMessage().contains("line 2"));
+    }
+
+    @Test
+    void buildMultiDialogueInterpolatesNpcNamesByIndex() {
+        assertEquals(
+            "&e[NPC] Alice&f: Hi\n&e[NPC] Bob&f: Hey",
+            GeneratorCommands.buildMultiDialogue("Alice, Bob", "0, Hi\\n1, Hey", false)
+        );
+    }
+
+    @Test
+    void buildMultiDialogueIncludesAbiphoneSymbolWhenEnabled() {
+        assertEquals(
+            "&e[NPC] Alice&f: &b%%ABIPHONE%%&f Hi",
+            GeneratorCommands.buildMultiDialogue("Alice", "0, Hi", true)
+        );
+    }
+
+    @Test
+    void buildMultiDialogueClampsTooLargeIndexToLastName() {
+        assertEquals(
+            "&e[NPC] Bob&f: Hi",
+            GeneratorCommands.buildMultiDialogue("Alice, Bob", "5, Hi", false)
+        );
+    }
+
+    @Test
+    void buildMultiDialogueExpandsOptionsBlock() {
+        assertEquals(
+            "&e[NPC] Alice&f: Hi \n&eSelect an option: &f&aYes&f &aNo&f ",
+            GeneratorCommands.buildMultiDialogue("Alice, Bob", "0, Hi {options: Yes, No}", false)
+        );
+    }
+
+    @Test
+    void buildMultiDialogueRejectsLineWithoutComma() {
+        GeneratorException exception = assertThrows(GeneratorException.class,
+            () -> GeneratorCommands.buildMultiDialogue("Alice, Bob", "0", false));
+
+        assertEquals("Each line must start with an NPC index followed by a comma (line 1)! Example: 0, Hello!", exception.getMessage());
+    }
+
+    @Test
+    void buildMultiDialogueRejectsNonNumericIndex() {
+        GeneratorException exception = assertThrows(GeneratorException.class,
+            () -> GeneratorCommands.buildMultiDialogue("Alice, Bob", "abc, Hi", false));
+
+        assertEquals("Invalid NPC name index found in dialogue: abc (line 1)", exception.getMessage());
+    }
+
+    @Test
+    void buildMultiDialogueRejectsNegativeIndex() {
+        GeneratorException exception = assertThrows(GeneratorException.class,
+            () -> GeneratorCommands.buildMultiDialogue("Alice, Bob", "-1, Hi", false));
+
+        assertEquals("Invalid NPC name index found in dialogue: -1 (line 1)", exception.getMessage());
+    }
+
+    @Test
+    void buildMultiDialogueRejectsMalformedOptionsBlock() {
+        GeneratorException exception = assertThrows(GeneratorException.class,
+            () -> GeneratorCommands.buildMultiDialogue("Alice, Bob", "0, Hi\\n1, Hey {options:", false));
+
+        assertTrue(exception.getMessage().contains("line 2"));
     }
 }


### PR DESCRIPTION
## Summary

`/gen dialogue single` and `/gen dialogue multi` could leave the interaction permanently stuck on "thinking..." for malformed input:

- **single**: an `{options:` block with nothing after the marker crashed with `ArrayIndexOutOfBoundsException` *before/outside* the command's try block, so nothing ever edited the deferred reply.
- **multi**: a line without an NPC index comma (e.g. `0`), a negative index (e.g. `-1, Hi`), or an empty `{options:` block crashed inside the try, but the `GeneratorException | IOException` catches don't cover `ArrayIndexOutOfBoundsException`.

## Changes

- Extracted dialogue preprocessing into package-private static helpers (`buildSingleDialogue` / `buildMultiDialogue` with a shared `expandDialogueOptions`), de-duplicating the options expansion and NPC-prefix construction between the two commands.
- Malformed input now throws `GeneratorException` with actionable messages (including the offending line number), e.g.
  - `Malformed {options: ...} block in dialogue (line 2)! Expected format: {options: Option 1, Option 2}`
  - `Each line must start with an NPC index followed by a comma (line 1)! Example: 0, Hello!`
- Moved the single-dialogue preprocessing inside the try block so those messages actually reach the user via the deferred-reply edit.
- Guarded the previously unhandled negative NPC index crash in multi.
- Unified the option separator: single required `", "` while multi accepted `", ?"`; both now accept a comma without a space.

## Testing

14 new JUnit tests covering the happy paths (prefixing, abiphone symbol, options expansion, index clamping) and every malformed-input case above. Full `app` module suite passes (59 tests).