### PR TITLE
chore: bump SlashCommands to v1.0.12

### DIFF
--- a/discord-framework/pom.xml
+++ b/discord-framework/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.github.Aerhhh</groupId>
             <artifactId>SlashCommands</artifactId>
-            <version>v1.0.11</version>
+            <version>v1.0.12</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Picks up [SlashCommands v1.0.12](https://github.com/Aerhhh/SlashCommands/releases/tag/v1.0.12), which fixes the framework error path for acknowledged interactions: when a command defers its reply and then throws, the framework now edits the deferred reply with an error message instead of leaving the user on a permanent "thinking..." state ([Aerhhh/SlashCommands#34](https://github.com/Aerhhh/SlashCommands/pull/34)).

Complements SkyBlock-Nerds/NerdBot#612, which fixes the specific `/gen dialogue` crashes at the source with actionable per-input error messages; this bump is the safety net for every other command.

Verified locally: full reactor test run against the JitPack `v1.0.12` artifact passes.