### PR TITLE
refactor(post): extract testable MarkdownPostService from PostCommands

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/PostCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/PostCommands.java
@@ -1,51 +1,26 @@
 package net.hypixel.nerdbot.app.command;
 
-import com.github.tomtung.latex2unicode.LaTeX2Unicode;
 import lombok.extern.slf4j.Slf4j;
 import net.aerh.slashcommands.api.annotations.SlashCommand;
 import net.aerh.slashcommands.api.annotations.SlashOption;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.hypixel.nerdbot.app.post.MarkdownPostService;
 import net.hypixel.nerdbot.discord.util.StringUtils;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Slf4j
 public class PostCommands {
 
     private static final int MAX_ATTACHMENT_SIZE_BYTES = 512 * 1_024; // 512 KB
-    private static final int DISCORD_MESSAGE_LIMIT = 2_000;
 
-    private static final Pattern HTML_TAG_PATTERN = Pattern.compile("</?[a-zA-Z][^>]*>");
-    private static final Pattern HORIZONTAL_RULE_PATTERN = Pattern.compile("^[-*_]{3,}\\s*$", Pattern.MULTILINE);
-    private static final Pattern DEEP_HEADING_PATTERN = Pattern.compile("^#{4,6}\\s+(.+)$", Pattern.MULTILINE);
-    private static final Pattern LATEX_BLOCK_PATTERN = Pattern.compile("\\$\\$\\s*\n(.*?)\n\\s*\\$\\$", Pattern.DOTALL);
-    private static final Pattern LATEX_INLINE_PATTERN = Pattern.compile("\\$([^$]+)\\$");
-    private static final Pattern LATEX_TEXT_PATTERN = Pattern.compile("\\\\text\\{([^{}]*)}");
-    private static final Pattern LATEX_TEXTBF_PATTERN = Pattern.compile("\\\\textbf\\{([^{}]*)}");
-    private static final Pattern LATEX_TEXTIT_PATTERN = Pattern.compile("\\\\textit\\{([^{}]*)}");
-    private static final Pattern LATEX_MATHRM_PATTERN = Pattern.compile("\\\\mathrm\\{([^{}]*)}");
-    private static final Pattern LATEX_MATHBF_PATTERN = Pattern.compile("\\\\mathbf\\{([^{}]*)}");
-    private static final Pattern LATEX_FRAC_PATTERN = Pattern.compile("\\\\frac\\{([^{}]*(?:\\{[^{}]*}[^{}]*)*)\\}\\{([^{}]*(?:\\{[^{}]*}[^{}]*)*)\\}");
-    private static final Pattern LATEX_REMAINING_BRACES = Pattern.compile("\\{([^{}]*)}");
-    private static final Pattern LATEX_UNKNOWN_COMMANDS = Pattern.compile("\\\\[a-zA-Z]+");
-    private static final Pattern BLANK_LINES_PATTERN = Pattern.compile("(?m)^\\s*$(\n\\s*$)+");
-    private static final Pattern PARAGRAPH_PATTERN = Pattern.compile("\n\n+");
-    private static final List<Pattern> HEADING_SPLIT_PATTERNS = List.of(
-        Pattern.compile("(?=^#{1,2}(?!#) )", Pattern.MULTILINE),
-        Pattern.compile("(?=^###(?!#) )", Pattern.MULTILINE),
-        Pattern.compile("(?=^####(?!#) )", Pattern.MULTILINE)
-    );
-    private static final Pattern TABLE_BLOCK_PATTERN = Pattern.compile("(?m)(^[ \\t]*\\|.+\\|[ \\t]*\n)(^[ \\t]*\\|[-|: ]+\\|[ \\t]*\n)((?:^[ \\t]*\\|.+\\|[ \\t]*\n?)+)");
+    private final MarkdownPostService markdownPostService = new MarkdownPostService();
 
     @SlashCommand(name = "post", subcommand = "markdown", description = "Post the contents of a markdown file into the current channel", guildOnly = true, defaultMemberPermissions = {"BAN_MEMBERS"}, requiredPermissions = {"BAN_MEMBERS"})
     public void postMarkdown(SlashCommandInteractionEvent event, @SlashOption(description = "The markdown file to post") Message.Attachment attachment) {
@@ -76,10 +51,7 @@ public class PostCommands {
             return;
         }
 
-        content = content.replace("\r\n", "\n").replace("\r", "\n");
-        content = convertToDiscordMarkdown(content);
-
-        List<String> sections = splitIntoSections(content);
+        List<String> sections = markdownPostService.render(content);
 
         if (sections.isEmpty()) {
             event.getHook().editOriginal("No content found after processing the file.").queue();
@@ -99,295 +71,5 @@ public class PostCommands {
                 event.getHook().editOriginal("An error occurred while posting the markdown content.").queue();
                 return null;
             });
-    }
-
-    private String convertToDiscordMarkdown(String markdown) {
-        String result = HTML_TAG_PATTERN.matcher(markdown).replaceAll("");
-        result = HORIZONTAL_RULE_PATTERN.matcher(result).replaceAll("");
-        result = DEEP_HEADING_PATTERN.matcher(result).replaceAll("**$1**");
-        result = convertLatex(result, LATEX_BLOCK_PATTERN);
-        result = convertLatex(result, LATEX_INLINE_PATTERN);
-        result = convertTables(result);
-        result = BLANK_LINES_PATTERN.matcher(result).replaceAll("\n");
-        return result;
-    }
-
-    private String convertLatex(String content, Pattern pattern) {
-        Matcher matcher = pattern.matcher(content);
-        StringBuilder sb = new StringBuilder();
-        while (matcher.find()) {
-            String latex = matcher.group(1).strip();
-            String converted = convertLatexExpression(latex);
-            matcher.appendReplacement(sb, Matcher.quoteReplacement(converted));
-        }
-        matcher.appendTail(sb);
-        return sb.toString();
-    }
-
-    private String convertLatexExpression(String latex) {
-        String result = latex;
-
-        // Handle structural commands the library doesn't support
-        result = LATEX_TEXT_PATTERN.matcher(result).replaceAll("$1");
-        result = LATEX_TEXTBF_PATTERN.matcher(result).replaceAll("$1");
-        result = LATEX_TEXTIT_PATTERN.matcher(result).replaceAll("$1");
-        result = LATEX_MATHRM_PATTERN.matcher(result).replaceAll("$1");
-        result = LATEX_MATHBF_PATTERN.matcher(result).replaceAll("$1");
-
-        // Handle \frac{a}{b} -> (a)/(b) since the library uses Unicode fractions that only work for single digits
-        for (int i = 0; i < 10; i++) {
-            String replaced = LATEX_FRAC_PATTERN.matcher(result).replaceAll("($1)/($2)");
-            if (replaced.equals(result)) break;
-            result = replaced;
-        }
-
-        // Let the library handle symbol conversion (Greek letters, operators, etc.)
-        try {
-            result = LaTeX2Unicode.convert(result);
-        } catch (Exception e) {
-            log.warn("Failed to convert LaTeX '{}', keeping original", latex, e);
-        }
-
-        // Clean up remaining braces and unknown commands the library didn't handle
-        result = LATEX_REMAINING_BRACES.matcher(result).replaceAll("$1");
-        result = LATEX_UNKNOWN_COMMANDS.matcher(result).replaceAll("");
-        result = result.replaceAll(" {2,}", " ");
-
-        return result.strip();
-    }
-
-    private String joinWrappedTableLines(String content) {
-        String[] lines = content.split("\n");
-        StringBuilder result = new StringBuilder();
-        StringBuilder pendingLine = null;
-
-        for (String line : lines) {
-            String trimmed = line.strip();
-            boolean startsWithPipe = trimmed.startsWith("|");
-            boolean endsWithPipe = trimmed.endsWith("|");
-
-            if (startsWithPipe && endsWithPipe) {
-                if (pendingLine != null) {
-                    result.append(pendingLine).append('\n');
-                    pendingLine = null;
-                }
-                result.append(line).append('\n');
-            } else if (startsWithPipe && !endsWithPipe) {
-                if (pendingLine != null) {
-                    result.append(pendingLine).append('\n');
-                }
-                pendingLine = new StringBuilder(trimmed);
-            } else if (!startsWithPipe && pendingLine != null) {
-                pendingLine.append(' ').append(trimmed);
-                if (endsWithPipe) {
-                    result.append(pendingLine).append('\n');
-                    pendingLine = null;
-                }
-            } else {
-                if (pendingLine != null) {
-                    result.append(pendingLine).append('\n');
-                    pendingLine = null;
-                }
-                result.append(line).append('\n');
-            }
-        }
-
-        if (pendingLine != null) {
-            result.append(pendingLine).append('\n');
-        }
-
-        return result.toString();
-    }
-
-    private String convertTables(String content) {
-        content = joinWrappedTableLines(content);
-        Matcher matcher = TABLE_BLOCK_PATTERN.matcher(content);
-        StringBuilder sb = new StringBuilder();
-        while (matcher.find()) {
-            String headerLine = matcher.group(1).strip();
-            String dataBlock = matcher.group(3).strip();
-
-            List<String[]> rows = new ArrayList<>();
-            rows.add(parseTableRow(headerLine));
-            for (String line : dataBlock.split("\n")) {
-                String trimmed = line.strip();
-                if (!trimmed.isEmpty()) {
-                    rows.add(parseTableRow(trimmed));
-                }
-            }
-
-            int colCount = rows.stream().mapToInt(r -> r.length).max().orElse(0);
-            if (colCount == 0) {
-                continue;
-            }
-
-            int[] widths = new int[colCount];
-            for (String[] row : rows) {
-                for (int i = 0; i < row.length && i < colCount; i++) {
-                    widths[i] = Math.max(widths[i], row[i].length());
-                }
-            }
-
-            StringBuilder table = new StringBuilder("\n```\n");
-
-            table.append(buildBorder(widths, '-'));
-            table.append(buildRow(rows.getFirst(), widths));
-            table.append(buildBorder(widths, '='));
-
-            for (int i = 1; i < rows.size(); i++) {
-                table.append(buildRow(rows.get(i), widths));
-                if (i < rows.size() - 1) {
-                    table.append(buildBorder(widths, '-'));
-                }
-            }
-
-            table.append(buildBorder(widths, '-'));
-            table.append("```\n");
-
-            matcher.appendReplacement(sb, Matcher.quoteReplacement(table.toString()));
-        }
-        matcher.appendTail(sb);
-        return sb.toString();
-    }
-
-    private String[] parseTableRow(String line) {
-        String stripped = line.strip();
-        if (stripped.startsWith("|")) {
-            stripped = stripped.substring(1);
-        }
-        if (stripped.endsWith("|")) {
-            stripped = stripped.substring(0, stripped.length() - 1);
-        }
-        return Arrays.stream(stripped.split("\\|"))
-            .map(String::strip)
-            .toArray(String[]::new);
-    }
-
-    private String buildBorder(int[] widths, char fill) {
-        StringBuilder sb = new StringBuilder();
-        sb.append('+');
-        for (int width : widths) {
-            sb.append(String.valueOf(fill).repeat(width + 2));
-            sb.append('+');
-        }
-        sb.append('\n');
-        return sb.toString();
-    }
-
-    private String buildRow(String[] cells, int[] widths) {
-        StringBuilder sb = new StringBuilder();
-        sb.append('|');
-        for (int i = 0; i < widths.length; i++) {
-            String cell = i < cells.length ? cells[i] : "";
-            sb.append(' ');
-            sb.append(cell);
-            sb.append(" ".repeat(widths[i] - cell.length()));
-            sb.append(" |");
-        }
-        sb.append('\n');
-        return sb.toString();
-    }
-
-    private List<String> splitIntoSections(String content) {
-        return splitRecursive(content, 0);
-    }
-
-    private List<String> splitRecursive(String content, int depth) {
-        if (content.length() <= DISCORD_MESSAGE_LIMIT) {
-            return List.of(content);
-        }
-        if (depth >= HEADING_SPLIT_PATTERNS.size()) {
-            return splitByParagraphs(content);
-        }
-
-        List<String> result = new ArrayList<>();
-        for (String section : splitByPattern(content, HEADING_SPLIT_PATTERNS.get(depth))) {
-            result.addAll(splitRecursive(section, depth + 1));
-        }
-        return result;
-    }
-
-    private List<String> splitByPattern(String content, Pattern pattern) {
-        String[] parts = pattern.split(content);
-        List<String> sections = new ArrayList<>();
-        for (String part : parts) {
-            String trimmed = part.strip();
-            if (!trimmed.isEmpty()) {
-                sections.add(trimmed);
-            }
-        }
-        return sections;
-    }
-
-    private List<String> splitByParagraphs(String content) {
-        String[] paragraphs = PARAGRAPH_PATTERN.split(content);
-        List<String> result = new ArrayList<>();
-        StringBuilder current = new StringBuilder();
-
-        for (String paragraph : paragraphs) {
-            String trimmed = paragraph.strip();
-            if (trimmed.isEmpty()) {
-                continue;
-            }
-
-            if (current.isEmpty()) {
-                current.append(trimmed);
-            } else if (current.length() + 2 + trimmed.length() <= DISCORD_MESSAGE_LIMIT) {
-                current.append("\n\n").append(trimmed);
-            } else {
-                result.add(current.toString());
-                current = new StringBuilder(trimmed);
-            }
-        }
-
-        if (!current.isEmpty()) {
-            result.add(current.toString());
-        }
-
-        List<String> safe = new ArrayList<>();
-        for (String chunk : result) {
-            if (chunk.length() <= DISCORD_MESSAGE_LIMIT) {
-                safe.add(chunk);
-            } else {
-                safe.addAll(splitByLines(chunk));
-            }
-        }
-
-        return safe;
-    }
-
-    private List<String> splitByLines(String content) {
-        String[] lines = content.split("\n");
-        List<String> result = new ArrayList<>();
-        StringBuilder current = new StringBuilder();
-
-        for (String line : lines) {
-            // Single line exceeds limit, hard truncate to avoid runtime failure
-            if (line.length() > DISCORD_MESSAGE_LIMIT) {
-                if (!current.isEmpty()) {
-                    result.add(current.toString());
-                    current = new StringBuilder();
-                }
-                for (int i = 0; i < line.length(); i += DISCORD_MESSAGE_LIMIT) {
-                    result.add(line.substring(i, Math.min(i + DISCORD_MESSAGE_LIMIT, line.length())));
-                }
-                continue;
-            }
-
-            if (current.isEmpty()) {
-                current.append(line);
-            } else if (current.length() + 1 + line.length() <= DISCORD_MESSAGE_LIMIT) {
-                current.append("\n").append(line);
-            } else {
-                result.add(current.toString());
-                current = new StringBuilder(line);
-            }
-        }
-
-        if (!current.isEmpty()) {
-            result.add(current.toString());
-        }
-
-        return result;
     }
 }

