### PR TITLE
refactor(profile): extract testable profile-update selection and nickname decision

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/feature/ProfileUpdateFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/feature/ProfileUpdateFeature.java
@@ -6,6 +6,8 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.exceptions.HierarchyException;
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
+import net.hypixel.nerdbot.app.storage.DiscordUserStore;
+import net.hypixel.nerdbot.app.storage.RepositoryDiscordUserStore;
 import net.hypixel.nerdbot.app.util.HttpUtils;
 import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.discord.api.feature.BotFeature;
@@ -20,6 +22,8 @@ import net.hypixel.nerdbot.discord.util.DiscordUtils;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 @Slf4j
@@ -67,11 +71,9 @@ public class ProfileUpdateFeature extends BotFeature implements SchedulableFeatu
             return;
         }
 
-        String currentNickname = member.getEffectiveName();
-        String normalizedNickname = currentNickname.toLowerCase(Locale.ROOT);
         String desiredNickname = mojangProfile.getUsername();
 
-        if (!normalizedNickname.contains(desiredNickname.toLowerCase(Locale.ROOT))) {
+        if (needsNicknameUpdate(member.getEffectiveName(), desiredNickname)) {
             try {
                 member.modifyNickname(desiredNickname).queue(
                     success -> log.info("Updated nickname for {} to {}", discordUser.getDiscordId(), desiredNickname),
@@ -81,6 +83,41 @@ public class ProfileUpdateFeature extends BotFeature implements SchedulableFeatu
                 log.warn("Unable to modify the nickname of {} ({}) to {} due to a hierarchy exception", member.getUser().getName(), member.getId(), mojangProfile.getUsername());
             }
         }
+    }
+
+    /**
+     * Select the users whose stored Mojang profile is assigned and stale enough to warrant a
+     * refresh.
+     *
+     * <p>Extracted from {@link #executeTask()} so the selection can be exercised against an
+     * in-memory {@link DiscordUserStore} without a live bot or database. The actual refresh
+     * ({@link #updateNickname(DiscordUser)}) still performs HTTP and JDA calls and is left to
+     * {@code executeTask()}.
+     *
+     * @param store         the user store to scan
+     * @param cacheTtlHours the Mojang username cache TTL in hours
+     * @return the users due for a profile update, in store iteration order
+     */
+    static List<DiscordUser> profilesRequiringUpdate(DiscordUserStore store, long cacheTtlHours) {
+        List<DiscordUser> due = new ArrayList<>();
+
+        for (DiscordUser discordUser : store.getAll()) {
+            if (discordUser.isProfileAssigned() && discordUser.getMojangProfile().requiresCacheUpdate(cacheTtlHours)) {
+                due.add(discordUser);
+            }
+        }
+
+        return due;
+    }
+
+    /**
+     * @param currentNickname the member's current effective name
+     * @param desiredUsername the Mojang username the nickname should reflect
+     * @return {@code true} if the current name does not already contain the desired username
+     * (case-insensitive), i.e. a nickname change is warranted
+     */
+    static boolean needsNicknameUpdate(String currentNickname, String desiredUsername) {
+        return !currentNickname.toLowerCase(Locale.ROOT).contains(desiredUsername.toLowerCase(Locale.ROOT));
     }
 
     @Override
@@ -100,12 +137,10 @@ public class ProfileUpdateFeature extends BotFeature implements SchedulableFeatu
         }
 
         DiscordUserRepository discordUserRepository = BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
+        DiscordUserStore store = new RepositoryDiscordUserStore(discordUserRepository);
         long cacheTtlHours = SkyBlockNerdsBot.config().getMojangUsernameCacheTTL();
-        discordUserRepository.forEach(discordUser -> {
-            if (discordUser.isProfileAssigned() && discordUser.getMojangProfile().requiresCacheUpdate(cacheTtlHours)) {
-                updateNickname(discordUser);
-            }
-        });
+
+        profilesRequiringUpdate(store, cacheTtlHours).forEach(ProfileUpdateFeature::updateNickname);
     }
 
     @Override

