### PR TITLE
refactor(curator): extract the testable greenlit-threshold decision

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/curator/Curator.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/curator/Curator.java
@@ -29,5 +29,20 @@ public abstract class Curator<T, O> {
         return positiveReactions / (positiveReactions + negativeReactions) * 100;
     }
 
+    /**
+     * Whether a suggestion's votes qualify it to be greenlit: it needs at least {@code agreeThreshold}
+     * agree reactions <em>and</em> an agree/disagree {@link #getRatio(double, double) ratio} of at
+     * least {@code ratioThreshold} percent.
+     *
+     * @param agree          the number of agree reactions
+     * @param disagree       the number of disagree reactions
+     * @param agreeThreshold the minimum agree reactions required
+     * @param ratioThreshold the minimum agree/disagree ratio required, as a percentage
+     * @return {@code true} if the suggestion meets both thresholds
+     */
+    public static boolean meetsGreenlitThreshold(int agree, int disagree, int agreeThreshold, double ratioThreshold) {
+        return agree >= agreeThreshold && getRatio(agree, disagree) >= ratioThreshold;
+    }
+
     public abstract List<GreenlitMessage> curate(T t);
 }

--- a/app/src/main/java/net/hypixel/nerdbot/app/curator/ForumChannelCurator.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/curator/ForumChannelCurator.java
@@ -190,7 +190,7 @@ public class ForumChannelCurator extends Curator<ForumChannel, ThreadChannel> {
                     double ratio = getRatio(agree, disagree);
                     log.info("Thread '{}' (ID: {}) has {} agree reactions, {} neutral reactions, and {} disagree reactions with a ratio of {}%", thread.getName(), thread.getId(), agree, neutral, disagree, ratio);
 
-                    if ((agree < suggestionConfig.getGreenlitThreshold()) || (ratio < suggestionConfig.getGreenlitRatio())) {
+                    if (!meetsGreenlitThreshold(agree, disagree, suggestionConfig.getGreenlitThreshold(), suggestionConfig.getGreenlitRatio())) {
                         log.info("Thread '{}' (ID: {}) does not meet the minimum threshold of {} agree reactions to be greenlit!", thread.getName(), thread.getId(), suggestionConfig.getGreenlitThreshold());
                         continue;
                     }

--- a/app/src/test/java/net/hypixel/nerdbot/app/curator/CuratorTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/curator/CuratorTest.java
@@ -1,0 +1,48 @@
+package net.hypixel.nerdbot.app.curator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the pure greenlit math on {@link Curator}: {@link Curator#getRatio} and
+ * {@link Curator#meetsGreenlitThreshold}.
+ */
+class CuratorTest {
+
+    @Test
+    void ratioIsZeroWhenThereAreNoReactions() {
+        assertEquals(0.0, Curator.getRatio(0, 0), 0.0001);
+    }
+
+    @Test
+    void ratioIsAgreeShareAsPercentage() {
+        assertEquals(75.0, Curator.getRatio(3, 1), 0.0001);
+    }
+
+    @Test
+    void meetsThresholdWhenBothAgreeCountAndRatioQualify() {
+        // 10 agree / 2 disagree -> 83.3% ratio, threshold 5 agree and 50%.
+        assertTrue(Curator.meetsGreenlitThreshold(10, 2, 5, 50.0));
+    }
+
+    @Test
+    void failsWhenAgreeCountIsBelowThreshold() {
+        // High ratio (100%) but only 3 agree against a threshold of 5.
+        assertFalse(Curator.meetsGreenlitThreshold(3, 0, 5, 50.0));
+    }
+
+    @Test
+    void failsWhenRatioIsBelowThreshold() {
+        // Plenty of agree reactions but 10/30 = 33% ratio against a 50% threshold.
+        assertFalse(Curator.meetsGreenlitThreshold(10, 20, 5, 50.0));
+    }
+
+    @Test
+    void zeroReactionsNeverGreenlight() {
+        // getRatio(0, 0) is 0, so even a zero agree threshold fails the ratio requirement.
+        assertFalse(Curator.meetsGreenlitThreshold(0, 0, 0, 50.0));
+    }
+}


### PR DESCRIPTION
## What

Small catalogue follow-up (the pure `GreenlitEvaluator` the survey flagged): make the auto-greenlit decision testable.

- A suggestion is auto-greenlit when it has at least the configured agree count **and** an agree/disagree ratio above the configured minimum. That decision was inlined in `ForumChannelCurator`'s curation loop.
- Extracted `Curator.meetsGreenlitThreshold(agree, disagree, agreeThreshold, ratioThreshold)`, sitting next to the existing `getRatio`. The curator calls it. Behaviour is unchanged.

## Why

The greenlit gate decides which suggestions get auto-greenlit - real stakes - and the compound condition plus `getRatio`'s zero-reactions edge case is exactly where a wrong implementation could hide.

## Tests

`mvn -pl app -am test` -> 128 passing (6 new): `getRatio` (zero reactions -> 0, otherwise the agree share) and `meetsGreenlitThreshold` (needs both thresholds; zero reactions never greenlight).
