### PR TITLE
refactor(nomination): extract the pure inactivity-warning decision

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/nomination/NominationInactivityService.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/nomination/NominationInactivityService.java
@@ -96,18 +96,9 @@ public class NominationInactivityService {
 
             log.info("Checking if {} (ID: {}) should be flagged for inactivity (total messages: {}, total comments: {}, total votes: {}) (has min. comments: {}, has min. votes: {}, has min. messages: {}, requirements met: {}/3)", member.getEffectiveName(), member.getId(), totalMessages, totalComments, totalVotes, hasRequiredComments, hasRequiredVotes, hasRequiredMessages, requirementsMet);
 
-            lastActivity.getNominationInfo().getLastInactivityWarningTimestamp().ifPresentOrElse(timestamp -> {
-                Month lastInactivityWarningMonth = Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).getMonth();
-                Month monthNow = Instant.now().atZone(ZoneId.systemDefault()).getMonth();
-
-                if (lastInactivityWarningMonth != monthNow && requirementsMet < 2) {
-                    sendInactiveUserMessage(member, discordUser, requiredMessages, requiredVotes, requiredComments, "Member");
-                }
-            }, () -> {
-                if (requirementsMet < 2) {
-                    sendInactiveUserMessage(member, discordUser, requiredMessages, requiredVotes, requiredComments, "Member");
-                }
-            });
+            if (shouldSendInactivityWarning(requirementsMet, 2, lastActivity.getNominationInfo().getLastInactivityWarningTimestamp().orElse(null), Instant.now().atZone(ZoneId.systemDefault()).getMonth())) {
+                sendInactiveUserMessage(member, discordUser, requiredMessages, requiredVotes, requiredComments, "Member");
+            }
 
             Long lastWarningTimestamp = lastActivity.getNominationInfo().getLastInactivityWarningTimestamp().orElse(null);
             if (lastWarningTimestamp != null) {
@@ -175,18 +166,9 @@ public class NominationInactivityService {
 
             log.info("[NewMember] Checking inactivity for {} (ID: {}) (messages: {}, comments: {}, votes: {}) (has min. comments: {}, has min. votes: {}, has min. messages: {}, requirements met: {}/3)", member.getEffectiveName(), member.getId(), totalMessages, totalComments, totalVotes, hasRequiredComments, hasRequiredVotes, hasRequiredMessages, requirementsMet);
 
-            lastActivity.getNominationInfo().getLastInactivityWarningTimestamp().ifPresentOrElse(timestamp -> {
-                Month lastInactivityWarningMonth = Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).getMonth();
-                Month monthNow = Instant.now().atZone(ZoneId.systemDefault()).getMonth();
-
-                if (lastInactivityWarningMonth != monthNow && requirementsMet < 3) {
-                    sendInactiveUserMessage(member, discordUser, requiredMessages, requiredVotes, requiredComments, "New Member");
-                }
-            }, () -> {
-                if (requirementsMet < 3) {
-                    sendInactiveUserMessage(member, discordUser, requiredMessages, requiredVotes, requiredComments, "New Member");
-                }
-            });
+            if (shouldSendInactivityWarning(requirementsMet, 3, lastActivity.getNominationInfo().getLastInactivityWarningTimestamp().orElse(null), Instant.now().atZone(ZoneId.systemDefault()).getMonth())) {
+                sendInactiveUserMessage(member, discordUser, requiredMessages, requiredVotes, requiredComments, "New Member");
+            }
 
             Long lastWarningTimestamp = lastActivity.getNominationInfo().getLastInactivityWarningTimestamp().orElse(null);
             if (lastWarningTimestamp != null) {
@@ -336,6 +318,37 @@ public class NominationInactivityService {
             log.info("Role-restricted inactivity sweep complete for group '{}': scanned={}, warnedThisMonth={}, skippedAlreadyThisMonth={}, ineligible={}, missingMember={}, took={}ms",
                 group.getIdentifier(), scanned, warned, skippedAlreadyThisMonth, ineligible, missingMember, durationMs);
         }
+    }
+
+    /**
+     * Decide whether an inactivity warning should be sent to a member this run.
+     *
+     * <p>A warning is sent when the member is below the activity threshold (fewer than
+     * {@code inactivityThreshold} of the three requirements met) and has not already been warned in
+     * the current month. Extracted from the member and new-member sweeps - which previously decided
+     * this via an {@code ifPresentOrElse} and then recomputed it to tally counters - so the decision
+     * can be unit-tested in isolation.
+     *
+     * <p>The "already warned this month" check compares the calendar {@link Month} only (ignoring
+     * year), preserving the pre-existing behaviour.
+     *
+     * @param requirementsMet      the number of activity thresholds met (0-3)
+     * @param inactivityThreshold  warn when fewer than this many requirements are met
+     * @param lastWarningTimestamp epoch-millis of the last inactivity warning, or {@code null}
+     * @param currentMonth         the month to treat as "now"
+     * @return {@code true} if an inactivity warning should be sent
+     */
+    static boolean shouldSendInactivityWarning(int requirementsMet, int inactivityThreshold, Long lastWarningTimestamp, Month currentMonth) {
+        if (requirementsMet >= inactivityThreshold) {
+            return false;
+        }
+
+        if (lastWarningTimestamp != null) {
+            Month lastWarningMonth = Instant.ofEpochMilli(lastWarningTimestamp).atZone(ZoneId.systemDefault()).getMonth();
+            return lastWarningMonth != currentMonth;
+        }
+
+        return true;
     }
 
     private void sendInactiveUserMessage(Member member, DiscordUser discordUser, int requiredMessages, int requiredVotes, int requiredComments, String inactivityType) {

--- a/app/src/test/java/net/hypixel/nerdbot/app/nomination/NominationInactivityServiceTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/nomination/NominationInactivityServiceTest.java
@@ -1,0 +1,58 @@
+package net.hypixel.nerdbot.app.nomination;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.Month;
+import java.time.ZoneId;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Characterization tests for the pure inactivity-warning decision extracted from
+ * {@link NominationInactivityService#shouldSendInactivityWarning}. These pin behaviour (including
+ * the per-sweep threshold and the deliberately-preserved month-only "already this month" check)
+ * ahead of unifying the triplicated sweeps.
+ */
+class NominationInactivityServiceTest {
+
+    private static final int MEMBER_THRESHOLD = 2;
+    private static final int NEW_MEMBER_THRESHOLD = 3;
+
+    @Test
+    void warnsWhenBelowThresholdAndNeverWarned() {
+        assertTrue(NominationInactivityService.shouldSendInactivityWarning(1, MEMBER_THRESHOLD, null, Month.MARCH));
+        assertTrue(NominationInactivityService.shouldSendInactivityWarning(0, MEMBER_THRESHOLD, null, Month.MARCH));
+    }
+
+    @Test
+    void doesNotWarnWhenAtOrAboveThreshold() {
+        assertFalse(NominationInactivityService.shouldSendInactivityWarning(2, MEMBER_THRESHOLD, null, Month.MARCH));
+        assertFalse(NominationInactivityService.shouldSendInactivityWarning(3, MEMBER_THRESHOLD, null, Month.MARCH));
+    }
+
+    @Test
+    void respectsTheHigherNewMemberThreshold() {
+        // Two requirements met is inactive for new members (threshold 3) but active for members (threshold 2).
+        assertTrue(NominationInactivityService.shouldSendInactivityWarning(2, NEW_MEMBER_THRESHOLD, null, Month.MARCH));
+        assertFalse(NominationInactivityService.shouldSendInactivityWarning(3, NEW_MEMBER_THRESHOLD, null, Month.MARCH));
+    }
+
+    @Test
+    void doesNotWarnWhenAlreadyWarnedThisMonth() {
+        long now = System.currentTimeMillis();
+        Month monthOfNow = Instant.ofEpochMilli(now).atZone(ZoneId.systemDefault()).getMonth();
+
+        assertFalse(NominationInactivityService.shouldSendInactivityWarning(0, MEMBER_THRESHOLD, now, monthOfNow));
+    }
+
+    @Test
+    void warnsWhenLastWarningWasADifferentMonth() {
+        long timestamp = System.currentTimeMillis();
+        Month timestampMonth = Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).getMonth();
+        Month differentMonth = timestampMonth.plus(1);
+
+        assertTrue(NominationInactivityService.shouldSendInactivityWarning(0, MEMBER_THRESHOLD, timestamp, differentMonth));
+    }
+}


### PR DESCRIPTION
## What

Extracts the inactivity-warning decision from `NominationInactivityService`'s member and new-member sweeps into a pure, unit-testable function - the characterization step before unifying the three triplicated sweeps (`5A`).

- Both sweeps decided whether to warn via an `ifPresentOrElse` over the last-warning timestamp, then **recomputed** the same timestamp/month check to tally the `warned` vs `skippedAlreadyThisMonth` counters.
- The decision is now `shouldSendInactivityWarning(requirementsMet, inactivityThreshold, lastWarningTimestamp, currentMonth)`, called with threshold 2 for members and 3 for new members. The post-send counting blocks are unchanged.

## Why

The warn decision was untestable (buried in the JDA-bound sweeps) and computed twice. Extracting and pinning it de-risks the upcoming sweep unification, which will collapse the three near-identical sweeps and batch the per-user ticket lookup.

## Behaviour

State behaviour and side effects are preserved, **including the month-only "already this month" comparison** (ignoring year). The role-restricted sweep, which warns unconditionally and does not share this decision, is untouched.

## Tests

`mvn -pl app -am test` -> 89 passing (5 new).
