### PR TITLE
chore(test): drop three low-value tests

### DIFF
--- a/app/src/test/java/net/hypixel/nerdbot/app/command/AdminCommandsTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/AdminCommandsTest.java
@@ -2,7 +2,6 @@ package net.hypixel.nerdbot.app.command;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -33,10 +32,4 @@ class AdminCommandsTest {
         assertFalse(AdminCommands.isBlockedConfigKey("mojangUsernameCacheTTL"));
     }
 
-    @Test
-    void rootConfigKeyReturnsSegmentBeforeFirstDot() {
-        assertEquals("roleConfig", AdminCommands.rootConfigKey("roleConfig.memberRoleId"));
-        assertEquals("a", AdminCommands.rootConfigKey("a.b.c"));
-        assertEquals("token", AdminCommands.rootConfigKey("token"));
-    }
 }

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/GeneratorCommandsTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/GeneratorCommandsTest.java
@@ -307,22 +307,4 @@ class GeneratorCommandsTest {
         assertEquals(10, output.lines().filter(line -> line.startsWith(" - ")).count(), "only 10 results should render");
     }
 
-    @Test
-    void appendSearchResultsSkipsBlockThatWouldExceedMessageLimit() {
-        // Discord's 2000-char message limit: a block whose header would not fit is skipped entirely.
-        StringBuilder message = new StringBuilder("x".repeat(1990));
-
-        GeneratorCommands.appendSearchResults(message, "Header", List.of("a"));
-
-        assertEquals(1990, message.length(), "the block should be skipped, leaving the message untouched");
-    }
-
-    @Test
-    void appendSearchResultsAppendsTruncationMarkerWhenLinesRunOut() {
-        StringBuilder message = new StringBuilder("x".repeat(1975));
-
-        GeneratorCommands.appendSearchResults(message, "H", List.of("a", "b"));
-
-        assertTrue(message.toString().endsWith(" - ...\n"), "should end with the truncation marker");
-    }
 }


### PR DESCRIPTION
## What

Removes three tests added earlier this session that do not earn their keep.

- `appendSearchResultsSkipsBlockThatWouldExceedMessageLimit` and `appendSearchResultsAppendsTruncationMarkerWhenLinesRunOut` pre-filled a `StringBuilder` to magic lengths (1990, 1975) to trip the 2000-char message limit. They are brittle (break on any constant change), and assert a byte boundary rather than documenting intent.
- `rootConfigKeyReturnsSegmentBeforeFirstDot` was trivial and fully redundant with the `isBlockedConfigKey` nested-path test, which already exercises `rootConfigKey`.

## What is kept

The meaningful coverage stays: `appendSearchResults` empty/formatting/cap-at-ten behaviour, and the `/config edit` blocked-key guard including nested paths.

## Tests

`mvn -pl app -am test` -> 110 passing.
