### PR TITLE
chore: bump SlashCommands to v1.0.13

### DIFF
--- a/discord-framework/pom.xml
+++ b/discord-framework/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.github.Aerhhh</groupId>
             <artifactId>SlashCommands</artifactId>
-            <version>v1.0.12</version>
+            <version>v1.0.13</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Picks up [SlashCommands v1.0.13](https://github.com/Aerhhh/SlashCommands/releases/tag/v1.0.13), which extends the deferred-interaction error fix from v1.0.12 to modal and component (button/select menu) handlers ([Aerhhh/SlashCommands#35](https://github.com/Aerhhh/SlashCommands/pull/35)): a handler that defers and then throws now responds with an error instead of leaving the user on a permanent "thinking..." state.

Verified locally: full reactor test run against the JitPack `v1.0.13` artifact passes (59 tests).