--- a/app/src/main/java/net/hypixel/nerdbot/app/post/MarkdownPostService.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/post/MarkdownPostService.java
@@ -1,0 +1,351 @@
+package net.hypixel.nerdbot.app.post;
+
+import com.github.tomtung.latex2unicode.LaTeX2Unicode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Converts an arbitrary Markdown document into a list of Discord-ready message chunks.
+ *
+ * <p>All logic here is pure - it has no Discord, database, config or network collaborators - so it
+ * is unit-testable in isolation. {@code PostCommands} is the thin adapter that downloads the file,
+ * calls {@link #render(String)}, and sends the resulting chunks.
+ *
+ * <p>Processing covers: stripping HTML tags and horizontal rules, folding deep headings to bold,
+ * converting LaTeX expressions to Unicode, rendering Markdown tables as fixed-width code blocks, and
+ * splitting the result into sections that each fit within Discord's message-length limit.
+ */
+@Slf4j
+public class MarkdownPostService {
+
+    private static final int DISCORD_MESSAGE_LIMIT = 2_000;
+
+    private static final Pattern HTML_TAG_PATTERN = Pattern.compile("</?[a-zA-Z][^>]*>");
+    private static final Pattern HORIZONTAL_RULE_PATTERN = Pattern.compile("^[-*_]{3,}\\s*$", Pattern.MULTILINE);
+    private static final Pattern DEEP_HEADING_PATTERN = Pattern.compile("^#{4,6}\\s+(.+)$", Pattern.MULTILINE);
+    private static final Pattern LATEX_BLOCK_PATTERN = Pattern.compile("\\$\\$\\s*\n(.*?)\n\\s*\\$\\$", Pattern.DOTALL);
+    private static final Pattern LATEX_INLINE_PATTERN = Pattern.compile("\\$([^$]+)\\$");
+    private static final Pattern LATEX_TEXT_PATTERN = Pattern.compile("\\\\text\\{([^{}]*)}");
+    private static final Pattern LATEX_TEXTBF_PATTERN = Pattern.compile("\\\\textbf\\{([^{}]*)}");
+    private static final Pattern LATEX_TEXTIT_PATTERN = Pattern.compile("\\\\textit\\{([^{}]*)}");
+    private static final Pattern LATEX_MATHRM_PATTERN = Pattern.compile("\\\\mathrm\\{([^{}]*)}");
+    private static final Pattern LATEX_MATHBF_PATTERN = Pattern.compile("\\\\mathbf\\{([^{}]*)}");
+    private static final Pattern LATEX_FRAC_PATTERN = Pattern.compile("\\\\frac\\{([^{}]*(?:\\{[^{}]*}[^{}]*)*)\\}\\{([^{}]*(?:\\{[^{}]*}[^{}]*)*)\\}");
+    private static final Pattern LATEX_REMAINING_BRACES = Pattern.compile("\\{([^{}]*)}");
+    private static final Pattern LATEX_UNKNOWN_COMMANDS = Pattern.compile("\\\\[a-zA-Z]+");
+    private static final Pattern BLANK_LINES_PATTERN = Pattern.compile("(?m)^\\s*$(\n\\s*$)+");
+    private static final Pattern PARAGRAPH_PATTERN = Pattern.compile("\n\n+");
+    private static final List<Pattern> HEADING_SPLIT_PATTERNS = List.of(
+        Pattern.compile("(?=^#{1,2}(?!#) )", Pattern.MULTILINE),
+        Pattern.compile("(?=^###(?!#) )", Pattern.MULTILINE),
+        Pattern.compile("(?=^####(?!#) )", Pattern.MULTILINE)
+    );
+    private static final Pattern TABLE_BLOCK_PATTERN = Pattern.compile("(?m)(^[ \\t]*\\|.+\\|[ \\t]*\n)(^[ \\t]*\\|[-|: ]+\\|[ \\t]*\n)((?:^[ \\t]*\\|.+\\|[ \\t]*\n?)+)");
+
+    /**
+     * Render a Markdown document into Discord-ready message chunks.
+     *
+     * @param markdown the raw Markdown source
+     * @return the processed content split into sections, each at or below Discord's message limit
+     */
+    public List<String> render(String markdown) {
+        String content = markdown.replace("\r\n", "\n").replace("\r", "\n");
+        content = convertToDiscordMarkdown(content);
+        return splitIntoSections(content);
+    }
+
+    private String convertToDiscordMarkdown(String markdown) {
+        String result = HTML_TAG_PATTERN.matcher(markdown).replaceAll("");
+        result = HORIZONTAL_RULE_PATTERN.matcher(result).replaceAll("");
+        result = DEEP_HEADING_PATTERN.matcher(result).replaceAll("**$1**");
+        result = convertLatex(result, LATEX_BLOCK_PATTERN);
+        result = convertLatex(result, LATEX_INLINE_PATTERN);
+        result = convertTables(result);
+        result = BLANK_LINES_PATTERN.matcher(result).replaceAll("\n");
+        return result;
+    }
+
+    private String convertLatex(String content, Pattern pattern) {
+        Matcher matcher = pattern.matcher(content);
+        StringBuilder sb = new StringBuilder();
+        while (matcher.find()) {
+            String latex = matcher.group(1).strip();
+            String converted = convertLatexExpression(latex);
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(converted));
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    private String convertLatexExpression(String latex) {
+        String result = latex;
+
+        // Handle structural commands the library doesn't support
+        result = LATEX_TEXT_PATTERN.matcher(result).replaceAll("$1");
+        result = LATEX_TEXTBF_PATTERN.matcher(result).replaceAll("$1");
+        result = LATEX_TEXTIT_PATTERN.matcher(result).replaceAll("$1");
+        result = LATEX_MATHRM_PATTERN.matcher(result).replaceAll("$1");
+        result = LATEX_MATHBF_PATTERN.matcher(result).replaceAll("$1");
+
+        // Handle \frac{a}{b} -> (a)/(b) since the library uses Unicode fractions that only work for single digits
+        for (int i = 0; i < 10; i++) {
+            String replaced = LATEX_FRAC_PATTERN.matcher(result).replaceAll("($1)/($2)");
+            if (replaced.equals(result)) break;
+            result = replaced;
+        }
+
+        // Let the library handle symbol conversion (Greek letters, operators, etc.)
+        try {
+            result = LaTeX2Unicode.convert(result);
+        } catch (Exception e) {
+            log.warn("Failed to convert LaTeX '{}', keeping original", latex, e);
+        }
+
+        // Clean up remaining braces and unknown commands the library didn't handle
+        result = LATEX_REMAINING_BRACES.matcher(result).replaceAll("$1");
+        result = LATEX_UNKNOWN_COMMANDS.matcher(result).replaceAll("");
+        result = result.replaceAll(" {2,}", " ");
+
+        return result.strip();
+    }
+
+    private String joinWrappedTableLines(String content) {
+        String[] lines = content.split("\n");
+        StringBuilder result = new StringBuilder();
+        StringBuilder pendingLine = null;
+
+        for (String line : lines) {
+            String trimmed = line.strip();
+            boolean startsWithPipe = trimmed.startsWith("|");
+            boolean endsWithPipe = trimmed.endsWith("|");
+
+            if (startsWithPipe && endsWithPipe) {
+                if (pendingLine != null) {
+                    result.append(pendingLine).append('\n');
+                    pendingLine = null;
+                }
+                result.append(line).append('\n');
+            } else if (startsWithPipe && !endsWithPipe) {
+                if (pendingLine != null) {
+                    result.append(pendingLine).append('\n');
+                }
+                pendingLine = new StringBuilder(trimmed);
+            } else if (!startsWithPipe && pendingLine != null) {
+                pendingLine.append(' ').append(trimmed);
+                if (endsWithPipe) {
+                    result.append(pendingLine).append('\n');
+                    pendingLine = null;
+                }
+            } else {
+                if (pendingLine != null) {
+                    result.append(pendingLine).append('\n');
+                    pendingLine = null;
+                }
+                result.append(line).append('\n');
+            }
+        }
+
+        if (pendingLine != null) {
+            result.append(pendingLine).append('\n');
+        }
+
+        return result.toString();
+    }
+
+    private String convertTables(String content) {
+        content = joinWrappedTableLines(content);
+        Matcher matcher = TABLE_BLOCK_PATTERN.matcher(content);
+        StringBuilder sb = new StringBuilder();
+        while (matcher.find()) {
+            String headerLine = matcher.group(1).strip();
+            String dataBlock = matcher.group(3).strip();
+
+            List<String[]> rows = new ArrayList<>();
+            rows.add(parseTableRow(headerLine));
+            for (String line : dataBlock.split("\n")) {
+                String trimmed = line.strip();
+                if (!trimmed.isEmpty()) {
+                    rows.add(parseTableRow(trimmed));
+                }
+            }
+
+            int colCount = rows.stream().mapToInt(r -> r.length).max().orElse(0);
+            if (colCount == 0) {
+                continue;
+            }
+
+            int[] widths = new int[colCount];
+            for (String[] row : rows) {
+                for (int i = 0; i < row.length && i < colCount; i++) {
+                    widths[i] = Math.max(widths[i], row[i].length());
+                }
+            }
+
+            StringBuilder table = new StringBuilder("\n```\n");
+
+            table.append(buildBorder(widths, '-'));
+            table.append(buildRow(rows.getFirst(), widths));
+            table.append(buildBorder(widths, '='));
+
+            for (int i = 1; i < rows.size(); i++) {
+                table.append(buildRow(rows.get(i), widths));
+                if (i < rows.size() - 1) {
+                    table.append(buildBorder(widths, '-'));
+                }
+            }
+
+            table.append(buildBorder(widths, '-'));
+            table.append("```\n");
+
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(table.toString()));
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    private String[] parseTableRow(String line) {
+        String stripped = line.strip();
+        if (stripped.startsWith("|")) {
+            stripped = stripped.substring(1);
+        }
+        if (stripped.endsWith("|")) {
+            stripped = stripped.substring(0, stripped.length() - 1);
+        }
+        return Arrays.stream(stripped.split("\\|"))
+            .map(String::strip)
+            .toArray(String[]::new);
+    }
+
+    private String buildBorder(int[] widths, char fill) {
+        StringBuilder sb = new StringBuilder();
+        sb.append('+');
+        for (int width : widths) {
+            sb.append(String.valueOf(fill).repeat(width + 2));
+            sb.append('+');
+        }
+        sb.append('\n');
+        return sb.toString();
+    }
+
+    private String buildRow(String[] cells, int[] widths) {
+        StringBuilder sb = new StringBuilder();
+        sb.append('|');
+        for (int i = 0; i < widths.length; i++) {
+            String cell = i < cells.length ? cells[i] : "";
+            sb.append(' ');
+            sb.append(cell);
+            sb.append(" ".repeat(widths[i] - cell.length()));
+            sb.append(" |");
+        }
+        sb.append('\n');
+        return sb.toString();
+    }
+
+    private List<String> splitIntoSections(String content) {
+        return splitRecursive(content, 0);
+    }
+
+    private List<String> splitRecursive(String content, int depth) {
+        if (content.length() <= DISCORD_MESSAGE_LIMIT) {
+            return List.of(content);
+        }
+        if (depth >= HEADING_SPLIT_PATTERNS.size()) {
+            return splitByParagraphs(content);
+        }
+
+        List<String> result = new ArrayList<>();
+        for (String section : splitByPattern(content, HEADING_SPLIT_PATTERNS.get(depth))) {
+            result.addAll(splitRecursive(section, depth + 1));
+        }
+        return result;
+    }
+
+    private List<String> splitByPattern(String content, Pattern pattern) {
+        String[] parts = pattern.split(content);
+        List<String> sections = new ArrayList<>();
+        for (String part : parts) {
+            String trimmed = part.strip();
+            if (!trimmed.isEmpty()) {
+                sections.add(trimmed);
+            }
+        }
+        return sections;
+    }
+
+    private List<String> splitByParagraphs(String content) {
+        String[] paragraphs = PARAGRAPH_PATTERN.split(content);
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+
+        for (String paragraph : paragraphs) {
+            String trimmed = paragraph.strip();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+
+            if (current.isEmpty()) {
+                current.append(trimmed);
+            } else if (current.length() + 2 + trimmed.length() <= DISCORD_MESSAGE_LIMIT) {
+                current.append("\n\n").append(trimmed);
+            } else {
+                result.add(current.toString());
+                current = new StringBuilder(trimmed);
+            }
+        }
+
+        if (!current.isEmpty()) {
+            result.add(current.toString());
+        }
+
+        List<String> safe = new ArrayList<>();
+        for (String chunk : result) {
+            if (chunk.length() <= DISCORD_MESSAGE_LIMIT) {
+                safe.add(chunk);
+            } else {
+                safe.addAll(splitByLines(chunk));
+            }
+        }
+
+        return safe;
+    }
+
+    private List<String> splitByLines(String content) {
+        String[] lines = content.split("\n");
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+
+        for (String line : lines) {
+            // Single line exceeds limit, hard truncate to avoid runtime failure
+            if (line.length() > DISCORD_MESSAGE_LIMIT) {
+                if (!current.isEmpty()) {
+                    result.add(current.toString());
+                    current = new StringBuilder();
+                }
+                for (int i = 0; i < line.length(); i += DISCORD_MESSAGE_LIMIT) {
+                    result.add(line.substring(i, Math.min(i + DISCORD_MESSAGE_LIMIT, line.length())));
+                }
+                continue;
+            }
+
+            if (current.isEmpty()) {
+                current.append(line);
+            } else if (current.length() + 1 + line.length() <= DISCORD_MESSAGE_LIMIT) {
+                current.append("\n").append(line);
+            } else {
+                result.add(current.toString());
+                current = new StringBuilder(line);
+            }
+        }
+
+        if (!current.isEmpty()) {
+            result.add(current.toString());
+        }
+
+        return result;
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/post/MarkdownPostServiceTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/post/MarkdownPostServiceTest.java
@@ -1,0 +1,79 @@
+package net.hypixel.nerdbot.app.post;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link MarkdownPostService#render}, the pure Markdown -> Discord-chunk conversion.
+ */
+class MarkdownPostServiceTest {
+
+    private static final int DISCORD_MESSAGE_LIMIT = 2_000;
+
+    private final MarkdownPostService service = new MarkdownPostService();
+
+    @Test
+    void stripsHtmlTags() {
+        List<String> sections = service.render("<b>bold</b> and <i>italic</i> text");
+
+        assertEquals(1, sections.size());
+        assertEquals("bold and italic text", sections.getFirst().strip());
+    }
+
+    @Test
+    void foldsDeepHeadingsToBold() {
+        assertEquals("**My Heading**", service.render("#### My Heading").getFirst().strip());
+    }
+
+    @Test
+    void removesHorizontalRules() {
+        String section = service.render("before\n\n---\n\nafter").getFirst();
+
+        assertFalse(section.contains("---"), "the horizontal rule should be removed");
+        assertTrue(section.contains("before") && section.contains("after"), "surrounding content should remain");
+    }
+
+    @Test
+    void rendersMarkdownTableAsFixedWidthCodeBlock() {
+        String section = service.render("| Name | Age |\n|------|-----|\n| Bob | 30 |\n").getFirst();
+
+        assertTrue(section.contains("```"), "table should be wrapped in a code block");
+        assertTrue(section.contains("+"), "table should have a fixed-width border");
+        assertTrue(section.contains("Name") && section.contains("Bob") && section.contains("30"),
+            "table cell values should survive");
+    }
+
+    @Test
+    void keepsShortContentAsASingleSection() {
+        List<String> sections = service.render("short text");
+
+        assertEquals(1, sections.size());
+        assertEquals("short text", sections.getFirst().strip());
+    }
+
+    @Test
+    void splitsOversizedContentIntoLimitCompliantSections() {
+        String paragraph = "x".repeat(800);
+        String markdown = paragraph + "\n\n" + paragraph + "\n\n" + paragraph; // ~2400 chars, three paragraphs
+
+        List<String> sections = service.render(markdown);
+
+        assertTrue(sections.size() > 1, "oversized content should be split");
+        assertTrue(sections.stream().allMatch(section -> section.length() <= DISCORD_MESSAGE_LIMIT),
+            "every section must fit within Discord's message limit");
+    }
+
+    @Test
+    void hardSplitsASingleOverlongLine() {
+        List<String> sections = service.render("y".repeat(2_500));
+
+        assertTrue(sections.size() > 1, "a single overlong line must be hard-split");
+        assertTrue(sections.stream().allMatch(section -> section.length() <= DISCORD_MESSAGE_LIMIT),
+            "every chunk must fit within Discord's message limit");
+    }
+}


### PR DESCRIPTION
## What

First service extraction from the catalogue - the highest-ROI one - turning `PostCommands` into a thin adapter over a new pure `MarkdownPostService`.

- `MarkdownPostService.render(String): List<String>` owns all of `/post markdown`'s conversion logic (~290 lines): HTML/horizontal-rule stripping, deep-heading folding, LaTeX-to-Unicode, Markdown table -> fixed-width code block, and recursive length-aware splitting into Discord-limit-compliant sections.
- It has **no collaborators** - no Discord, database, config, or network - so it is the closest match to the `ResourcePackService` ideal in the codebase.
- `PostCommands` now just downloads the attachment, calls `render`, and sends the sections. Behaviour is unchanged.

## Why

This intricate, bug-prone logic (regex table rendering, recursive splitting, the 2000-char boundary) was completely untestable while inlined in the command. Extracting it makes it exercisable with fixtures.

## Tests

`mvn -pl app -am test` -> 117 passing (7 new).

Pins: HTML stripped, deep headings folded to bold, horizontal rules removed, tables rendered as fixed-width code blocks, short content kept as one section, and oversized content (including a single overlong line) split so every section fits the message limit.
