### PR TITLE
refactor(generator): drop the no-op big image flag

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -149,8 +149,7 @@ public class GeneratorCommands {
                     .withData(data)
                     .withColor(color)
                     .isEnchanted(enchanted)
-                    .withHoverEffect(hoverEffect)
-                    .isBigImage();
+                    .withHoverEffect(hoverEffect);
                 applyItemPack(itemBuilder, packId, animated);
 
                 if (durability != null) {
@@ -340,8 +339,7 @@ public class GeneratorCommands {
                         MinecraftItemGenerator.Builder itemBuilder = new MinecraftItemGenerator.Builder()
                             .withItem(itemId)
                             .withColor(color)
-                            .isEnchanted(enchanted)
-                            .isBigImage();
+                            .isEnchanted(enchanted);
                         applyItemPack(itemBuilder, packId, animated);
 
                         generatorImageBuilder.addGenerator(itemBuilder.build());
@@ -798,8 +796,7 @@ public class GeneratorCommands {
                     MinecraftItemGenerator.Builder itemBuilder = new MinecraftItemGenerator.Builder()
                         .withItem(itemId)
                         .withColor(color)
-                        .isEnchanted(enchanted)
-                        .isBigImage();
+                        .isEnchanted(enchanted);
                     applyItemPack(itemBuilder, packId, animated);
 
                     if (durability != null) {

--- a/discord-framework/src/main/java/net/hypixel/nerdbot/discord/config/GeneratorConfig.java
+++ b/discord-framework/src/main/java/net/hypixel/nerdbot/discord/config/GeneratorConfig.java
@@ -130,11 +130,6 @@ public class GeneratorConfig {
         private boolean defaultHoverEffect = false;
 
         /**
-         * Whether big image mode is enabled by default
-         */
-        private boolean defaultBigImage = false;
-
-        /**
          * Default durability percentage (null = no durability bar)
          */
         private Integer defaultDurabilityPercent = null;

--- a/example-config.json
+++ b/example-config.json
@@ -195,7 +195,6 @@
     "item": {
       "defaultEnchanted": true,
       "defaultHoverEffect": true,
-      "defaultBigImage": true,
       "defaultDurabilityPercent": 1
     },
     "inventory": {


### PR DESCRIPTION
Removes the bot's use of the image generator's `isBigImage` flag: the three unconditional `.isBigImage()` calls in `GeneratorCommands`, the `defaultBigImage` config field (never read anywhere), and its `example-config.json` key. Already-deployed configs still carrying the key are unaffected - unknown JSON keys are ignored on load.

The flag is provably dead: it gates a 10x upscale behind an `image <= 16x16` guard, but every item path produces a 256x256 base (the vanilla atlas is 256 per item and pack sprites are force-scaled to 256), so the upscale has never fired. Verified empirically with a three-way byte comparison (flag on, flag off, flag removed) across static, glint GIF, pack-animated GIF and NBT-parser renders: all outputs byte-identical by SHA-256 and per-frame pixel compare.

Merge this before the library-side removal PR so the API deletion never lands under code still calling it. No output or behavior changes; suite green.