### PR TITLE
refactor(users): reconcile guild members through the injectable DiscordUserStore

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/feature/UserGrabberFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/feature/UserGrabberFeature.java
@@ -3,18 +3,17 @@ package net.hypixel.nerdbot.app.feature;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.Guild;
 import net.hypixel.nerdbot.app.badge.BadgeManager;
+import net.hypixel.nerdbot.app.storage.DiscordUserStore;
+import net.hypixel.nerdbot.app.storage.RepositoryDiscordUserStore;
 import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.discord.api.feature.BotFeature;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
-import net.hypixel.nerdbot.marmalade.storage.database.model.user.badge.BadgeEntry;
-import net.hypixel.nerdbot.marmalade.storage.database.model.user.birthday.BirthdayData;
-import net.hypixel.nerdbot.marmalade.storage.database.model.user.generator.GeneratorHistory;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.stats.LastActivity;
-import net.hypixel.nerdbot.marmalade.storage.database.model.user.stats.MojangProfile;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
 import net.hypixel.nerdbot.discord.util.DiscordUtils;
 
 import java.util.ArrayList;
+import java.util.function.Predicate;
 
 @Slf4j
 public class UserGrabberFeature extends BotFeature {
@@ -32,6 +31,7 @@ public class UserGrabberFeature extends BotFeature {
         }
 
         DiscordUserRepository discordUserRepository = BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
+        DiscordUserStore store = new RepositoryDiscordUserStore(discordUserRepository);
         Guild guild = DiscordUtils.getMainGuild();
         log.info("Grabbing users from guild {} (ID: {})", guild.getName(), guild.getId());
 
@@ -41,35 +41,59 @@ public class UserGrabberFeature extends BotFeature {
                 }
 
                 log.info("Found user {} ({})", member.getEffectiveName(), member.getId());
-
-                DiscordUser discordUser = discordUserRepository.findById(member.getId()).orElse(null);
-                if (discordUser == null) {
-                    discordUser = new DiscordUser(member.getId(), new ArrayList<>(), new LastActivity(), new BirthdayData(), new MojangProfile(), new GeneratorHistory(), false);
-                    log.info("Creating new DiscordUser for user {}", member.getId());
-                }
-
-                if (discordUser.getLastActivity() == null) {
-                    log.info("Last activity for {} (ID: {}) was null. Setting to default values!", member.getEffectiveName(), member.getId());
-                    discordUser.setLastActivity(new LastActivity());
-                }
-
-                if (discordUser.getBadges() == null) {
-                    log.info("Badges for {} (ID: {}) was null. Setting to default values!", member.getEffectiveName(), member.getId());
-                    discordUser.setBadges(new ArrayList<>());
-                }
-
-                for (BadgeEntry s : discordUser.getBadges()) {
-                    if (BadgeManager.getBadgeById(s.badgeId()) == null && BadgeManager.getTieredBadgeById(s.badgeId()) == null) {
-                        log.warn("Badge '{}' for {} (ID: {}) was not found in the badge map! Removing...", s, member.getEffectiveName(), member.getId());
-                    }
-                }
-
-                discordUser.getBadges().removeIf(badgeEntry -> BadgeManager.getBadgeById(badgeEntry.badgeId()) == null
-                    && BadgeManager.getTieredBadgeById(badgeEntry.badgeId()) == null);
-                discordUserRepository.cacheObject(discordUser);
+                reconcileMember(store, member.getId(), member.getEffectiveName(), UserGrabberFeature::isKnownBadge);
             })
             .onSuccess(aVoid -> log.info("Finished grabbing users from guild {} (ID: {})", guild.getName(), guild.getId()))
             .onError(throwable -> log.error("Failed to grab users from guild {} (ID: {})", guild.getName(), guild.getId(), throwable));
+    }
+
+    /**
+     * Reconcile a single guild member into the store: look the user up (creating a fresh one if
+     * absent), backfill any null activity/badge fields, drop badges the bot no longer recognises,
+     * and save.
+     *
+     * <p>Extracted from {@link #onFeatureStart()} so the reconciliation can be exercised against an
+     * in-memory {@link DiscordUserStore} without a live bot, database or JDA guild. Badge validity
+     * is supplied as a predicate rather than read from the static {@link BadgeManager}, so tests
+     * control which badges are known.
+     *
+     * @param store         the user store to reconcile into
+     * @param memberId      the member's Discord ID
+     * @param effectiveName the member's display name (used only for logging)
+     * @param knownBadge    returns {@code true} if the given badge ID is still recognised
+     * @return the reconciled (and saved) user
+     */
+    static DiscordUser reconcileMember(DiscordUserStore store, String memberId, String effectiveName, Predicate<String> knownBadge) {
+        DiscordUser discordUser = store.findById(memberId).orElse(null);
+        if (discordUser == null) {
+            discordUser = new DiscordUser(memberId);
+            log.info("Creating new DiscordUser for user {}", memberId);
+        }
+
+        if (discordUser.getLastActivity() == null) {
+            log.info("Last activity for {} (ID: {}) was null. Setting to default values!", effectiveName, memberId);
+            discordUser.setLastActivity(new LastActivity());
+        }
+
+        if (discordUser.getBadges() == null) {
+            log.info("Badges for {} (ID: {}) was null. Setting to default values!", effectiveName, memberId);
+            discordUser.setBadges(new ArrayList<>());
+        }
+
+        discordUser.getBadges().removeIf(badgeEntry -> {
+            boolean unknown = !knownBadge.test(badgeEntry.badgeId());
+            if (unknown) {
+                log.warn("Badge '{}' for {} (ID: {}) was not found in the badge map! Removing...", badgeEntry, effectiveName, memberId);
+            }
+            return unknown;
+        });
+
+        store.save(discordUser);
+        return discordUser;
+    }
+
+    private static boolean isKnownBadge(String badgeId) {
+        return BadgeManager.getBadgeById(badgeId) != null || BadgeManager.getTieredBadgeById(badgeId) != null;
     }
 
     @Override

