### PR TITLE
fix(nomination): compare year+month, not just calendar month, for 'already this month'

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/nomination/NominationInactivityService.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/nomination/NominationInactivityService.java
@@ -26,7 +26,7 @@ import org.bson.conversions.Bson;
 
 import java.awt.*;
 import java.time.Instant;
-import java.time.Month;
+import java.time.YearMonth;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -96,16 +96,16 @@ public class NominationInactivityService {
 
             log.info("Checking if {} (ID: {}) should be flagged for inactivity (total messages: {}, total comments: {}, total votes: {}) (has min. comments: {}, has min. votes: {}, has min. messages: {}, requirements met: {}/3)", member.getEffectiveName(), member.getId(), totalMessages, totalComments, totalVotes, hasRequiredComments, hasRequiredVotes, hasRequiredMessages, requirementsMet);
 
-            if (shouldSendInactivityWarning(requirementsMet, 2, lastActivity.getNominationInfo().getLastInactivityWarningTimestamp().orElse(null), Instant.now().atZone(ZoneId.systemDefault()).getMonth())) {
+            if (shouldSendInactivityWarning(requirementsMet, 2, lastActivity.getNominationInfo().getLastInactivityWarningTimestamp().orElse(null), YearMonth.now(ZoneId.systemDefault()))) {
                 sendInactiveUserMessage(member, discordUser, requiredMessages, requiredVotes, requiredComments, "Member");
             }
 
             Long lastWarningTimestamp = lastActivity.getNominationInfo().getLastInactivityWarningTimestamp().orElse(null);
             if (lastWarningTimestamp != null) {
-                Month lastWarnMonth = Instant.ofEpochMilli(lastWarningTimestamp).atZone(ZoneId.systemDefault()).getMonth();
-                Month nowMonth = Instant.now().atZone(ZoneId.systemDefault()).getMonth();
+                YearMonth lastWarnMonth = YearMonth.from(Instant.ofEpochMilli(lastWarningTimestamp).atZone(ZoneId.systemDefault()));
+                YearMonth nowMonth = YearMonth.now(ZoneId.systemDefault());
 
-                if (lastWarnMonth == nowMonth) {
+                if (lastWarnMonth.equals(nowMonth)) {
                     warned++;
                 } else {
                     skippedAlreadyThisMonth++;
@@ -166,16 +166,16 @@ public class NominationInactivityService {
 
             log.info("[NewMember] Checking inactivity for {} (ID: {}) (messages: {}, comments: {}, votes: {}) (has min. comments: {}, has min. votes: {}, has min. messages: {}, requirements met: {}/3)", member.getEffectiveName(), member.getId(), totalMessages, totalComments, totalVotes, hasRequiredComments, hasRequiredVotes, hasRequiredMessages, requirementsMet);
 
-            if (shouldSendInactivityWarning(requirementsMet, 3, lastActivity.getNominationInfo().getLastInactivityWarningTimestamp().orElse(null), Instant.now().atZone(ZoneId.systemDefault()).getMonth())) {
+            if (shouldSendInactivityWarning(requirementsMet, 3, lastActivity.getNominationInfo().getLastInactivityWarningTimestamp().orElse(null), YearMonth.now(ZoneId.systemDefault()))) {
                 sendInactiveUserMessage(member, discordUser, requiredMessages, requiredVotes, requiredComments, "New Member");
             }
 
             Long lastWarningTimestamp = lastActivity.getNominationInfo().getLastInactivityWarningTimestamp().orElse(null);
             if (lastWarningTimestamp != null) {
-                Month lastWarnMonth = Instant.ofEpochMilli(lastWarningTimestamp).atZone(ZoneId.systemDefault()).getMonth();
-                Month nowMonth = Instant.now().atZone(ZoneId.systemDefault()).getMonth();
+                YearMonth lastWarnMonth = YearMonth.from(Instant.ofEpochMilli(lastWarningTimestamp).atZone(ZoneId.systemDefault()));
+                YearMonth nowMonth = YearMonth.now(ZoneId.systemDefault());
 
-                if (lastWarnMonth == nowMonth) {
+                if (lastWarnMonth.equals(nowMonth)) {
                     warned++;
                 } else {
                     skippedAlreadyThisMonth++;
@@ -325,27 +325,24 @@ public class NominationInactivityService {
      *
      * <p>A warning is sent when the member is below the activity threshold (fewer than
      * {@code inactivityThreshold} of the three requirements met) and has not already been warned in
-     * the current month. Extracted from the member and new-member sweeps - which previously decided
-     * this via an {@code ifPresentOrElse} and then recomputed it to tally counters - so the decision
-     * can be unit-tested in isolation.
-     *
-     * <p>The "already warned this month" check compares the calendar {@link Month} only (ignoring
-     * year), preserving the pre-existing behaviour.
+     * the current calendar month. Extracted from the member and new-member sweeps - which previously
+     * decided this via an {@code ifPresentOrElse} and then recomputed it to tally counters - so the
+     * decision can be unit-tested in isolation.
      *
      * @param requirementsMet      the number of activity thresholds met (0-3)
      * @param inactivityThreshold  warn when fewer than this many requirements are met
      * @param lastWarningTimestamp epoch-millis of the last inactivity warning, or {@code null}
-     * @param currentMonth         the month to treat as "now"
+     * @param currentYearMonth     the year-month to treat as "now"
      * @return {@code true} if an inactivity warning should be sent
      */
-    static boolean shouldSendInactivityWarning(int requirementsMet, int inactivityThreshold, Long lastWarningTimestamp, Month currentMonth) {
+    static boolean shouldSendInactivityWarning(int requirementsMet, int inactivityThreshold, Long lastWarningTimestamp, YearMonth currentYearMonth) {
         if (requirementsMet >= inactivityThreshold) {
             return false;
         }
 
         if (lastWarningTimestamp != null) {
-            Month lastWarningMonth = Instant.ofEpochMilli(lastWarningTimestamp).atZone(ZoneId.systemDefault()).getMonth();
-            return lastWarningMonth != currentMonth;
+            YearMonth lastWarningMonth = YearMonth.from(Instant.ofEpochMilli(lastWarningTimestamp).atZone(ZoneId.systemDefault()));
+            return !lastWarningMonth.equals(currentYearMonth);
         }
 
         return true;

--- a/app/src/main/java/net/hypixel/nerdbot/app/nomination/NominationService.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/nomination/NominationService.java
@@ -19,8 +19,8 @@ import net.hypixel.nerdbot.discord.util.StringUtils;
 import java.awt.*;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.Month;
 import java.time.OffsetDateTime;
+import java.time.YearMonth;
 import java.time.ZoneId;
 import java.util.function.BiPredicate;
 
@@ -168,7 +168,7 @@ public class NominationService {
         }
 
         Long lastNominationTimestamp = lastActivity.getNominationInfo().getLastNominationTimestamp().orElse(null);
-        NominationOutcome outcome = decideOutcome(requirementsMet, lastNominationTimestamp, Instant.now().atZone(ZoneId.systemDefault()).getMonth());
+        NominationOutcome outcome = decideOutcome(requirementsMet, lastNominationTimestamp, YearMonth.now(ZoneId.systemDefault()));
 
         if (outcome == NominationOutcome.NOMINATED) {
             sendNominationMessage(member, discordUser, requiredMessages, requiredVotes, requiredComments, daysWindow);
@@ -181,23 +181,21 @@ public class NominationService {
      * Decide a member's nomination outcome from how many of the three activity thresholds they meet
      * and when they were last nominated.
      *
-     * <p>A member already nominated in the current month is skipped regardless of their activity;
-     * otherwise they are nominated when they meet at least two of the three thresholds, and skipped
-     * as below-threshold when they do not.
+     * <p>A member already nominated in the current calendar month is skipped regardless of their
+     * activity; otherwise they are nominated when they meet at least two of the three thresholds, and
+     * skipped as below-threshold when they do not.
      *
-     * <p>The "already this month" check compares the calendar {@link Month} only (ignoring year),
-     * preserving the pre-existing behaviour. Extracted from {@link #evaluateNomination} so the
-     * decision can be unit-tested in isolation.
+     * <p>Extracted from {@link #evaluateNomination} so the decision can be unit-tested in isolation.
      *
      * @param requirementsMet         the number of thresholds met (0-3)
      * @param lastNominationTimestamp epoch-millis of the last nomination, or {@code null} if never
-     * @param currentMonth            the month to treat as "now"
+     * @param currentYearMonth        the year-month to treat as "now"
      * @return the nomination outcome
      */
-    static NominationOutcome decideOutcome(int requirementsMet, Long lastNominationTimestamp, Month currentMonth) {
+    static NominationOutcome decideOutcome(int requirementsMet, Long lastNominationTimestamp, YearMonth currentYearMonth) {
         if (lastNominationTimestamp != null) {
-            Month lastNominationMonth = Instant.ofEpochMilli(lastNominationTimestamp).atZone(ZoneId.systemDefault()).getMonth();
-            if (lastNominationMonth == currentMonth) {
+            YearMonth lastNominationMonth = YearMonth.from(Instant.ofEpochMilli(lastNominationTimestamp).atZone(ZoneId.systemDefault()));
+            if (lastNominationMonth.equals(currentYearMonth)) {
                 return NominationOutcome.SKIPPED_ALREADY_THIS_MONTH;
             }
         }

--- a/app/src/test/java/net/hypixel/nerdbot/app/nomination/NominationInactivityServiceTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/nomination/NominationInactivityServiceTest.java
@@ -2,57 +2,61 @@ package net.hypixel.nerdbot.app.nomination;
 
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
-import java.time.Month;
+import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.ZoneId;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Characterization tests for the pure inactivity-warning decision extracted from
- * {@link NominationInactivityService#shouldSendInactivityWarning}. These pin behaviour (including
- * the per-sweep threshold and the deliberately-preserved month-only "already this month" check)
- * ahead of unifying the triplicated sweeps.
+ * Tests for the pure inactivity-warning decision
+ * {@link NominationInactivityService#shouldSendInactivityWarning}, including the per-sweep threshold
+ * and the "already warned this calendar month" check.
  */
 class NominationInactivityServiceTest {
 
     private static final int MEMBER_THRESHOLD = 2;
     private static final int NEW_MEMBER_THRESHOLD = 3;
+    private static final YearMonth MARCH_2026 = YearMonth.of(2026, 3);
 
     @Test
     void warnsWhenBelowThresholdAndNeverWarned() {
-        assertTrue(NominationInactivityService.shouldSendInactivityWarning(1, MEMBER_THRESHOLD, null, Month.MARCH));
-        assertTrue(NominationInactivityService.shouldSendInactivityWarning(0, MEMBER_THRESHOLD, null, Month.MARCH));
+        assertTrue(NominationInactivityService.shouldSendInactivityWarning(1, MEMBER_THRESHOLD, null, MARCH_2026));
+        assertTrue(NominationInactivityService.shouldSendInactivityWarning(0, MEMBER_THRESHOLD, null, MARCH_2026));
     }
 
     @Test
     void doesNotWarnWhenAtOrAboveThreshold() {
-        assertFalse(NominationInactivityService.shouldSendInactivityWarning(2, MEMBER_THRESHOLD, null, Month.MARCH));
-        assertFalse(NominationInactivityService.shouldSendInactivityWarning(3, MEMBER_THRESHOLD, null, Month.MARCH));
+        assertFalse(NominationInactivityService.shouldSendInactivityWarning(2, MEMBER_THRESHOLD, null, MARCH_2026));
+        assertFalse(NominationInactivityService.shouldSendInactivityWarning(3, MEMBER_THRESHOLD, null, MARCH_2026));
     }
 
     @Test
     void respectsTheHigherNewMemberThreshold() {
         // Two requirements met is inactive for new members (threshold 3) but active for members (threshold 2).
-        assertTrue(NominationInactivityService.shouldSendInactivityWarning(2, NEW_MEMBER_THRESHOLD, null, Month.MARCH));
-        assertFalse(NominationInactivityService.shouldSendInactivityWarning(3, NEW_MEMBER_THRESHOLD, null, Month.MARCH));
+        assertTrue(NominationInactivityService.shouldSendInactivityWarning(2, NEW_MEMBER_THRESHOLD, null, MARCH_2026));
+        assertFalse(NominationInactivityService.shouldSendInactivityWarning(3, NEW_MEMBER_THRESHOLD, null, MARCH_2026));
     }
 
     @Test
     void doesNotWarnWhenAlreadyWarnedThisMonth() {
-        long now = System.currentTimeMillis();
-        Month monthOfNow = Instant.ofEpochMilli(now).atZone(ZoneId.systemDefault()).getMonth();
-
-        assertFalse(NominationInactivityService.shouldSendInactivityWarning(0, MEMBER_THRESHOLD, now, monthOfNow));
+        assertFalse(NominationInactivityService.shouldSendInactivityWarning(0, MEMBER_THRESHOLD, epochMillisAt(2026, 3, 10), MARCH_2026));
     }
 
     @Test
-    void warnsWhenLastWarningWasADifferentMonth() {
-        long timestamp = System.currentTimeMillis();
-        Month timestampMonth = Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).getMonth();
-        Month differentMonth = timestampMonth.plus(1);
+    void warnsWhenLastWarningWasAnEarlierMonthOfTheSameYear() {
+        assertTrue(NominationInactivityService.shouldSendInactivityWarning(0, MEMBER_THRESHOLD, epochMillisAt(2026, 1, 10), MARCH_2026));
+    }
 
-        assertTrue(NominationInactivityService.shouldSendInactivityWarning(0, MEMBER_THRESHOLD, timestamp, differentMonth));
+    @Test
+    void warnsWhenLastWarningWasTheSameMonthOfAPreviousYear() {
+        // Regression: "already this month" must consider the year, not just the calendar month.
+        // Previously March 2025 was wrongly treated as the current March and suppressed the warning.
+        assertTrue(NominationInactivityService.shouldSendInactivityWarning(0, MEMBER_THRESHOLD, epochMillisAt(2025, 3, 10), MARCH_2026));
+    }
+
+    private static long epochMillisAt(int year, int month, int day) {
+        return LocalDate.of(year, month, day).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
     }
 }

--- a/app/src/test/java/net/hypixel/nerdbot/app/nomination/NominationServiceTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/nomination/NominationServiceTest.java
@@ -3,57 +3,58 @@ package net.hypixel.nerdbot.app.nomination;
 import net.hypixel.nerdbot.app.nomination.NominationService.NominationOutcome;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
-import java.time.Month;
+import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.ZoneId;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Characterization tests for the pure nomination decision extracted from
- * {@link NominationService#decideOutcome}. These pin behaviour ahead of any wider refactor of the
- * nomination subsystem, including the deliberately-preserved month-only "already this month" check.
+ * Tests for the pure promotion-nomination decision {@link NominationService#decideOutcome}.
  */
 class NominationServiceTest {
 
+    private static final YearMonth MARCH_2026 = YearMonth.of(2026, 3);
+
     @Test
     void nominatesWhenThresholdsMetAndNeverNominated() {
-        assertEquals(NominationOutcome.NOMINATED, NominationService.decideOutcome(2, null, Month.MARCH));
-        assertEquals(NominationOutcome.NOMINATED, NominationService.decideOutcome(3, null, Month.MARCH));
+        assertEquals(NominationOutcome.NOMINATED, NominationService.decideOutcome(2, null, MARCH_2026));
+        assertEquals(NominationOutcome.NOMINATED, NominationService.decideOutcome(3, null, MARCH_2026));
     }
 
     @Test
     void skipsBelowThresholdWhenNeverNominatedAndUnderTwoRequirements() {
-        assertEquals(NominationOutcome.SKIPPED_BELOW_THRESHOLD, NominationService.decideOutcome(0, null, Month.MARCH));
-        assertEquals(NominationOutcome.SKIPPED_BELOW_THRESHOLD, NominationService.decideOutcome(1, null, Month.MARCH));
+        assertEquals(NominationOutcome.SKIPPED_BELOW_THRESHOLD, NominationService.decideOutcome(0, null, MARCH_2026));
+        assertEquals(NominationOutcome.SKIPPED_BELOW_THRESHOLD, NominationService.decideOutcome(1, null, MARCH_2026));
     }
 
     @Test
     void skipsWhenAlreadyNominatedThisMonthEvenIfEligible() {
-        long now = System.currentTimeMillis();
-        Month monthOfNow = Instant.ofEpochMilli(now).atZone(ZoneId.systemDefault()).getMonth();
-
         assertEquals(NominationOutcome.SKIPPED_ALREADY_THIS_MONTH,
-            NominationService.decideOutcome(3, now, monthOfNow));
+            NominationService.decideOutcome(3, epochMillisAt(2026, 3, 10), MARCH_2026));
     }
 
     @Test
-    void nominatesWhenLastNominationWasADifferentMonth() {
-        long timestamp = System.currentTimeMillis();
-        Month timestampMonth = Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).getMonth();
-        Month differentMonth = timestampMonth.plus(1);
-
+    void nominatesWhenLastNominationWasAnEarlierMonthOfTheSameYear() {
         assertEquals(NominationOutcome.NOMINATED,
-            NominationService.decideOutcome(2, timestamp, differentMonth));
+            NominationService.decideOutcome(2, epochMillisAt(2026, 1, 10), MARCH_2026));
     }
 
     @Test
     void skipsBelowThresholdWhenDifferentMonthButUnderTwoRequirements() {
-        long timestamp = System.currentTimeMillis();
-        Month timestampMonth = Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).getMonth();
-        Month differentMonth = timestampMonth.plus(1);
-
         assertEquals(NominationOutcome.SKIPPED_BELOW_THRESHOLD,
-            NominationService.decideOutcome(1, timestamp, differentMonth));
+            NominationService.decideOutcome(1, epochMillisAt(2026, 1, 10), MARCH_2026));
+    }
+
+    @Test
+    void nominatesWhenLastNominationWasTheSameMonthOfAPreviousYear() {
+        // Regression: "already this month" must consider the year, not just the calendar month.
+        // Previously March 2025 was wrongly treated as the current March and skipped.
+        assertEquals(NominationOutcome.NOMINATED,
+            NominationService.decideOutcome(2, epochMillisAt(2025, 3, 10), MARCH_2026));
+    }
+
+    private static long epochMillisAt(int year, int month, int day) {
+        return LocalDate.of(year, month, day).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
     }
 }


### PR DESCRIPTION
## What

Fixes a real correctness bug in the nomination subsystem: the "have we already nominated / warned this person this month?" checks compared `java.time.Month` only, **ignoring the year**.

A member last nominated (or last sent an inactivity warning) in, say, **March 2025** was treated as already handled in **March 2026** - so they were skipped for a full extra year.

The fix compares `java.time.YearMonth` instead, across:
- `NominationService.decideOutcome` (promotion nominations)
- `NominationInactivityService.shouldSendInactivityWarning` (inactivity warnings)
- both inactivity-sweep `warned` / `skippedAlreadyThisMonth` counters

## Behaviour change - please review

This **changes eligibility semantics** at year boundaries: members correctly become eligible again the next calendar month even if that month shares its name with the month they were last handled a year earlier. That's the intended behaviour, but because it affects who gets nominated/warned I've left this PR for your review rather than auto-merging it.

## Tests

`mvn -pl app -am test` -> 112 passing (2 new regression tests pinning that the same month of a previous year is no longer treated as "this month").
