### PR TITLE
refactor(nomination): extract the pure promotion-nomination decision

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/nomination/NominationService.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/nomination/NominationService.java
@@ -167,58 +167,42 @@ public class NominationService {
                 contextLabel, member.getEffectiveName(), member.getId(), totalMessages, totalComments, totalVotes, hasRequiredMessages, hasRequiredComments, hasRequiredVotes, requirementsMet);
         }
 
-        final NominationOutcome[] outcomeRef = new NominationOutcome[]{null};
+        Long lastNominationTimestamp = lastActivity.getNominationInfo().getLastNominationTimestamp().orElse(null);
+        NominationOutcome outcome = decideOutcome(requirementsMet, lastNominationTimestamp, Instant.now().atZone(ZoneId.systemDefault()).getMonth());
 
-        lastActivity.getNominationInfo().getLastNominationTimestamp().ifPresentOrElse(timestamp -> {
-            Month lastNominationMonth = Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).getMonth();
-            Month now = Instant.now().atZone(ZoneId.systemDefault()).getMonth();
-
-            if (lastNominationMonth != now && requirementsMet >= 2) {
-                if (contextLabel == null) {
-                    log.info("Last nomination was not this month (last: {}, now: {}), sending nomination message for {} (ID: {}) (nomination info: {})",
-                        lastNominationMonth, now, member.getEffectiveName(), member.getId(), discordUser.getLastActivity().getNominationInfo());
-                } else {
-                    log.info("[{}] Last nomination not this month (last: {}, now: {}), sending nomination message for {} (ID: {})",
-                        contextLabel, lastNominationMonth, now, member.getEffectiveName(), member.getId());
-                }
-
-                sendNominationMessage(member, discordUser, requiredMessages, requiredVotes, requiredComments, daysWindow);
-                outcomeRef[0] = NominationOutcome.NOMINATED;
-            }
-        }, () -> {
-            if (contextLabel == null) {
-                log.info("No last nomination date found for {} (ID: {}), checking if they meet the minimum requirements (min. messages: {}, min. votes: {}, min. comments: {}, nomination info: {})",
-                    member.getEffectiveName(), member.getId(), requiredMessages, requiredVotes, requiredComments, discordUser.getLastActivity().getNominationInfo());
-            } else {
-                log.info("[{}] No last nomination date found for {} (ID: {}), checking minimum requirements",
-                    contextLabel, member.getEffectiveName(), member.getId());
-            }
-
-            if (requirementsMet >= 2) {
-                sendNominationMessage(member, discordUser, requiredMessages, requiredVotes, requiredComments, daysWindow);
-                outcomeRef[0] = NominationOutcome.NOMINATED;
-            }
-        });
-
-        if (outcomeRef[0] != null) {
-            return outcomeRef[0];
+        if (outcome == NominationOutcome.NOMINATED) {
+            sendNominationMessage(member, discordUser, requiredMessages, requiredVotes, requiredComments, daysWindow);
         }
 
-        Long lastTimestamp = lastActivity.getNominationInfo().getLastNominationTimestamp().orElse(null);
-        if (lastTimestamp != null) {
-            Month lastMonth = Instant.ofEpochMilli(lastTimestamp).atZone(ZoneId.systemDefault()).getMonth();
-            Month nowMonth = Instant.now().atZone(ZoneId.systemDefault()).getMonth();
+        return outcome;
+    }
 
-            if (lastMonth == nowMonth) {
+    /**
+     * Decide a member's nomination outcome from how many of the three activity thresholds they meet
+     * and when they were last nominated.
+     *
+     * <p>A member already nominated in the current month is skipped regardless of their activity;
+     * otherwise they are nominated when they meet at least two of the three thresholds, and skipped
+     * as below-threshold when they do not.
+     *
+     * <p>The "already this month" check compares the calendar {@link Month} only (ignoring year),
+     * preserving the pre-existing behaviour. Extracted from {@link #evaluateNomination} so the
+     * decision can be unit-tested in isolation.
+     *
+     * @param requirementsMet         the number of thresholds met (0-3)
+     * @param lastNominationTimestamp epoch-millis of the last nomination, or {@code null} if never
+     * @param currentMonth            the month to treat as "now"
+     * @return the nomination outcome
+     */
+    static NominationOutcome decideOutcome(int requirementsMet, Long lastNominationTimestamp, Month currentMonth) {
+        if (lastNominationTimestamp != null) {
+            Month lastNominationMonth = Instant.ofEpochMilli(lastNominationTimestamp).atZone(ZoneId.systemDefault()).getMonth();
+            if (lastNominationMonth == currentMonth) {
                 return NominationOutcome.SKIPPED_ALREADY_THIS_MONTH;
             }
         }
 
-        if (requirementsMet >= 2) {
-            return NominationOutcome.NOMINATED;
-        }
-
-        return NominationOutcome.SKIPPED_BELOW_THRESHOLD;
+        return requirementsMet >= 2 ? NominationOutcome.NOMINATED : NominationOutcome.SKIPPED_BELOW_THRESHOLD;
     }
 
     private void sendNominationMessage(Member member, DiscordUser discordUser, int requiredMessages, int requiredVotes, int requiredComments, int daysWindow) {
@@ -285,7 +269,7 @@ public class NominationService {
         });
     }
 
-    private enum NominationOutcome {
+    enum NominationOutcome {
         NOMINATED,
         SKIPPED_ALREADY_THIS_MONTH,
         SKIPPED_BELOW_THRESHOLD

--- a/app/src/test/java/net/hypixel/nerdbot/app/nomination/NominationServiceTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/nomination/NominationServiceTest.java
@@ -1,0 +1,59 @@
+package net.hypixel.nerdbot.app.nomination;
+
+import net.hypixel.nerdbot.app.nomination.NominationService.NominationOutcome;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.Month;
+import java.time.ZoneId;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Characterization tests for the pure nomination decision extracted from
+ * {@link NominationService#decideOutcome}. These pin behaviour ahead of any wider refactor of the
+ * nomination subsystem, including the deliberately-preserved month-only "already this month" check.
+ */
+class NominationServiceTest {
+
+    @Test
+    void nominatesWhenThresholdsMetAndNeverNominated() {
+        assertEquals(NominationOutcome.NOMINATED, NominationService.decideOutcome(2, null, Month.MARCH));
+        assertEquals(NominationOutcome.NOMINATED, NominationService.decideOutcome(3, null, Month.MARCH));
+    }
+
+    @Test
+    void skipsBelowThresholdWhenNeverNominatedAndUnderTwoRequirements() {
+        assertEquals(NominationOutcome.SKIPPED_BELOW_THRESHOLD, NominationService.decideOutcome(0, null, Month.MARCH));
+        assertEquals(NominationOutcome.SKIPPED_BELOW_THRESHOLD, NominationService.decideOutcome(1, null, Month.MARCH));
+    }
+
+    @Test
+    void skipsWhenAlreadyNominatedThisMonthEvenIfEligible() {
+        long now = System.currentTimeMillis();
+        Month monthOfNow = Instant.ofEpochMilli(now).atZone(ZoneId.systemDefault()).getMonth();
+
+        assertEquals(NominationOutcome.SKIPPED_ALREADY_THIS_MONTH,
+            NominationService.decideOutcome(3, now, monthOfNow));
+    }
+
+    @Test
+    void nominatesWhenLastNominationWasADifferentMonth() {
+        long timestamp = System.currentTimeMillis();
+        Month timestampMonth = Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).getMonth();
+        Month differentMonth = timestampMonth.plus(1);
+
+        assertEquals(NominationOutcome.NOMINATED,
+            NominationService.decideOutcome(2, timestamp, differentMonth));
+    }
+
+    @Test
+    void skipsBelowThresholdWhenDifferentMonthButUnderTwoRequirements() {
+        long timestamp = System.currentTimeMillis();
+        Month timestampMonth = Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).getMonth();
+        Month differentMonth = timestampMonth.plus(1);
+
+        assertEquals(NominationOutcome.SKIPPED_BELOW_THRESHOLD,
+            NominationService.decideOutcome(1, timestamp, differentMonth));
+    }
+}


### PR DESCRIPTION
## What

Extracts the promotion-nomination decision in `NominationService` into a pure, unit-testable function, as preparation for the larger nomination-subsystem work.

- `evaluateNomination` decided the outcome twice - once inside an `ifPresentOrElse` using a mutable `NominationOutcome[]` holder (with the side-effecting send), then again in a trailing re-check to classify the skip reason. Both are collapsed into `decideOutcome(requirementsMet, lastNominationTimestamp, currentMonth)`, and the nomination message is sent only when it returns `NOMINATED`.
- The month passed to `decideOutcome` makes the "already this month" check deterministic in tests.

## Why

The decision was untestable (buried in a JDA-bound sweep) and awkwardly computed twice. Extracting it removes the duplication and pins the logic. The same double-computation pattern exists in the 455-line `NominationInactivityService` (the eventual `5A` target); establishing a tested decision function here de-risks that.

## Behaviour

State behaviour and side effects are unchanged, **including the pre-existing month-only comparison** (a nomination in the same calendar month of a previous year still counts as "this month") - preserved deliberately rather than fixed, so this stays a pure refactor. Some redundant intermediate diagnostic logs from the old branches are dropped; the per-member "Checking if ..." summary log is kept.

## Tests

`mvn -pl app -am test` -> 84 passing (5 new).
