### PR TITLE
refactor(reminder): extract a testable duration parser

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/ReminderCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/ReminderCommands.java
@@ -59,15 +59,19 @@ public class ReminderCommands {
         .withZone(ZoneId.of("UTC"));
 
     /**
-     * Parse a time string in the format of {@code 1w2d3h4m5s} into a Date
+     * Parse a {@code 1w2d3h4m5s}-style duration string into a {@link Duration}.
      *
-     * @param time The time string to parse
+     * <p>Every unit is optional and an empty string yields {@link Duration#ZERO}; weeks are expanded
+     * to seven days. Extracted from {@link #parseCustomFormat} so the deterministic parsing can be
+     * unit-tested without depending on the current time.
      *
-     * @return The parsed string as a Date
+     * @param time The duration string, e.g. {@code 1w2d3h4m5s}
      *
-     * @throws DateTimeParseException If the string could not be parsed
+     * @return The parsed {@link Duration}
+     *
+     * @throws DateTimeParseException If the string does not match the expected format
      */
-    public static Date parseCustomFormat(String time) throws DateTimeParseException {
+    static Duration parseDuration(String time) throws DateTimeParseException {
         Matcher matcher = DURATION.matcher(time);
 
         if (!matcher.matches()) {
@@ -95,8 +99,20 @@ public class ReminderCommands {
             duration = duration.plusSeconds(Long.parseLong(matcher.group(10)));
         }
 
-        Instant date = Instant.now().plus(duration);
-        return Date.from(date);
+        return duration;
+    }
+
+    /**
+     * Parse a time string in the format of {@code 1w2d3h4m5s} into a Date
+     *
+     * @param time The time string to parse
+     *
+     * @return The parsed string as a Date
+     *
+     * @throws DateTimeParseException If the string could not be parsed
+     */
+    public static Date parseCustomFormat(String time) throws DateTimeParseException {
+        return Date.from(Instant.now().plus(parseDuration(time)));
     }
 
     private Date parseLong(String time) throws NumberFormatException {

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/ReminderCommandsTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/ReminderCommandsTest.java
@@ -1,0 +1,44 @@
+package net.hypixel.nerdbot.app.command;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for {@link ReminderCommands#parseDuration}, the {@code 1w2d3h4m5s} duration parser.
+ */
+class ReminderCommandsTest {
+
+    @Test
+    void expandsWeeksToSevenDays() {
+        assertEquals(Duration.ofDays(7), ReminderCommands.parseDuration("1w"));
+    }
+
+    @Test
+    void parsesEachUnit() {
+        assertEquals(Duration.ofDays(2), ReminderCommands.parseDuration("2d"));
+        assertEquals(Duration.ofHours(3), ReminderCommands.parseDuration("3h"));
+        assertEquals(Duration.ofMinutes(4), ReminderCommands.parseDuration("4m"));
+        assertEquals(Duration.ofSeconds(5), ReminderCommands.parseDuration("5s"));
+    }
+
+    @Test
+    void accumulatesMultipleUnits() {
+        Duration expected = Duration.ofDays(9).plusHours(3).plusMinutes(4).plusSeconds(5); // 1w + 2d
+        assertEquals(expected, ReminderCommands.parseDuration("1w2d3h4m5s"));
+    }
+
+    @Test
+    void emptyStringYieldsZero() {
+        assertEquals(Duration.ZERO, ReminderCommands.parseDuration(""));
+    }
+
+    @Test
+    void rejectsMalformedInput() {
+        assertThrows(DateTimeParseException.class, () -> ReminderCommands.parseDuration("abc"));
+    }
+}


### PR DESCRIPTION
## What

Catalogue item #3 (the pure, high-value part): make the reminder duration parser testable.

- `parseCustomFormat` parsed a `1w2d3h4m5s` string and returned `Instant.now()` plus that duration, so its parsing couldn't be unit-tested without depending on the wall clock.
- Split out `parseDuration(String): Duration` (pure, deterministic). `parseCustomFormat` now just adds it to `Instant.now()`. Behaviour is unchanged.

## Why

The parser has real edge cases - weeks expand to seven days, units accumulate, an empty string is a valid zero duration, malformed input throws - that a wrong implementation could easily get wrong (and would produce reminders at the wrong time). Now they're pinned.

## Tests

`mvn -pl app -am test` -> 122 passing (5 new).