--- a/app/src/test/java/net/hypixel/nerdbot/app/feature/ProfileUpdateFeatureTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/feature/ProfileUpdateFeatureTest.java
@@ -1,0 +1,65 @@
+package net.hypixel.nerdbot.app.feature;
+
+import net.hypixel.nerdbot.app.testsupport.FakeDiscordUserStore;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.stats.MojangProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Characterization tests for the pure decisions extracted from {@link ProfileUpdateFeature}:
+ * which users are due for a refresh, and whether a nickname actually needs changing.
+ */
+class ProfileUpdateFeatureTest {
+
+    private static final long TTL_HOURS = 24;
+
+    @Test
+    void selectsOnlyAssignedProfilesThatAreStale() {
+        DiscordUser stale = userWithProfile("stale", 0L);              // lastUpdated far in the past -> due
+        DiscordUser fresh = userWithProfile("fresh", System.currentTimeMillis()); // just updated -> not due
+        DiscordUser unassigned = new DiscordUser("unassigned");        // default profile has no UUID
+
+        FakeDiscordUserStore store = new FakeDiscordUserStore().seed(stale).seed(fresh).seed(unassigned);
+
+        List<DiscordUser> due = ProfileUpdateFeature.profilesRequiringUpdate(store, TTL_HOURS);
+
+        assertEquals(List.of("stale"), due.stream().map(DiscordUser::getDiscordId).toList());
+    }
+
+    @Test
+    void selectionIsEmptyWhenNoProfilesAreAssigned() {
+        FakeDiscordUserStore store = new FakeDiscordUserStore()
+            .seed(new DiscordUser("a"))
+            .seed(new DiscordUser("b"));
+
+        assertTrue(ProfileUpdateFeature.profilesRequiringUpdate(store, TTL_HOURS).isEmpty());
+    }
+
+    @Test
+    void nicknameUpdateNeededWhenCurrentNameLacksUsername() {
+        assertTrue(ProfileUpdateFeature.needsNicknameUpdate("SomeNickname", "Notch"));
+    }
+
+    @Test
+    void nicknameUpdateNotNeededWhenCurrentNameAlreadyContainsUsernameCaseInsensitively() {
+        assertFalse(ProfileUpdateFeature.needsNicknameUpdate("xX_NOTCH_Xx", "notch"));
+        assertFalse(ProfileUpdateFeature.needsNicknameUpdate("Notch", "Notch"));
+    }
+
+    private static DiscordUser userWithProfile(String discordId, long lastUpdated) {
+        DiscordUser user = new DiscordUser(discordId);
+        MojangProfile profile = new MojangProfile();
+        profile.setUniqueId(UUID.randomUUID());
+        profile.setUsername("Username");
+        profile.setLastUpdated(lastUpdated);
+        user.setMojangProfile(profile);
+        return user;
+    }
+}


### PR DESCRIPTION
## What

Third service to adopt the `DiscordUserStore` seam (#623, #624). `ProfileUpdateFeature` is I/O-heavy - `updateNickname` does a blocking Mojang HTTP call and JDA guild/member work - so this slice extracts only the two pure *decisions* and leaves the orchestration alone.

- `profilesRequiringUpdate(store, cacheTtlHours)` selects the assigned, stale-enough profiles via the injectable store (was an inline `repository.forEach` filter in `executeTask()`).
- `needsNicknameUpdate(currentNickname, desiredUsername)` captures the case-insensitive "does the name already contain the username" decision (was an inline condition in `updateNickname`).
- `executeTask()` and `updateNickname()` retain the HTTP/JDA calls - **behaviour is unchanged**.

## Why

The selection and nickname decisions were buried in methods that also perform network and Discord I/O, so they could not be unit-tested. Extracting them keeps the untestable I/O boundary thin and pins the logic that actually decides who gets updated.

## Tests

`mvn -pl app -am test` -> 79 passing (4 new).

Pins: only assigned + stale profiles are selected (fresh and unassigned are skipped); a nickname update is needed only when the current name does not already contain the username, case-insensitively.
