### PR TITLE
feat(generator): pack-driven animated item renders

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -102,7 +102,7 @@ public class GeneratorCommands {
     private static final String COLOR_DESCRIPTION = "The overlay color (e.g., red, blue, #FF0000)";
     private static final String PACK_DESCRIPTION = "The resource pack used to resolve item textures";
     private static final String TOOLTIP_STYLE_DESCRIPTION = "The pack tooltip style to render with (defaults to the rarity's configured style)";
-    private static final String ANIMATED_DESCRIPTION = "Render the pack's animated item textures as a GIF (requires a pack with animated textures)";
+    private static final String ANIMATED_DESCRIPTION = "Whether animated pack textures render as a GIF (defaults to the texture's own animation data; False forces a static render)";
 
     private static final boolean AUTO_HIDE_ON_ERROR = true;
 
@@ -132,7 +132,7 @@ public class GeneratorCommands {
 
         enchanted = enchanted != null && enchanted;
         hoverEffect = hoverEffect != null && hoverEffect;
-        animated = animated != null && animated;
+        animated = animated == null || animated;
         durability = durability == null ? 100 : durability;
 
         try {
@@ -207,7 +207,7 @@ public class GeneratorCommands {
         alpha = alpha == null ? MinecraftTooltip.DEFAULT_ALPHA : alpha;
         padding = padding == null ? MinecraftTooltip.DEFAULT_PADDING : padding;
         enchanted = enchanted != null && enchanted;
-        animated = animated != null && animated;
+        animated = animated == null || animated;
 
         Function<String, Map<String, Integer>> parseStatsToMap = stats -> {
             Map<String, Integer> map = new HashMap<>();
@@ -620,10 +620,11 @@ public class GeneratorCommands {
                     // pack and the rarity-derived tooltip style, reproducing the preview exactly
                     applyPackTheme(tooltipBuilder, packId, null, tooltipBuilder.getRarity());
                 } else if (generator instanceof MinecraftItemGenerator.Builder itemBuilder) {
-                    // Parsed NBT reproduces a static item and emits a reproducible command; animation
-                    // is an explicit opt-in exposed only on /gen item, display and powerstone, so it is
-                    // deliberately not resolved here (there is no animate intent in the source NBT).
-                    applyItemPack(itemBuilder, packId, false);
+                    // The texture's own animation data decides the output, matching the item
+                    // commands' default: an animated pack texture parses into a GIF preview and
+                    // everything else stays static. The emitted command round-trips because the
+                    // animated option defaults on everywhere.
+                    applyItemPack(itemBuilder, packId, true);
                 }
 
                 generatorImageBuilder.addGenerator(generator.build());
@@ -758,7 +759,7 @@ public class GeneratorCommands {
         padding = padding == null ? MinecraftTooltip.DEFAULT_PADDING : padding;
         centered = centered != null && centered;
         enchanted = enchanted != null && enchanted;
-        animated = animated != null && animated;
+        animated = animated == null || animated;
         firstLinePadding = firstLinePadding == null || firstLinePadding;
         maxLineLength = maxLineLength == null ? MinecraftTooltipGenerator.DEFAULT_MAX_LINE_LENGTH : maxLineLength;
         renderBorder = renderBorder == null || renderBorder;
@@ -1037,7 +1038,8 @@ public class GeneratorCommands {
      * @param slashCommand The tooltip builder's reconstructed command to append onto
      * @param itemId       The rendered item id, or null/blank when no item was rendered
      * @param enchanted    Whether the item render was enchanted
-     * @param animated     Whether the item render used the pack's animated textures
+     * @param animated     Whether the item render used the pack's animated textures; false emits
+     *                     an explicit opt-out because animation defaults on
      *
      * @return The slash command with the item options appended
      */
@@ -1050,8 +1052,8 @@ public class GeneratorCommands {
             slashCommand += " enchanted: True";
         }
 
-        if (animated) {
-            slashCommand += " animated: True";
+        if (!animated) {
+            slashCommand += " animated: False";
         }
 
         return slashCommand;

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -320,16 +320,8 @@ public class GeneratorCommands {
 
                 if (includeGenCommand != null && includeGenCommand) {
                     // The builder round-trips its own fields (including pack and tooltip_style);
-                    // only options that belong to other generators still need appending by hand.
-                    String slashCommand = tooltipGenerator.buildSlashCommand();
-
-                    if (itemId != null && !itemId.isBlank()) {
-                        slashCommand += " item_id: " + itemId;
-                    }
-
-                    if (enchanted) {
-                        slashCommand += " enchanted: True";
-                    }
+                    // only options that belong to the item generator still need appending by hand.
+                    String slashCommand = appendPowerStoneItemOptions(tooltipGenerator.buildSlashCommand(), itemId, enchanted, animated);
 
                     event.getHook().sendMessage("Your Power Stone has been parsed into a slash command:\n```" + slashCommand.trim() + "```").queue();
                 }
@@ -628,6 +620,9 @@ public class GeneratorCommands {
                     // pack and the rarity-derived tooltip style, reproducing the preview exactly
                     applyPackTheme(tooltipBuilder, packId, null, tooltipBuilder.getRarity());
                 } else if (generator instanceof MinecraftItemGenerator.Builder itemBuilder) {
+                    // Parsed NBT reproduces a static item and emits a reproducible command; animation
+                    // is an explicit opt-in exposed only on /gen item, display and powerstone, so it is
+                    // deliberately not resolved here (there is no animate intent in the source NBT).
                     applyItemPack(itemBuilder, packId, false);
                 }
 
@@ -1030,6 +1025,36 @@ public class GeneratorCommands {
             event.getHook().editOriginal("An error occurred while generating the dialogue!").queue();
             log.error("Encountered an error while generating dialogue", exception);
         }
+    }
+
+    /**
+     * Appends the options driving the Power Stone's item render onto its reconstructed slash
+     * command. The tooltip builder already round-trips its own fields (name, lore, pack,
+     * tooltip_style) via {@link MinecraftTooltipGenerator.Builder#buildSlashCommand()}; item_id,
+     * enchanted and animated belong to the sibling item generator, so they are appended here so a
+     * re-run reproduces the same render (an animated Power Stone stays animated on round-trip).
+     *
+     * @param slashCommand The tooltip builder's reconstructed command to append onto
+     * @param itemId       The rendered item id, or null/blank when no item was rendered
+     * @param enchanted    Whether the item render was enchanted
+     * @param animated     Whether the item render used the pack's animated textures
+     *
+     * @return The slash command with the item options appended
+     */
+    static String appendPowerStoneItemOptions(String slashCommand, String itemId, boolean enchanted, boolean animated) {
+        if (itemId != null && !itemId.isBlank()) {
+            slashCommand += " item_id: " + itemId;
+        }
+
+        if (enchanted) {
+            slashCommand += " enchanted: True";
+        }
+
+        if (animated) {
+            slashCommand += " animated: True";
+        }
+
+        return slashCommand;
     }
 
     static String buildSingleDialogue(String npcName, String dialogue, boolean abiphone) {

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -20,6 +20,7 @@ import net.aerh.imagegenerator.impl.MinecraftPlayerHeadGenerator;
 import net.aerh.imagegenerator.impl.tooltip.MinecraftTooltipGenerator;
 import net.aerh.imagegenerator.item.GeneratedObject;
 import net.aerh.imagegenerator.pack.PackId;
+import net.aerh.imagegenerator.pack.PackRepository;
 import net.aerh.imagegenerator.spritesheet.OverlayLoader;
 import net.aerh.imagegenerator.spritesheet.Spritesheet;
 import net.aerh.imagegenerator.text.TextColorRemap;
@@ -101,6 +102,7 @@ public class GeneratorCommands {
     private static final String COLOR_DESCRIPTION = "The overlay color (e.g., red, blue, #FF0000)";
     private static final String PACK_DESCRIPTION = "The resource pack used to resolve item textures";
     private static final String TOOLTIP_STYLE_DESCRIPTION = "The pack tooltip style to render with (defaults to the rarity's configured style)";
+    private static final String ANIMATED_DESCRIPTION = "Render the pack's animated item textures as a GIF (requires a pack with animated textures)";
 
     private static final boolean AUTO_HIDE_ON_ERROR = true;
 
@@ -115,6 +117,7 @@ public class GeneratorCommands {
         @SlashOption(description = SKIN_VALUE_DESCRIPTION, required = false) String skinValue,
         @SlashOption(description = DURABILITY_DESCRIPTION, required = false) Integer durability,
         @SlashOption(autocompleteId = "pack-ids", description = PACK_DESCRIPTION, required = false) String pack,
+        @SlashOption(description = ANIMATED_DESCRIPTION, required = false) Boolean animated,
         @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden
     ) {
         if (shouldBlockGeneratorCommand(event)) {
@@ -129,6 +132,7 @@ public class GeneratorCommands {
 
         enchanted = enchanted != null && enchanted;
         hoverEffect = hoverEffect != null && hoverEffect;
+        animated = animated != null && animated;
         durability = durability == null ? 100 : durability;
 
         try {
@@ -146,8 +150,8 @@ public class GeneratorCommands {
                     .withColor(color)
                     .isEnchanted(enchanted)
                     .withHoverEffect(hoverEffect)
-                    .withPack(packId)
                     .isBigImage();
+                applyItemPack(itemBuilder, packId, animated);
 
                 if (durability != null) {
                     itemBuilder.withDurability(durability);
@@ -158,11 +162,7 @@ public class GeneratorCommands {
 
             GeneratedObject generatedObject = item.build();
 
-            if (generatedObject.isAnimated()) {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(generatedObject.getGifData(), "item.gif")).queue();
-            } else {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "item.png")).queue();
-            }
+            event.getHook().editOriginalAttachments(renderAttachment(generatedObject, "item")).queue();
 
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         } catch (GeneratorException exception) {
@@ -191,6 +191,7 @@ public class GeneratorCommands {
         @SlashOption(description = "Whether the Power Stone shows as selected", required = false) Boolean selected,
         @SlashOption(description = ENCHANTED_DESCRIPTION, required = false) Boolean enchanted,
         @SlashOption(autocompleteId = "pack-ids", description = PACK_DESCRIPTION, required = false) String pack,
+        @SlashOption(description = ANIMATED_DESCRIPTION, required = false) Boolean animated,
         @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden
     ) {
         if (shouldBlockGeneratorCommand(event)) {
@@ -206,6 +207,7 @@ public class GeneratorCommands {
         alpha = alpha == null ? MinecraftTooltip.DEFAULT_ALPHA : alpha;
         padding = padding == null ? MinecraftTooltip.DEFAULT_PADDING : padding;
         enchanted = enchanted != null && enchanted;
+        animated = animated != null && animated;
 
         Function<String, Map<String, Integer>> parseStatsToMap = stats -> {
             Map<String, Integer> map = new HashMap<>();
@@ -343,24 +345,21 @@ public class GeneratorCommands {
 
                         generatorImageBuilder.addGenerator(generator.build());
                     } else {
-                        generatorImageBuilder.addGenerator(new MinecraftItemGenerator.Builder()
+                        MinecraftItemGenerator.Builder itemBuilder = new MinecraftItemGenerator.Builder()
                             .withItem(itemId)
                             .withColor(color)
                             .isEnchanted(enchanted)
-                            .withPack(packId)
-                            .isBigImage()
-                            .build());
+                            .isBigImage();
+                        applyItemPack(itemBuilder, packId, animated);
+
+                        generatorImageBuilder.addGenerator(itemBuilder.build());
                     }
                 }
 
                 generatorImageBuilder.addGenerator(tooltipGenerator.build());
                 GeneratedObject generatedObject = generatorImageBuilder.build();
 
-                if (generatedObject.isAnimated()) {
-                    event.getHook().editOriginalAttachments(FileUpload.fromData(generatedObject.getGifData(), "powerstone.gif")).queue();
-                } else {
-                    event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "powerstone.png")).queue();
-                }
+                event.getHook().editOriginalAttachments(renderAttachment(generatedObject, "powerstone")).queue();
 
                 addCommandToUserHistory(event.getUser(), event.getCommandString());
             } catch (GeneratorException | IllegalArgumentException exception) {
@@ -510,7 +509,7 @@ public class GeneratorCommands {
                     .build())
                 .build();
 
-            event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "recipe.png")).queue();
+            event.getHook().editOriginalAttachments(renderAttachment(generatedObject, "recipe")).queue();
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         } catch (GeneratorException exception) {
             event.getHook().editOriginal(exception.getMessage()).queue();
@@ -578,11 +577,7 @@ public class GeneratorCommands {
 
             GeneratedObject finalObject = generatedObject.build();
 
-            if (finalObject.isAnimated()) {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(finalObject.getGifData(), "inventory.gif")).queue();
-            } else {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(finalObject.getImage()), "inventory.png")).queue();
-            }
+            event.getHook().editOriginalAttachments(renderAttachment(finalObject, "inventory")).queue();
 
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         } catch (GeneratorException exception) {
@@ -633,7 +628,7 @@ public class GeneratorCommands {
                     // pack and the rarity-derived tooltip style, reproducing the preview exactly
                     applyPackTheme(tooltipBuilder, packId, null, tooltipBuilder.getRarity());
                 } else if (generator instanceof MinecraftItemGenerator.Builder itemBuilder) {
-                    itemBuilder.withPack(packId);
+                    applyItemPack(itemBuilder, packId, false);
                 }
 
                 generatorImageBuilder.addGenerator(generator.build());
@@ -676,11 +671,7 @@ public class GeneratorCommands {
             MessageEditBuilder builder = new MessageEditBuilder()
                 .setContent("Your NBT " + sourceLabel + " has been parsed into a slash command:" + System.lineSeparator() + "```" + System.lineSeparator() + slashCommand + "```");
 
-            if (generatedObject.isAnimated()) {
-                builder.setFiles(FileUpload.fromData(generatedObject.getGifData(), "parsed_nbt.gif"));
-            } else {
-                builder.setFiles(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "parsed_nbt.png"));
-            }
+            builder.setFiles(renderAttachment(generatedObject, "parsed_nbt"));
 
             event.getHook().editOriginal(builder.build()).queue();
             addCommandToUserHistory(event.getUser(), event.getCommandString());
@@ -753,6 +744,7 @@ public class GeneratorCommands {
         @SlashOption(description = DURABILITY_DESCRIPTION, required = false) Integer durability,
         @SlashOption(autocompleteId = "pack-ids", description = PACK_DESCRIPTION, required = false) String pack,
         @SlashOption(autocompleteId = "tooltip-styles", description = TOOLTIP_STYLE_DESCRIPTION, required = false) String tooltipStyle,
+        @SlashOption(description = ANIMATED_DESCRIPTION, required = false) Boolean animated,
         @SlashOption(description = HIDDEN_OUTPUT_DESCRIPTION, required = false) Boolean hidden
     ) {
         if (shouldBlockGeneratorCommand(event)) {
@@ -771,6 +763,7 @@ public class GeneratorCommands {
         padding = padding == null ? MinecraftTooltip.DEFAULT_PADDING : padding;
         centered = centered != null && centered;
         enchanted = enchanted != null && enchanted;
+        animated = animated != null && animated;
         firstLinePadding = firstLinePadding == null || firstLinePadding;
         maxLineLength = maxLineLength == null ? MinecraftTooltipGenerator.DEFAULT_MAX_LINE_LENGTH : maxLineLength;
         renderBorder = renderBorder == null || renderBorder;
@@ -810,8 +803,8 @@ public class GeneratorCommands {
                         .withItem(itemId)
                         .withColor(color)
                         .isEnchanted(enchanted)
-                        .withPack(packId)
                         .isBigImage();
+                    applyItemPack(itemBuilder, packId, animated);
 
                     if (durability != null) {
                         itemBuilder.withDurability(durability);
@@ -845,11 +838,7 @@ public class GeneratorCommands {
 
             GeneratedObject generatedObject = generatorImageBuilder.build();
 
-            if (generatedObject.isAnimated()) {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(generatedObject.getGifData(), "item.gif")).queue();
-            } else {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "item.png")).queue();
-            }
+            event.getHook().editOriginalAttachments(renderAttachment(generatedObject, "item")).queue();
 
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         } catch (GeneratorException | IllegalArgumentException exception) {
@@ -907,11 +896,7 @@ public class GeneratorCommands {
             generatorImageBuilder.addGenerator(tooltipBuilder.build());
             GeneratedObject generatedObject = generatorImageBuilder.build();
 
-            if (generatedObject.isAnimated()) {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(generatedObject.getGifData(), "text.gif")).queue();
-            } else {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "text.png")).queue();
-            }
+            event.getHook().editOriginalAttachments(renderAttachment(generatedObject, "text")).queue();
 
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         } catch (GeneratorException exception) {
@@ -973,11 +958,7 @@ public class GeneratorCommands {
 
             GeneratedObject generatedObject = generatorImageBuilder.build();
 
-            if (generatedObject.isAnimated()) {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(generatedObject.getGifData(), "dialogue.gif")).queue();
-            } else {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "dialogue.png")).queue();
-            }
+            event.getHook().editOriginalAttachments(renderAttachment(generatedObject, "dialogue")).queue();
 
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         } catch (GeneratorException exception) {
@@ -1039,11 +1020,7 @@ public class GeneratorCommands {
 
             GeneratedObject generatedObject = generatorImageBuilder.build();
 
-            if (generatedObject.isAnimated()) {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(generatedObject.getGifData(), "dialogue.gif")).queue();
-            } else {
-                event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "dialogue.png")).queue();
-            }
+            event.getHook().editOriginalAttachments(renderAttachment(generatedObject, "dialogue")).queue();
 
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         } catch (GeneratorException exception) {
@@ -1214,6 +1191,44 @@ public class GeneratorCommands {
      */
     private PackId resolvePackOption(String pack) {
         return SkyBlockNerdsBot.resourcePackService().resolvePackOption(pack);
+    }
+
+    /**
+     * Applies the resolved pack to an item builder: the pack selection, the repository the bot
+     * manages the pack in, and the animated-textures opt-in. Mirrors {@link #applyPackTheme} for
+     * tooltips so every item render resolves against the same pack state. With no pack (vanilla)
+     * and animation off this leaves the render byte-identical to the pre-pack path.
+     *
+     * @param builder  The item builder to configure
+     * @param packId   The resolved pack, or null for vanilla rendering
+     * @param animated Whether to render the pack's animated item textures as a GIF
+     */
+    private void applyItemPack(MinecraftItemGenerator.Builder builder, PackId packId, boolean animated) {
+        PackRepository packRepository = SkyBlockNerdsBot.resourcePackService().packRepository();
+        builder.withPack(packId)
+            .withPackRepository(packRepository)
+            .withAnimatedTextures(animated);
+    }
+
+    /**
+     * Builds the Discord attachment for a generated render, branching on
+     * {@link GeneratedObject#isAnimated()}: animated renders upload the encoded GIF bytes as
+     * {@code <baseName>.gif}, static renders upload the PNG as {@code <baseName>.png}. Shared by
+     * every generator command so the GIF/PNG decision stays in one place.
+     *
+     * @param generatedObject The render to attach
+     * @param baseName        The attachment file name without extension (e.g. {@code "item"})
+     *
+     * @return The {@link FileUpload} to send back to Discord
+     *
+     * @throws IOException If writing the static PNG to a temporary file fails
+     */
+    static FileUpload renderAttachment(GeneratedObject generatedObject, String baseName) throws IOException {
+        if (generatedObject.isAnimated()) {
+            return FileUpload.fromData(generatedObject.getGifData(), baseName + ".gif");
+        }
+
+        return FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), baseName + ".png");
     }
 
     /**

--- a/app/src/main/java/net/hypixel/nerdbot/app/generation/pack/ResourcePackService.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/generation/pack/ResourcePackService.java
@@ -62,6 +62,15 @@ public class ResourcePackService {
     }
 
     /**
+     * The {@link PackRepository} this service registers packs into, so generator builders resolve
+     * pack content against the exact repository the bot manages rather than an implicit default.
+     */
+    @NotNull
+    public PackRepository packRepository() {
+        return packRepository;
+    }
+
+    /**
      * Registers every pack declared in the given configuration. A pack that fails to load is
      * logged and skipped so that one broken pack cannot prevent the bot (or the other packs)
      * from starting. Already-registered pack IDs are skipped, making this safe to call again on

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/GeneratorCommandsTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/GeneratorCommandsTest.java
@@ -59,6 +59,42 @@ class GeneratorCommandsTest {
     }
 
     @Test
+    void appendPowerStoneItemOptionsAppendsItemIdWhenPresent() {
+        assertEquals("/gen powerstone item_id: stick",
+            GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "stick", false, false));
+    }
+
+    @Test
+    void appendPowerStoneItemOptionsOmitsItemIdWhenNullOrBlank() {
+        assertEquals("/gen powerstone", GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", null, false, false));
+        assertEquals("/gen powerstone", GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "  ", false, false));
+    }
+
+    @Test
+    void appendPowerStoneItemOptionsAppendsEnchantedWhenTrue() {
+        assertEquals("/gen powerstone item_id: stick enchanted: True",
+            GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "stick", true, false));
+    }
+
+    @Test
+    void appendPowerStoneItemOptionsAppendsAnimatedWhenTrue() {
+        assertEquals("/gen powerstone item_id: stick animated: True",
+            GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "stick", false, true));
+    }
+
+    @Test
+    void appendPowerStoneItemOptionsOmitsAnimatedWhenFalse() {
+        assertEquals("/gen powerstone item_id: stick",
+            GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "stick", false, false));
+    }
+
+    @Test
+    void appendPowerStoneItemOptionsAppendsAllOptionsInOrder() {
+        assertEquals("/gen powerstone item_id: stick enchanted: True animated: True",
+            GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "stick", true, true));
+    }
+
+    @Test
     void getCommandHistoryReturnsEmptyListForNullUser() {
         assertTrue(GeneratorCommands.getCommandHistory(null).isEmpty());
     }

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/GeneratorCommandsTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/GeneratorCommandsTest.java
@@ -61,37 +61,37 @@ class GeneratorCommandsTest {
     @Test
     void appendPowerStoneItemOptionsAppendsItemIdWhenPresent() {
         assertEquals("/gen powerstone item_id: stick",
-            GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "stick", false, false));
+            GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "stick", false, true));
     }
 
     @Test
     void appendPowerStoneItemOptionsOmitsItemIdWhenNullOrBlank() {
-        assertEquals("/gen powerstone", GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", null, false, false));
-        assertEquals("/gen powerstone", GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "  ", false, false));
+        assertEquals("/gen powerstone", GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", null, false, true));
+        assertEquals("/gen powerstone", GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "  ", false, true));
     }
 
     @Test
     void appendPowerStoneItemOptionsAppendsEnchantedWhenTrue() {
         assertEquals("/gen powerstone item_id: stick enchanted: True",
-            GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "stick", true, false));
+            GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "stick", true, true));
     }
 
     @Test
-    void appendPowerStoneItemOptionsAppendsAnimatedWhenTrue() {
-        assertEquals("/gen powerstone item_id: stick animated: True",
+    void appendPowerStoneItemOptionsOmitsAnimatedWhenDefaultedOn() {
+        assertEquals("/gen powerstone item_id: stick",
             GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "stick", false, true));
     }
 
     @Test
-    void appendPowerStoneItemOptionsOmitsAnimatedWhenFalse() {
-        assertEquals("/gen powerstone item_id: stick",
+    void appendPowerStoneItemOptionsAppendsAnimatedFalseWhenOptedOut() {
+        assertEquals("/gen powerstone item_id: stick animated: False",
             GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "stick", false, false));
     }
 
     @Test
     void appendPowerStoneItemOptionsAppendsAllOptionsInOrder() {
-        assertEquals("/gen powerstone item_id: stick enchanted: True animated: True",
-            GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "stick", true, true));
+        assertEquals("/gen powerstone item_id: stick enchanted: True animated: False",
+            GeneratorCommands.appendPowerStoneItemOptions("/gen powerstone", "stick", true, false));
     }
 
     @Test

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/GeneratorCommandsTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/GeneratorCommandsTest.java
@@ -1,17 +1,62 @@
 package net.hypixel.nerdbot.app.command;
 
 import net.aerh.imagegenerator.exception.GeneratorException;
+import net.aerh.imagegenerator.item.GeneratedObject;
+import net.dv8tion.jda.api.utils.FileUpload;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.generator.GeneratorHistory;
 import org.junit.jupiter.api.Test;
 
+import java.awt.image.BufferedImage;
+import java.io.IOException;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GeneratorCommandsTest {
+
+    @Test
+    void renderAttachmentUploadsStaticRenderAsPng() throws IOException {
+        GeneratedObject staticObject = new GeneratedObject(new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB));
+
+        try (FileUpload upload = GeneratorCommands.renderAttachment(staticObject, "item")) {
+            assertEquals("item.png", upload.getName());
+        }
+    }
+
+    @Test
+    void renderAttachmentUploadsAnimatedRenderAsGif() throws IOException {
+        byte[] gifData = {'G', 'I', 'F', '8', '9', 'a'};
+        GeneratedObject animatedObject = new GeneratedObject(
+            gifData,
+            List.of(new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)),
+            50
+        );
+
+        try (FileUpload upload = GeneratorCommands.renderAttachment(animatedObject, "item")) {
+            assertEquals("item.gif", upload.getName());
+            assertArrayEquals(gifData, upload.getData().readAllBytes());
+        }
+    }
+
+    @Test
+    void renderAttachmentUsesGivenBaseNameForFileExtension() throws IOException {
+        GeneratedObject staticObject = new GeneratedObject(new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB));
+        GeneratedObject animatedObject = new GeneratedObject(
+            new byte[]{1, 2, 3, 4},
+            List.of(new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)),
+            50
+        );
+
+        try (FileUpload pngUpload = GeneratorCommands.renderAttachment(staticObject, "recipe");
+             FileUpload gifUpload = GeneratorCommands.renderAttachment(animatedObject, "powerstone")) {
+            assertEquals("recipe.png", pngUpload.getName());
+            assertEquals("powerstone.gif", gifUpload.getName());
+        }
+    }
 
     @Test
     void getCommandHistoryReturnsEmptyListForNullUser() {


### PR DESCRIPTION
Items now render through the image generator's merged pack pipeline. `/gen item`, `display` and `powerstone` (and parse previews) resolve the selected pack's item models via `withItemModel`, `withPack` and `withPackRepository`, so every pack item renders - including ones whose models parent unshipped vanilla templates - and animated pack textures come back as looping GIFs with their exact authored tick timing.

The texture's own animation data decides the output: animated rendering is on by default, the mcmeta decides whether anything actually animates, and the reply branches on `GeneratedObject.isAnimated()` - GIF attachment when true, the existing PNG path when false. `animated: False` stays available as an explicit opt-out and is the only state the emitted round-trip command records, so re-running an emitted command always reproduces what was rendered.

No behavior change without a pack selected. The attachment decision and option round-trips are unit-tested; full suite green.