### PR TITLE
refactor(suggestion): extract testable tag-filter parsing

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/util/SuggestionCommandUtils.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/util/SuggestionCommandUtils.java
@@ -30,19 +30,43 @@ import java.util.stream.Collectors;
 @UtilityClass
 public class SuggestionCommandUtils {
 
-    public static List<Suggestion> getSuggestions(Member member, @Nullable Long userId, String tags, String title, Suggestion.ChannelType channelType) {
-        final List<String> allTags = (tags == null || tags.trim().isEmpty())
+    /**
+     * The include and exclude tag names parsed from a suggestion tag filter string.
+     *
+     * @param include tags a suggestion must all have
+     * @param exclude tags a suggestion must not have
+     */
+    public record TagFilters(List<String> include, List<String> exclude) {
+    }
+
+    /**
+     * Split a comma-separated tag filter string into include and exclude lists. Tags prefixed with
+     * {@code !} are exclusions (with the {@code !} stripped); the rest are inclusions. A null or
+     * blank string yields two empty lists.
+     *
+     * @param tags the raw tag filter string, e.g. {@code "bug, !wontfix"}
+     * @return the parsed include/exclude tag lists
+     */
+    static TagFilters parseTagFilters(String tags) {
+        List<String> allTags = (tags == null || tags.trim().isEmpty())
             ? Collections.emptyList()
             : Arrays.asList(tags.split(", ?"));
 
-        // Separate tags into include (positive) and exclude (negated with !) lists
-        final List<String> includeTags = allTags.stream()
+        List<String> include = allTags.stream()
             .filter(tag -> !tag.startsWith("!"))
             .toList();
-        final List<String> excludeTags = allTags.stream()
+        List<String> exclude = allTags.stream()
             .filter(tag -> tag.startsWith("!"))
             .map(tag -> tag.substring(1))
             .toList();
+
+        return new TagFilters(include, exclude);
+    }
+
+    public static List<Suggestion> getSuggestions(Member member, @Nullable Long userId, String tags, String title, Suggestion.ChannelType channelType) {
+        TagFilters tagFilters = parseTagFilters(tags);
+        final List<String> includeTags = tagFilters.include();
+        final List<String> excludeTags = tagFilters.exclude();
 
         List<Suggestion> allSuggestions = SkyBlockNerdsBot.suggestionCache().getSuggestions();
         if (allSuggestions.isEmpty()) {

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/util/SuggestionCommandUtilsTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/util/SuggestionCommandUtilsTest.java
@@ -1,0 +1,51 @@
+package net.hypixel.nerdbot.app.command.util;
+
+import net.hypixel.nerdbot.app.command.util.SuggestionCommandUtils.TagFilters;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link SuggestionCommandUtils#parseTagFilters}, the include/exclude tag filter parsing.
+ */
+class SuggestionCommandUtilsTest {
+
+    @Test
+    void separatesIncludeAndExcludeTags() {
+        TagFilters filters = SuggestionCommandUtils.parseTagFilters("bug, !wontfix");
+
+        assertEquals(List.of("bug"), filters.include());
+        assertEquals(List.of("wontfix"), filters.exclude());
+    }
+
+    @Test
+    void treatsAllTagsAsIncludesWhenNoneAreNegated() {
+        TagFilters filters = SuggestionCommandUtils.parseTagFilters("bug, feature");
+
+        assertEquals(List.of("bug", "feature"), filters.include());
+        assertEquals(List.of(), filters.exclude());
+    }
+
+    @Test
+    void stripsTheBangFromEveryExcludedTag() {
+        TagFilters filters = SuggestionCommandUtils.parseTagFilters("!a, !b");
+
+        assertEquals(List.of(), filters.include());
+        assertEquals(List.of("a", "b"), filters.exclude());
+    }
+
+    @Test
+    void yieldsEmptyListsForNullOrBlank() {
+        assertEquals(List.of(), SuggestionCommandUtils.parseTagFilters(null).include());
+        assertEquals(List.of(), SuggestionCommandUtils.parseTagFilters("   ").include());
+        assertEquals(List.of(), SuggestionCommandUtils.parseTagFilters(null).exclude());
+    }
+
+    @Test
+    void splitsWithOrWithoutASpaceAfterTheComma() {
+        assertEquals(List.of("a", "b"), SuggestionCommandUtils.parseTagFilters("a,b").include());
+        assertEquals(List.of("a", "b"), SuggestionCommandUtils.parseTagFilters("a, b").include());
+    }
+}


### PR DESCRIPTION
## What

Catalogue item #7 (the pure part): make suggestion tag-filter parsing testable.

- `getSuggestions` parsed its comma-separated tag filter inline - splitting the string and separating `!`-negated exclusions from inclusions - which couldn't be tested because the surrounding filter runs against live-channel `Suggestion` objects.
- Extracted `parseTagFilters(String): TagFilters` (a record of include/exclude lists). `getSuggestions` uses it; behaviour is unchanged.

## Why

The `!` negation and split handling is exactly the kind of small-but-consequential parsing where a wrong implementation (forgetting to strip `!`, mis-splitting) silently shows the wrong suggestions.

## Tests

`mvn -pl app -am test` -> 133 passing (5 new): include/exclude separation, `!` stripping, null/blank -> empty, and split tolerance for an optional space after the comma.
