### PR TITLE
refactor(profile): extract testable badge display comparator

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/ProfileCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/ProfileCommands.java
@@ -57,6 +57,7 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -70,28 +71,41 @@ public class ProfileCommands {
         .scheduler(Scheduler.systemScheduler())
         .build();
 
-    public static MessageEmbed createBadgesEmbed(Member member, DiscordUser discordUser, boolean viewingSelf) {
-        List<BadgeEntry> badges = discordUser.getBadges().stream()
-            .sorted((o1, o2) -> {
-                if (BadgeManager.isTieredBadge(o1.badgeId()) && BadgeManager.isTieredBadge(o2.badgeId())) {
-                    TieredBadge tieredBadge1 = BadgeManager.getTieredBadgeById(o1.badgeId());
-                    TieredBadge tieredBadge2 = BadgeManager.getTieredBadgeById(o2.badgeId());
+    /**
+     * The order badges are displayed in: tiered badges first, higher tiers before lower, then
+     * non-tiered badges most-recently-obtained first.
+     *
+     * <p>Extracted from {@link #createBadgesEmbed} so the ordering can be unit-tested. Resolves
+     * badge metadata through the static {@link BadgeManager}.
+     *
+     * @return the display comparator for a user's {@link BadgeEntry badges}
+     */
+    static Comparator<BadgeEntry> badgeDisplayComparator() {
+        return (o1, o2) -> {
+            if (BadgeManager.isTieredBadge(o1.badgeId()) && BadgeManager.isTieredBadge(o2.badgeId())) {
+                TieredBadge tieredBadge1 = BadgeManager.getTieredBadgeById(o1.badgeId());
+                TieredBadge tieredBadge2 = BadgeManager.getTieredBadgeById(o2.badgeId());
 
-                    if (o1.tier() != null && o2.tier() != null) {
-                        return Integer.compare(tieredBadge2.getTier(o2.tier()).getTier(), tieredBadge1.getTier(o1.tier()).getTier());
-                    } else if (o1.tier() != null) {
-                        return -1;
-                    } else if (o2.tier() != null) {
-                        return 1;
-                    }
-                } else if (BadgeManager.isTieredBadge(o1.badgeId())) {
+                if (o1.tier() != null && o2.tier() != null) {
+                    return Integer.compare(tieredBadge2.getTier(o2.tier()).getTier(), tieredBadge1.getTier(o1.tier()).getTier());
+                } else if (o1.tier() != null) {
                     return -1;
-                } else if (BadgeManager.isTieredBadge(o2.badgeId())) {
+                } else if (o2.tier() != null) {
                     return 1;
                 }
+            } else if (BadgeManager.isTieredBadge(o1.badgeId())) {
+                return -1;
+            } else if (BadgeManager.isTieredBadge(o2.badgeId())) {
+                return 1;
+            }
 
-                return Long.compare(o2.obtainedAt(), o1.obtainedAt());
-            })
+            return Long.compare(o2.obtainedAt(), o1.obtainedAt());
+        };
+    }
+
+    public static MessageEmbed createBadgesEmbed(Member member, DiscordUser discordUser, boolean viewingSelf) {
+        List<BadgeEntry> badges = discordUser.getBadges().stream()
+            .sorted(badgeDisplayComparator())
             .toList();
 
         EmbedBuilder embedBuilder = new EmbedBuilder()

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/ProfileCommandsTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/ProfileCommandsTest.java
@@ -1,15 +1,21 @@
 package net.hypixel.nerdbot.app.command;
 
+import net.hypixel.nerdbot.app.badge.BadgeManager;
+import net.hypixel.nerdbot.marmalade.storage.badge.TieredBadge;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.badge.BadgeEntry;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Characterization tests for the Hypixel social-media verification extracted from
- * {@link ProfileCommands#socialVerificationError}.
+ * Characterization tests for pure logic extracted from {@link ProfileCommands}: the Hypixel
+ * social-media verification and the badge display ordering.
  */
 class ProfileCommandsTest {
 
@@ -41,5 +47,60 @@ class ProfileCommandsTest {
 
         assertTrue(error.isPresent());
         assertEquals("The Discord account `Notch` does not match the social media linked on the Hypixel profile for `Notch`! It is currently set to `null`", error.get());
+    }
+
+    @AfterEach
+    void clearBadges() {
+        BadgeManager.getBadgeMap().clear();
+    }
+
+    private static void registerTieredBadge() {
+        BadgeManager.getBadgeMap().put("tiered", new TieredBadge("tiered", "Tiered", List.of(
+            new TieredBadge.Tier("one", "e", 1),
+            new TieredBadge.Tier("two", "e", 2),
+            new TieredBadge.Tier("three", "e", 3))));
+    }
+
+    @Test
+    void tieredBadgesSortBeforeNonTiered() {
+        registerTieredBadge();
+        BadgeEntry plain = new BadgeEntry("plain", null, 1L);
+        BadgeEntry tiered = new BadgeEntry("tiered", 1, 1L);
+
+        List<BadgeEntry> sorted = Stream.of(plain, tiered).sorted(ProfileCommands.badgeDisplayComparator()).toList();
+
+        assertEquals(List.of(tiered, plain), sorted);
+    }
+
+    @Test
+    void higherTierSortsBeforeLowerTier() {
+        registerTieredBadge();
+        BadgeEntry low = new BadgeEntry("tiered", 1, 1L);
+        BadgeEntry high = new BadgeEntry("tiered", 3, 1L);
+
+        List<BadgeEntry> sorted = Stream.of(low, high).sorted(ProfileCommands.badgeDisplayComparator()).toList();
+
+        assertEquals(List.of(high, low), sorted);
+    }
+
+    @Test
+    void nonTieredBadgesSortByMostRecentlyObtained() {
+        BadgeEntry older = new BadgeEntry("a", null, 100L);
+        BadgeEntry newer = new BadgeEntry("b", null, 200L);
+
+        List<BadgeEntry> sorted = Stream.of(older, newer).sorted(ProfileCommands.badgeDisplayComparator()).toList();
+
+        assertEquals(List.of(newer, older), sorted);
+    }
+
+    @Test
+    void tieredEntryWithTierSortsBeforeTieredEntryWithoutTier() {
+        registerTieredBadge();
+        BadgeEntry withoutTier = new BadgeEntry("tiered", null, 1L);
+        BadgeEntry withTier = new BadgeEntry("tiered", 2, 1L);
+
+        List<BadgeEntry> sorted = Stream.of(withoutTier, withTier).sorted(ProfileCommands.badgeDisplayComparator()).toList();
+
+        assertEquals(List.of(withTier, withoutTier), sorted);
     }
 }


### PR DESCRIPTION
## What

Another `2A` slice in `ProfileCommands`: extract the badge display ordering so it can be tested.

- `/badges` sorted a user's badges with an inline comparator - tiered badges first, higher tiers before lower, then non-tiered badges most-recently-obtained first - so that ordering had no coverage.
- Extracted into `badgeDisplayComparator()`; `createBadgesEmbed` sorts with it. No behaviour change.

## Tests

`mvn -pl app -am test` -> 113 passing (4 new).

The tests seed `BadgeManager` with a tiered and non-tiered badge and pin: tiered sorts before non-tiered, higher tier before lower, a tiered entry with a tier before one without, and non-tiered by most-recently-obtained.
