### PR TITLE
refactor(profile): extract testable Hypixel social-media verification

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/ProfileCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/ProfileCommands.java
@@ -59,6 +59,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 
@@ -154,18 +155,15 @@ public class ProfileCommands {
                         }
 
                         if (enforceSocial) {
-                            if (hypixelPlayerResponse.getPlayer().getSocialMedia() == null) {
-                                MojangProfile errorProfile = new MojangProfile();
-                                errorProfile.setErrorMessage("The Hypixel profile for `" + mojangProfile.getUsername() + "` does not have any social media linked!");
-                                return errorProfile;
-                            }
+                            HypixelPlayerResponse.SocialMedia socialMedia = hypixelPlayerResponse.getPlayer().getSocialMedia();
+                            String linkedDiscord = socialMedia == null
+                                ? null
+                                : socialMedia.getLinks().get(HypixelPlayerResponse.SocialMedia.Service.DISCORD);
 
-                            String discord = hypixelPlayerResponse.getPlayer().getSocialMedia().getLinks().get(HypixelPlayerResponse.SocialMedia.Service.DISCORD);
-                            String discordName = member.getUser().getName();
-
-                            if (!discordName.equalsIgnoreCase(discord)) {
+                            Optional<String> socialError = socialVerificationError(member.getUser().getName(), linkedDiscord, mojangProfile.getUsername(), socialMedia != null);
+                            if (socialError.isPresent()) {
                                 MojangProfile errorProfile = new MojangProfile();
-                                errorProfile.setErrorMessage("The Discord account `" + discordName + "` does not match the social media linked on the Hypixel profile for `" + mojangProfile.getUsername() + "`! It is currently set to `" + discord + "`");
+                                errorProfile.setErrorMessage(socialError.get());
                                 return errorProfile;
                             }
                         }
@@ -173,6 +171,31 @@ public class ProfileCommands {
                         return mojangProfile;
                     });
             });
+    }
+
+    /**
+     * Verify that a member's Discord username matches the Discord handle linked on their Hypixel
+     * profile.
+     *
+     * <p>Extracted from {@link #requestMojangProfileAsync} so the verification, including its exact
+     * error messages, can be unit-tested without Mojang/Hypixel HTTP calls.
+     *
+     * @param discordName        the member's current Discord username
+     * @param linkedDiscord      the Discord handle linked on Hypixel, or {@code null} if unset
+     * @param minecraftUsername  the Minecraft username, used in the error messages
+     * @param socialMediaPresent whether the Hypixel profile has any social media linked at all
+     * @return an error message if verification fails, otherwise {@link Optional#empty()}
+     */
+    static Optional<String> socialVerificationError(String discordName, String linkedDiscord, String minecraftUsername, boolean socialMediaPresent) {
+        if (!socialMediaPresent) {
+            return Optional.of("The Hypixel profile for `" + minecraftUsername + "` does not have any social media linked!");
+        }
+
+        if (!discordName.equalsIgnoreCase(linkedDiscord)) {
+            return Optional.of("The Discord account `" + discordName + "` does not match the social media linked on the Hypixel profile for `" + minecraftUsername + "`! It is currently set to `" + linkedDiscord + "`");
+        }
+
+        return Optional.empty();
     }
 
     public static void updateMojangProfile(Member member, MojangProfile mojangProfile) throws HttpException {

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/ProfileCommandsTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/ProfileCommandsTest.java
@@ -1,0 +1,45 @@
+package net.hypixel.nerdbot.app.command;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Characterization tests for the Hypixel social-media verification extracted from
+ * {@link ProfileCommands#socialVerificationError}.
+ */
+class ProfileCommandsTest {
+
+    @Test
+    void failsWhenNoSocialMediaIsLinked() {
+        Optional<String> error = ProfileCommands.socialVerificationError("Notch", null, "Notch", false);
+
+        assertTrue(error.isPresent());
+        assertEquals("The Hypixel profile for `Notch` does not have any social media linked!", error.get());
+    }
+
+    @Test
+    void passesWhenLinkedDiscordMatchesCaseInsensitively() {
+        assertTrue(ProfileCommands.socialVerificationError("Notch", "notch", "Notch", true).isEmpty());
+        assertTrue(ProfileCommands.socialVerificationError("Notch", "Notch", "Notch", true).isEmpty());
+    }
+
+    @Test
+    void failsWhenLinkedDiscordDoesNotMatch() {
+        Optional<String> error = ProfileCommands.socialVerificationError("Notch", "Herobrine", "Notch", true);
+
+        assertTrue(error.isPresent());
+        assertEquals("The Discord account `Notch` does not match the social media linked on the Hypixel profile for `Notch`! It is currently set to `Herobrine`", error.get());
+    }
+
+    @Test
+    void failsWhenSocialMediaIsPresentButNoDiscordLinkIsSet() {
+        Optional<String> error = ProfileCommands.socialVerificationError("Notch", null, "Notch", true);
+
+        assertTrue(error.isPresent());
+        assertEquals("The Discord account `Notch` does not match the social media linked on the Hypixel profile for `Notch`! It is currently set to `null`", error.get());
+    }
+}


### PR DESCRIPTION
## What

First slice of the god-command breakup (`2A`), applying the same extract-pure-logic-and-test pattern to `ProfileCommands` (1078 lines).

- The `/link` enforce-social verification - "does the member's Discord username match the Discord handle linked on their Hypixel profile?" - was buried inside the async Mojang/Hypixel HTTP chain of `requestMojangProfileAsync`, so it could not be unit-tested.
- Extracted into `socialVerificationError(discordName, linkedDiscord, minecraftUsername, socialMediaPresent)` returning an optional error message; the HTTP chain now calls it.

## Why

The verification (including its exact user-facing error messages) is fiddly, case-insensitive, and has edge cases (no social media linked, social media present but no Discord link) - exactly the logic worth pinning with tests, and previously untestable because it lived inside the HTTP callback.

## Behaviour

Unchanged, including the error-message text and the case-insensitive comparison.

## Tests

`mvn -pl app -am test` -> 93 passing (4 new, in a new `ProfileCommandsTest`).
