### PR TITLE
perf(activity): demote per-event activity traces from info to debug

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/activity/ActivityListener.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/activity/ActivityListener.java
@@ -99,7 +99,7 @@ public class ActivityListener {
                     // New Suggestion
                     if (forumChannelId.equals(DiscordBotEnvironment.getBot().getConfig().getSuggestionConfig().getForumChannelId())) {
                         discordUser.getLastActivity().getSuggestionCreationHistory().add(0, time);
-                        log.info("Updating new suggestion activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+                        log.debug("Updating new suggestion activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
                     }
 
                     // New Alpha Suggestion
@@ -107,14 +107,14 @@ public class ActivityListener {
                     if (ArrayUtils.safeArrayStream(alphaProjectConfig.getAlphaForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                         discordUser.getLastActivity().getAlphaSuggestionCreationHistory().add(0, time);
                         discordUser.getLastActivity().setLastAlphaActivity(time);
-                        log.info("Updating new alpha suggestion activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+                        log.debug("Updating new alpha suggestion activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
                     }
 
                     // New Project Suggestion
                     if (ArrayUtils.safeArrayStream(alphaProjectConfig.getProjectForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                         discordUser.getLastActivity().getProjectSuggestionCreationHistory().add(0, time);
                         discordUser.getLastActivity().setLastProjectActivity(time);
-                        log.info("Updating new project suggestion activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+                        log.debug("Updating new project suggestion activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
                     }
                 });
         }
@@ -168,7 +168,7 @@ public class ActivityListener {
             // Handle thread comments in role-restricted channels
             if (guildChannel instanceof ThreadChannel && event.getChannel().getIdLong() != event.getMessage().getIdLong()) {
                 discordUser.getLastActivity().addRoleRestrictedChannelComment(groupIdentifier, time);
-                log.info("Updating role-restricted channel group '{}' comment activity for {} (ID: {}) to {}",
+                log.debug("Updating role-restricted channel group '{}' comment activity for {} (ID: {}) to {}",
                     groupIdentifier, member.getEffectiveName(), member.getId(), time);
             }
 
@@ -178,7 +178,7 @@ public class ActivityListener {
                 : guildChannel;
 
             discordUser.getLastActivity().addRoleRestrictedChannelActivity(groupIdentifier, targetChannel.getId(), targetChannel.getName(), 1, time);
-            log.info("Updating role-restricted channel group '{}' message activity for {} (ID: {}) to {}",
+            log.debug("Updating role-restricted channel group '{}' message activity for {} (ID: {}) to {}",
                 groupIdentifier, member.getEffectiveName(), member.getId(), time);
         }
 
@@ -190,33 +190,33 @@ public class ActivityListener {
             // New Suggestion Comments
             if (channelType == Suggestion.ChannelType.NORMAL) {
                 discordUser.getLastActivity().getSuggestionCommentHistory().add(0, time);
-                log.info("Updating suggestion comment activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+                log.debug("Updating suggestion comment activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
             }
 
             // New Alpha Suggestion Comments
             if (channelType == Suggestion.ChannelType.ALPHA) {
                 discordUser.getLastActivity().getAlphaSuggestionCommentHistory().add(0, time);
-                log.info("Updating alpha suggestion comment activity and last alpha activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+                log.debug("Updating alpha suggestion comment activity and last alpha activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
             }
 
             // New Project Suggestion Comments
             if (channelType == Suggestion.ChannelType.PROJECT) {
                 discordUser.getLastActivity().getProjectSuggestionCommentHistory().add(0, time);
-                log.info("Updating project suggestion comment activity and last project activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+                log.debug("Updating project suggestion comment activity and last project activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
             }
         }
 
         // Alpha/Project-specific Messages
         if (channelType == Suggestion.ChannelType.ALPHA) {
             discordUser.getLastActivity().setLastAlphaActivity(time);
-            log.info("Updating last alpha activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+            log.debug("Updating last alpha activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
         } else if (channelType == Suggestion.ChannelType.PROJECT) {
             discordUser.getLastActivity().setLastProjectActivity(time);
-            log.info("Updating last project activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+            log.debug("Updating last project activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
         }
 
         // Global Messages
-        log.info("Updating last global activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+        log.debug("Updating last global activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
         discordUser.getLastActivity().setLastGlobalActivity(time);
 
         // Update Channel Message History (only if not already tracked in role-restricted channels)
@@ -268,13 +268,13 @@ public class ActivityListener {
 
                     if (channelType == Suggestion.ChannelType.ALPHA) {
                         discordUser.getLastActivity().setAlphaVoiceJoinDate(time);
-                        log.info("Updating last alpha voice activity for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+                        log.debug("Updating last alpha voice activity for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
                     } else if (channelType == Suggestion.ChannelType.PROJECT) {
                         discordUser.getLastActivity().setProjectVoiceJoinDate(time);
-                        log.info("Updating last project voice activity for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+                        log.debug("Updating last project voice activity for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
                     } else {
                         discordUser.getLastActivity().setLastVoiceChannelJoinDate(time);
-                        log.info("Updating last global voice activity for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+                        log.debug("Updating last global voice activity for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
                     }
 
                     // Check if voice channel belongs to a role-restricted group
@@ -282,7 +282,7 @@ public class ActivityListener {
                     if (matchingGroup.isPresent()) {
                         String groupIdentifier = matchingGroup.get().getIdentifier();
                         discordUser.getLastActivity().getRoleRestrictedChannelLastActivity().put(groupIdentifier, time);
-                        log.info("Updating role-restricted channel group '{}' voice activity for {} (ID: {}) to {}",
+                        log.debug("Updating role-restricted channel group '{}' voice activity for {} (ID: {}) to {}",
                             groupIdentifier, member.getEffectiveName(), member.getId(), time);
                     }
                 }
@@ -344,7 +344,7 @@ public class ActivityListener {
             if (matchingGroup.isPresent()) {
                 String groupIdentifier = matchingGroup.get().getIdentifier();
                 discordUser.getLastActivity().addRoleRestrictedChannelVote(groupIdentifier, threadChannel.getId(), time);
-                log.info("Updating role-restricted channel group '{}' voting activity for {} (ID: {}) to {}",
+                log.debug("Updating role-restricted channel group '{}' voting activity for {} (ID: {}) to {}",
                     groupIdentifier, member.getEffectiveName(), member.getId(), time);
             }
 
@@ -352,7 +352,7 @@ public class ActivityListener {
             if (forumChannelId.equals(DiscordBotEnvironment.getBot().getConfig().getSuggestionConfig().getForumChannelId())) {
                 discordUser.getLastActivity().getSuggestionVoteHistoryMap().putIfAbsent(threadChannel.getId(), time);
                 SkyBlockNerdsBot.suggestionCache().updateSuggestion(threadChannel);
-                log.info("Updating suggestion voting activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+                log.debug("Updating suggestion voting activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
             }
 
             // New Alpha Suggestion Voting
@@ -360,14 +360,14 @@ public class ActivityListener {
             if (ArrayUtils.safeArrayStream(alphaProjectConfig.getAlphaForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                 discordUser.getLastActivity().getAlphaSuggestionVoteHistoryMap().putIfAbsent(threadChannel.getId(), time);
                 SkyBlockNerdsBot.suggestionCache().updateSuggestion(threadChannel);
-                log.info("Updating alpha suggestion voting activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+                log.debug("Updating alpha suggestion voting activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
             }
 
             // New Project Suggestion Voting
             if (ArrayUtils.safeArrayStream(alphaProjectConfig.getProjectForumIds()).anyMatch(forumChannelId::equalsIgnoreCase)) {
                 discordUser.getLastActivity().getProjectSuggestionVoteHistoryMap().putIfAbsent(threadChannel.getId(), time);
                 SkyBlockNerdsBot.suggestionCache().updateSuggestion(threadChannel);
-                log.info("Updating project suggestion voting activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
+                log.debug("Updating project suggestion voting activity date for {} (ID: {}) to {}", member.getEffectiveName(), member.getId(), time);
             }
         }
     }


### PR DESCRIPTION
## What

`ActivityListener` emitted up to ~22 unconditional `log.info` calls per processed message (one per activity-history update), each formatting member names, IDs and timestamps on the JDA event thread regardless of the active log level. On a busy guild that is a constant per-message allocation + I/O cost on a hot path.

This demotes the routine `"Updating ... activity ..."` diagnostic traces to `debug` across the message, reaction, voice and thread-create handlers. Genuine lifecycle events stay at `info`:

- member join
- member leave
- new `DiscordUser` creation

## Why

These are per-activity diagnostic traces, not events an operator needs at info level. Demoting them removes the hot-path logging cost while keeping the detail available at `debug` when needed.

## Scope

Logging levels only - no behavioural change. The per-event repository lookup in these handlers is intentionally left as-is; converting it to an injected field belongs with the broader dependency-injection work rather than this change.