--- a/app/src/test/java/net/hypixel/nerdbot/app/feature/UserGrabberFeatureTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/feature/UserGrabberFeatureTest.java
@@ -1,0 +1,74 @@
+package net.hypixel.nerdbot.app.feature;
+
+import net.hypixel.nerdbot.app.testsupport.FakeDiscordUserStore;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.badge.BadgeEntry;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Characterization tests pinning the per-member reconciliation performed by
+ * {@link UserGrabberFeature#reconcileMember}.
+ */
+class UserGrabberFeatureTest {
+
+    private static final Predicate<String> ALL_KNOWN = badgeId -> true;
+
+    @Test
+    void createsNewUserWhenAbsentThenSavesIt() {
+        FakeDiscordUserStore store = new FakeDiscordUserStore();
+
+        DiscordUser result = UserGrabberFeature.reconcileMember(store, "123", "Nerd", ALL_KNOWN);
+
+        assertEquals("123", result.getDiscordId());
+        assertNotNull(result.getLastActivity(), "a new user should have default activity");
+        assertNotNull(result.getBadges(), "a new user should have a (non-null) badge list");
+        assertEquals(List.of("123"), store.savedIds(), "the new user should have been saved");
+        assertTrue(store.findById("123").isPresent(), "the new user should now be in the store");
+    }
+
+    @Test
+    void backfillsNullLastActivity() {
+        DiscordUser existing = new DiscordUser("123");
+        existing.setLastActivity(null);
+        FakeDiscordUserStore store = new FakeDiscordUserStore().seed(existing);
+
+        DiscordUser result = UserGrabberFeature.reconcileMember(store, "123", "Nerd", ALL_KNOWN);
+
+        assertNotNull(result.getLastActivity(), "null activity should have been replaced with a default");
+        assertEquals(List.of("123"), store.savedIds());
+    }
+
+    @Test
+    void backfillsNullBadges() {
+        DiscordUser existing = new DiscordUser("123");
+        existing.setBadges(null);
+        FakeDiscordUserStore store = new FakeDiscordUserStore().seed(existing);
+
+        DiscordUser result = UserGrabberFeature.reconcileMember(store, "123", "Nerd", ALL_KNOWN);
+
+        assertNotNull(result.getBadges(), "null badges should have been replaced with an empty list");
+        assertTrue(result.getBadges().isEmpty());
+        assertEquals(List.of("123"), store.savedIds());
+    }
+
+    @Test
+    void prunesUnknownBadgesButKeepsKnownOnes() {
+        DiscordUser existing = new DiscordUser("123");
+        existing.setBadges(new ArrayList<>(List.of(new BadgeEntry("known"), new BadgeEntry("stale"))));
+        FakeDiscordUserStore store = new FakeDiscordUserStore().seed(existing);
+
+        DiscordUser result = UserGrabberFeature.reconcileMember(store, "123", "Nerd", badgeId -> badgeId.equals("known"));
+
+        assertEquals(1, result.getBadges().size(), "the unrecognised badge should have been removed");
+        assertEquals("known", result.getBadges().get(0).badgeId());
+        assertEquals(List.of("123"), store.savedIds());
+    }
+}


### PR DESCRIPTION
## What

Second service to adopt the `DiscordUserStore` seam introduced in #623, continuing the incremental move off the global service-locator.

- Extracts `UserGrabberFeature`'s per-member reconciliation (find-or-create the user, backfill null activity/badge fields, prune unrecognised badges, save) into `reconcileMember(store, memberId, effectiveName, knownBadge)`.
- `onFeatureStart()` stays the thin adapter that supplies the real store and drives `guild.loadMembers(...)` - **behaviour is unchanged**.
- Badge validity is passed in as a `Predicate<String>` rather than read from the static `BadgeManager`, so the reconciliation is testable without global badge state.

## Why

Same rationale as #623: the feature reached through `BotEnvironment.getBot()...getRepository(...)` and the static `BadgeManager`, so its logic could not be exercised without a live bot, database and guild. Injecting the store and the badge predicate makes it unit-testable against the in-memory fake.

## Tests

`mvn -pl app -am test` -> 75 passing (4 new).

The reconciliation tests pin: a new user is created and saved when absent; null activity/badge fields are backfilled; unrecognised badges are pruned while known ones are kept.
