### PR TITLE
refactor(admin): extract testable /config edit blocked-key guard

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/AdminCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/AdminCommands.java
@@ -286,11 +286,34 @@ public class AdminCommands {
         "ownerIds", "guildId", "token", "databaseUri", "databaseName"
     );
 
+    /**
+     * Extract the root segment of a dotted config key path (the part before the first {@code .}).
+     *
+     * @param key the config key, e.g. {@code "roleConfig.memberRoleId"} or {@code "token"}
+     * @return the root key, e.g. {@code "roleConfig"} or {@code "token"}
+     */
+    static String rootConfigKey(String key) {
+        return key.contains(".") ? key.substring(0, key.indexOf('.')) : key;
+    }
+
+    /**
+     * Whether the given config key may not be edited via {@code /config edit}. Sensitive keys
+     * (credentials and identity) are blocked, including any nested path beneath them.
+     *
+     * <p>Extracted from {@link #editConfig} so this security guard can be unit-tested directly.
+     *
+     * @param key the config key an admin is attempting to edit
+     * @return {@code true} if editing the key is not permitted
+     */
+    static boolean isBlockedConfigKey(String key) {
+        return BLOCKED_CONFIG_KEYS.contains(rootConfigKey(key));
+    }
+
     @SlashCommand(name = "config", subcommand = "edit", description = "Edit the config file", guildOnly = true, defaultMemberPermissions = {"ADMINISTRATOR"}, requiredPermissions = {"ADMINISTRATOR"})
     public void editConfig(SlashCommandInteractionEvent event, @SlashOption String key, @SlashOption String value) {
         // Validate the config key is not in the blocked list
-        String rootKey = key.contains(".") ? key.substring(0, key.indexOf('.')) : key;
-        if (BLOCKED_CONFIG_KEYS.contains(rootKey)) {
+        String rootKey = rootConfigKey(key);
+        if (isBlockedConfigKey(key)) {
             event.reply("Editing the `" + rootKey + "` config key is not permitted.").setEphemeral(true).queue();
             return;
         }

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/AdminCommandsTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/AdminCommandsTest.java
@@ -1,0 +1,42 @@
+package net.hypixel.nerdbot.app.command;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Characterization tests for the {@code /config edit} guard extracted from {@link AdminCommands}.
+ */
+class AdminCommandsTest {
+
+    @Test
+    void blocksSensitiveTopLevelKeys() {
+        assertTrue(AdminCommands.isBlockedConfigKey("token"));
+        assertTrue(AdminCommands.isBlockedConfigKey("ownerIds"));
+        assertTrue(AdminCommands.isBlockedConfigKey("guildId"));
+        assertTrue(AdminCommands.isBlockedConfigKey("databaseUri"));
+        assertTrue(AdminCommands.isBlockedConfigKey("databaseName"));
+    }
+
+    @Test
+    void blocksNestedPathsBeneathSensitiveKeys() {
+        assertTrue(AdminCommands.isBlockedConfigKey("token.value"));
+        assertTrue(AdminCommands.isBlockedConfigKey("databaseUri.host.port"));
+    }
+
+    @Test
+    void allowsNonSensitiveKeys() {
+        assertFalse(AdminCommands.isBlockedConfigKey("messageLimit"));
+        assertFalse(AdminCommands.isBlockedConfigKey("roleConfig.memberRoleId"));
+        assertFalse(AdminCommands.isBlockedConfigKey("mojangUsernameCacheTTL"));
+    }
+
+    @Test
+    void rootConfigKeyReturnsSegmentBeforeFirstDot() {
+        assertEquals("roleConfig", AdminCommands.rootConfigKey("roleConfig.memberRoleId"));
+        assertEquals("a", AdminCommands.rootConfigKey("a.b.c"));
+        assertEquals("token", AdminCommands.rootConfigKey("token"));
+    }
+}


### PR DESCRIPTION
## What

Continues the god-command breakup (`2A`) in `AdminCommands` (1631 lines), targeting a security-relevant guard.

- `/config edit` blocks editing sensitive keys (`token`, `ownerIds`, `guildId`, `databaseUri`, `databaseName`) by taking the root segment of a dotted key path and checking a blocklist. That logic was inline in the command, so it could not be unit-tested.
- Extracted `rootConfigKey(key)` and `isBlockedConfigKey(key)`; `editConfig` now calls them.

## Why

This guard protects credentials and identity config from being edited via a slash command, including nested paths like `token.value`. It is exactly the kind of security check that deserves direct test coverage, and it was previously locked inside the command handler.

## Behaviour

Unchanged, including the user-facing "not permitted" message and the nested-path handling.

## Tests

`mvn -pl app -am test` -> 104 passing (4 new in a new `AdminCommandsTest`).
