### PR TITLE
refactor(activity): injectable DiscordUserStore + first characterization tests

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/activity/ActivityPurgeFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/activity/ActivityPurgeFeature.java
@@ -2,10 +2,13 @@ package net.hypixel.nerdbot.app.activity;
 
 import lombok.extern.slf4j.Slf4j;
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
+import net.hypixel.nerdbot.app.storage.DiscordUserStore;
+import net.hypixel.nerdbot.app.storage.RepositoryDiscordUserStore;
 import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.discord.api.feature.BotFeature;
 import net.hypixel.nerdbot.discord.api.feature.SchedulableFeature;
 import net.hypixel.nerdbot.discord.config.NerdBotConfig;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
 
 import java.time.Duration;
@@ -27,11 +30,35 @@ public class ActivityPurgeFeature extends BotFeature implements SchedulableFeatu
 
         DiscordUserRepository discordUserRepository = BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
         int daysRequiredForVoteHistory = SkyBlockNerdsBot.config().getRoleConfig().getDaysRequiredForVoteHistory();
-        discordUserRepository.getAll().forEach(discordUser -> {
+
+        int purged = purgeOldHistory(new RepositoryDiscordUserStore(discordUserRepository), daysRequiredForVoteHistory);
+        log.debug("Activity purge complete: {} user(s) had stale history removed", purged);
+    }
+
+    /**
+     * Purge activity history older than {@code daysRequiredForVoteHistory} for every stored user,
+     * re-saving only the users whose history actually changed.
+     *
+     * <p>Extracted from {@link #executeTask()} so the purge logic can be exercised against an
+     * in-memory {@link DiscordUserStore} without a live bot or database. {@code executeTask()}
+     * remains the thin adapter that supplies the real store and configured retention window.
+     *
+     * @param store                       the user store to purge in place
+     * @param daysRequiredForVoteHistory  retention window in days; entries at or older than this
+     *                                    are removed
+     * @return the number of users whose history was modified
+     */
+    static int purgeOldHistory(DiscordUserStore store, int daysRequiredForVoteHistory) {
+        int purged = 0;
+
+        for (DiscordUser discordUser : store.getAll()) {
             if (discordUser.getLastActivity().purgeOldHistory(daysRequiredForVoteHistory)) {
-                discordUserRepository.cacheObject(discordUser);
+                store.save(discordUser);
+                purged++;
             }
-        });
+        }
+
+        return purged;
     }
 
     @Override

