### PR TITLE
Remove dead DURATION field from ProfileCommands

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/ProfileCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/ProfileCommands.java
@@ -61,7 +61,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Pattern;
 
 @Slf4j
 public class ProfileCommands {
@@ -70,7 +69,6 @@ public class ProfileCommands {
         .expireAfterAccess(Duration.ofDays(1L))
         .scheduler(Scheduler.systemScheduler())
         .build();
-    private static final Pattern DURATION = Pattern.compile("((\\d+)w)?((\\d+)d)?((\\d+)h)?((\\d+)m)?((\\d+)s)?");
 
     public static MessageEmbed createBadgesEmbed(Member member, DiscordUser discordUser, boolean viewingSelf) {
         List<BadgeEntry> badges = discordUser.getBadges().stream()


### PR DESCRIPTION
Removes a private static `Pattern DURATION` field from `ProfileCommands` that was never referenced anywhere in the class - leftover from a removed feature. A repo-wide search confirms the only live uses of an identically-named pattern are in `ReminderCommands`, which is unaffected.

The now-unused `java.util.regex.Pattern` import is removed as well, since nothing else in the file used it.

`mvn -pl app -am test` passes (93 tests, build success).