### PR TITLE
refactor(generator): make search-result truncation testable

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -413,7 +413,7 @@ public class GeneratorCommands {
         return map;
     }
 
-    private static void appendSearchResults(StringBuilder message, String header, List<String> results) {
+    static void appendSearchResults(StringBuilder message, String header, List<String> results) {
         if (results.isEmpty()) {
             return;
         }

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/GeneratorCommandsTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/GeneratorCommandsTest.java
@@ -276,4 +276,53 @@ class GeneratorCommandsTest {
 
         assertTrue(exception.getMessage().contains("Invalid number"));
     }
+
+    @Test
+    void appendSearchResultsIgnoresEmptyResults() {
+        StringBuilder message = new StringBuilder("existing");
+
+        GeneratorCommands.appendSearchResults(message, "Header", List.of());
+
+        assertEquals("existing", message.toString());
+    }
+
+    @Test
+    void appendSearchResultsAppendsHeaderWithTotalAndEachResult() {
+        StringBuilder message = new StringBuilder();
+
+        GeneratorCommands.appendSearchResults(message, "Top", List.of("a", "b"));
+
+        assertEquals("Top (2 total):\n - `a`\n - `b`\n", message.toString());
+    }
+
+    @Test
+    void appendSearchResultsCapsRenderedLinesButReportsFullTotal() {
+        List<String> results = java.util.stream.IntStream.range(0, 15).mapToObj(i -> "item" + i).toList();
+        StringBuilder message = new StringBuilder();
+
+        GeneratorCommands.appendSearchResults(message, "Results", results);
+
+        String output = message.toString();
+        assertTrue(output.startsWith("Results (15 total):\n"), "header should report the full total");
+        assertEquals(10, output.lines().filter(line -> line.startsWith(" - ")).count(), "only 10 results should render");
+    }
+
+    @Test
+    void appendSearchResultsSkipsBlockThatWouldExceedMessageLimit() {
+        // Discord's 2000-char message limit: a block whose header would not fit is skipped entirely.
+        StringBuilder message = new StringBuilder("x".repeat(1990));
+
+        GeneratorCommands.appendSearchResults(message, "Header", List.of("a"));
+
+        assertEquals(1990, message.length(), "the block should be skipped, leaving the message untouched");
+    }
+
+    @Test
+    void appendSearchResultsAppendsTruncationMarkerWhenLinesRunOut() {
+        StringBuilder message = new StringBuilder("x".repeat(1975));
+
+        GeneratorCommands.appendSearchResults(message, "H", List.of("a", "b"));
+
+        assertTrue(message.toString().endsWith(" - ...\n"), "should end with the truncation marker");
+    }
 }


### PR DESCRIPTION
## What

Another `2A` slice in `GeneratorCommands`: make the `/gen` search-result truncation testable.

- `appendSearchResults` assembles the search reply inside Discord's 2000-character message limit: it skips a block whose header would not fit, caps rendered lines at `SEARCH_RESULT_LIMIT` (10) while still reporting the full total, and appends a truncation marker when the next line would overflow.
- It was `private`, so none of that limit handling was covered. Widened to package-private; no behaviour change.

## Tests

`mvn -pl app -am test` -> 109 passing (5 new).

Pins: empty results ignored; header reports full total with only 10 lines rendered; a block that would exceed the limit is skipped entirely; the truncation marker is appended when lines run out.