--- a/app/src/main/java/net/hypixel/nerdbot/app/storage/DiscordUserStore.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/storage/DiscordUserStore.java
@@ -1,0 +1,38 @@
+package net.hypixel.nerdbot.app.storage;
+
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Narrow, injectable view over {@link DiscordUser} persistence.
+ *
+ * <p>Services depend on this interface instead of reaching through the global bot instance for the
+ * concrete {@code DiscordUserRepository}. Receiving the store as an explicit collaborator lets the
+ * logic that depends on user storage be unit-tested against an in-memory fake, with no live bot or
+ * database. Production code is backed by {@link RepositoryDiscordUserStore}.
+ */
+public interface DiscordUserStore {
+
+    /**
+     * @return every known user. The returned list is a snapshot and safe to iterate while calling
+     * {@link #save(DiscordUser)}.
+     */
+    List<DiscordUser> getAll();
+
+    /**
+     * @param discordId the user's Discord ID
+     * @return the stored user with that ID, or {@link Optional#empty()} if none is stored
+     */
+    Optional<DiscordUser> findById(String discordId);
+
+    /**
+     * Upsert a user into the store. Mirrors the repository's cache-write semantics: the in-memory
+     * copy is updated immediately and persisted through the underlying repository's normal write
+     * path.
+     *
+     * @param user the user to store
+     */
+    void save(DiscordUser user);
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/storage/RepositoryDiscordUserStore.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/storage/RepositoryDiscordUserStore.java
@@ -1,0 +1,38 @@
+package net.hypixel.nerdbot.app.storage;
+
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Production {@link DiscordUserStore} backed by the real {@link DiscordUserRepository}.
+ *
+ * <p>This is a thin adapter: {@link #getAll()} and {@link #save(DiscordUser)} map directly onto the
+ * repository's in-memory cache operations, matching the behaviour of the call sites this store
+ * replaces.
+ */
+public class RepositoryDiscordUserStore implements DiscordUserStore {
+
+    private final DiscordUserRepository repository;
+
+    public RepositoryDiscordUserStore(DiscordUserRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<DiscordUser> getAll() {
+        return repository.getAll();
+    }
+
+    @Override
+    public Optional<DiscordUser> findById(String discordId) {
+        return repository.findById(discordId).toOptional();
+    }
+
+    @Override
+    public void save(DiscordUser user) {
+        repository.cacheObject(user);
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/activity/ActivityPurgeFeatureTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/activity/ActivityPurgeFeatureTest.java
@@ -1,0 +1,68 @@
+package net.hypixel.nerdbot.app.activity;
+
+import net.hypixel.nerdbot.app.testsupport.FakeDiscordUserStore;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Characterization tests pinning the behaviour of {@link ActivityPurgeFeature#purgeOldHistory}
+ * before any further refactoring of the nomination/activity subsystem.
+ */
+class ActivityPurgeFeatureTest {
+
+    private static final int RETENTION_DAYS = 30;
+
+    @Test
+    void purgesStaleHistoryAndResavesOnlyChangedUsers() {
+        DiscordUser stale = userWithSuggestionCreatedAt("stale", daysAgo(100));
+        DiscordUser recent = userWithSuggestionCreatedAt("recent", daysAgo(1));
+        FakeDiscordUserStore store = new FakeDiscordUserStore().seed(stale).seed(recent);
+
+        int purged = ActivityPurgeFeature.purgeOldHistory(store, RETENTION_DAYS);
+
+        assertEquals(1, purged, "only the stale user should be counted as purged");
+        assertEquals(List.of("stale"), store.savedIds(), "only the changed user should be re-saved");
+        assertTrue(stale.getLastActivity().getSuggestionCreationHistory().isEmpty(),
+            "the stale entry should have been removed");
+        assertEquals(1, recent.getLastActivity().getSuggestionCreationHistory().size(),
+            "the recent entry should have been kept");
+    }
+
+    @Test
+    void leavesStoreUntouchedWhenNothingIsStale() {
+        DiscordUser recent = userWithSuggestionCreatedAt("recent", daysAgo(1));
+        FakeDiscordUserStore store = new FakeDiscordUserStore().seed(recent);
+
+        int purged = ActivityPurgeFeature.purgeOldHistory(store, RETENTION_DAYS);
+
+        assertEquals(0, purged);
+        assertTrue(store.savedIds().isEmpty(), "no user should be re-saved when nothing is stale");
+        assertEquals(1, recent.getLastActivity().getSuggestionCreationHistory().size());
+    }
+
+    @Test
+    void handlesEmptyStore() {
+        FakeDiscordUserStore store = new FakeDiscordUserStore();
+
+        int purged = ActivityPurgeFeature.purgeOldHistory(store, RETENTION_DAYS);
+
+        assertEquals(0, purged);
+        assertTrue(store.savedIds().isEmpty());
+    }
+
+    private static DiscordUser userWithSuggestionCreatedAt(String discordId, long timestamp) {
+        DiscordUser user = new DiscordUser(discordId);
+        user.getLastActivity().getSuggestionCreationHistory().add(timestamp);
+        return user;
+    }
+
+    private static long daysAgo(int days) {
+        return System.currentTimeMillis() - Duration.ofDays(days).toMillis();
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/testsupport/FakeDiscordUserStore.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/testsupport/FakeDiscordUserStore.java
@@ -1,0 +1,55 @@
+package net.hypixel.nerdbot.app.testsupport;
+
+import net.hypixel.nerdbot.app.storage.DiscordUserStore;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * In-memory {@link DiscordUserStore} for tests.
+ *
+ * <p>Seed users with {@link #seed(DiscordUser)} and inspect which users were re-saved with
+ * {@link #savedIds()}. Insertion order is preserved so tests can assert deterministic iteration.
+ */
+public class FakeDiscordUserStore implements DiscordUserStore {
+
+    private final Map<String, DiscordUser> users = new LinkedHashMap<>();
+    private final List<String> savedIds = new ArrayList<>();
+
+    /**
+     * Add (or replace) a user in the store without recording it as a {@link #save(DiscordUser)}.
+     *
+     * @return this store, for chaining
+     */
+    public FakeDiscordUserStore seed(DiscordUser user) {
+        users.put(user.getDiscordId(), user);
+        return this;
+    }
+
+    @Override
+    public List<DiscordUser> getAll() {
+        return new ArrayList<>(users.values());
+    }
+
+    @Override
+    public Optional<DiscordUser> findById(String discordId) {
+        return Optional.ofNullable(users.get(discordId));
+    }
+
+    @Override
+    public void save(DiscordUser user) {
+        users.put(user.getDiscordId(), user);
+        savedIds.add(user.getDiscordId());
+    }
+
+    /**
+     * @return the IDs passed to {@link #save(DiscordUser)}, in call order (duplicates preserved)
+     */
+    public List<String> savedIds() {
+        return List.copyOf(savedIds);
+    }
+}


### PR DESCRIPTION
## What

First vertical slice of the move away from the global service-locator toward dependency injection, chosen as a small, self-contained service so the pattern can be established with minimal risk.

- Introduces a narrow **`DiscordUserStore`** interface (`getAll` / `findById` / `save`) with a production **`RepositoryDiscordUserStore`** adapter over the real `DiscordUserRepository`.
- Extracts `ActivityPurgeFeature`'s purge loop into `purgeOldHistory(DiscordUserStore, int)`. `executeTask()` remains the thin adapter that supplies the real store and the configured retention window - **behaviour is unchanged**.
- Adds a reusable in-memory **`FakeDiscordUserStore`** (map-backed, records saves) under `testsupport/`, and the first **characterization tests** for the activity subsystem.

## Why

Services currently reach through `BotEnvironment.getBot()...getRepository(...)` inside their methods, so their logic cannot be unit-tested without a live bot and database. Receiving a `DiscordUserStore` as an explicit collaborator makes the logic testable against an in-memory fake. `ActivityPurgeFeature` is the first, smallest service to adopt this; the store + fake are intended to be reused as further services are made injectable.

## Tests

`mvn -pl app -am test` -> 71 passing (3 new).

The purge tests pin: stale history is removed and only changed users are re-saved; recent history is kept; an empty store is handled.
