### PR TITLE
refactor(punishment): extract PunishmentService behind a PunishmentStore

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/PunishmentCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/PunishmentCommands.java
@@ -18,6 +18,9 @@ import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.interactions.components.text.TextInput;
 import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
 import net.dv8tion.jda.api.interactions.modals.Modal;
+import net.hypixel.nerdbot.app.punishment.PunishmentService;
+import net.hypixel.nerdbot.app.punishment.PunishmentStats;
+import net.hypixel.nerdbot.app.punishment.RepositoryPunishmentStore;
 import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.discord.cache.ChannelCache;
 import net.hypixel.nerdbot.marmalade.format.DiscordTimestamp;
@@ -72,29 +75,15 @@ public class PunishmentCommands {
     ) {
         event.deferReply(true).complete();
 
-        PunishmentRepository repo = getPunishmentRepository();
-        List<Punishment> results;
-
         PunishmentType punishmentType = type != null ? PunishmentType.fromName(type) : null;
 
-        if (moderator != null && punishmentType != null) {
-            results = repo.findByModeratorUserId(moderator.getId()).stream()
-                .filter(p -> p.getType() == punishmentType)
-                .limit(ITEMS_PER_PAGE)
-                .toList();
-        } else if (moderator != null) {
-            results = repo.findByModeratorUserId(moderator.getId()).stream()
-                .limit(ITEMS_PER_PAGE)
-                .toList();
-        } else if (punishmentType != null) {
-            results = repo.getAll().stream()
-                .filter(p -> p.getType() == punishmentType)
-                .limit(ITEMS_PER_PAGE)
-                .toList();
-        } else {
+        if (moderator == null && punishmentType == null) {
             event.getHook().editOriginal("Please provide at least one filter (moderator or type).").queue();
             return;
         }
+
+        PunishmentService punishmentService = new PunishmentService(new RepositoryPunishmentStore(getPunishmentRepository()));
+        List<Punishment> results = punishmentService.search(moderator != null ? moderator.getId() : null, punishmentType, ITEMS_PER_PAGE);
 
         if (results.isEmpty()) {
             event.getHook().editOriginal("No punishments found matching the given filters.").queue();
@@ -121,24 +110,19 @@ public class PunishmentCommands {
     public void punishmentStats(SlashCommandInteractionEvent event, @SlashOption Member member) {
         event.deferReply(true).complete();
 
-        PunishmentRepository repo = getPunishmentRepository();
-        String targetId = member.getId();
-        long total = repo.countByTargetUserId(targetId);
+        PunishmentService punishmentService = new PunishmentService(new RepositoryPunishmentStore(getPunishmentRepository()));
+        PunishmentStats stats = punishmentService.stats(member.getId());
 
         EmbedBuilder embed = new EmbedBuilder()
             .setTitle("Punishment Stats for " + member.getEffectiveName())
             .setColor(Color.BLUE)
             .setThumbnail(member.getEffectiveAvatarUrl())
-            .addField("Total", String.valueOf(total), true);
+            .addField("Total", String.valueOf(stats.total()), true);
 
-        for (PunishmentType type : PunishmentType.values()) {
-            long count = repo.countByTargetAndType(targetId, type);
-            if (count > 0) {
-                embed.addField(type.getDisplayName(), String.valueOf(count), true);
-            }
-        }
+        stats.countsByType().forEach((type, count) ->
+            embed.addField(type.getDisplayName(), String.valueOf(count), true));
 
-        if (total == 0) {
+        if (stats.total() == 0) {
             embed.setDescription("This user has no recorded punishments.");
         }
 

--- a/app/src/main/java/net/hypixel/nerdbot/app/punishment/PunishmentService.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/punishment/PunishmentService.java
@@ -1,0 +1,72 @@
+package net.hypixel.nerdbot.app.punishment;
+
+import net.hypixel.nerdbot.marmalade.storage.database.model.punishment.Punishment;
+import net.hypixel.nerdbot.marmalade.storage.database.model.punishment.PunishmentType;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Punishment search and statistics, extracted from {@code PunishmentCommands} so the querying and
+ * aggregation logic can be exercised against a {@link PunishmentStore} without a live bot or
+ * database. The commands keep the Discord modal/embed plumbing.
+ */
+public class PunishmentService {
+
+    private final PunishmentStore store;
+
+    public PunishmentService(PunishmentStore store) {
+        this.store = store;
+    }
+
+    /**
+     * Search punishments by moderator and/or type.
+     *
+     * <p>When a moderator is given, only their punishments are scanned; otherwise all punishments
+     * are scanned. A type, when given, further filters the results. If neither filter is given the
+     * result is empty (callers should require at least one filter). At most {@code limit} results are
+     * returned.
+     *
+     * @param moderatorUserId the moderator to filter by, or {@code null} for any
+     * @param type            the punishment type to filter by, or {@code null} for any
+     * @param limit           the maximum number of results
+     * @return the matching punishments, capped at {@code limit}
+     */
+    public List<Punishment> search(@Nullable String moderatorUserId, @Nullable PunishmentType type, int limit) {
+        List<Punishment> base;
+        if (moderatorUserId != null) {
+            base = store.findByModeratorUserId(moderatorUserId);
+        } else if (type != null) {
+            base = store.getAll();
+        } else {
+            return List.of();
+        }
+
+        return base.stream()
+            .filter(punishment -> type == null || punishment.getType() == type)
+            .limit(limit)
+            .toList();
+    }
+
+    /**
+     * Tally a user's punishments into a total and a per-type breakdown (omitting zero counts).
+     *
+     * @param targetUserId the punished user's Discord ID
+     * @return the user's {@link PunishmentStats}
+     */
+    public PunishmentStats stats(String targetUserId) {
+        long total = store.countByTargetUserId(targetUserId);
+
+        Map<PunishmentType, Long> countsByType = new EnumMap<>(PunishmentType.class);
+        for (PunishmentType type : PunishmentType.values()) {
+            long count = store.countByTargetAndType(targetUserId, type);
+            if (count > 0) {
+                countsByType.put(type, count);
+            }
+        }
+
+        return new PunishmentStats(total, countsByType);
+    }
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/punishment/PunishmentStats.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/punishment/PunishmentStats.java
@@ -1,0 +1,15 @@
+package net.hypixel.nerdbot.app.punishment;
+
+import net.hypixel.nerdbot.marmalade.storage.database.model.punishment.PunishmentType;
+
+import java.util.Map;
+
+/**
+ * A user's punishment tally: the total count plus a per-type breakdown containing only the types
+ * with at least one punishment.
+ *
+ * @param total         the total number of punishments the user has received
+ * @param countsByType  count per {@link PunishmentType}, omitting types with a zero count
+ */
+public record PunishmentStats(long total, Map<PunishmentType, Long> countsByType) {
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/punishment/PunishmentStore.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/punishment/PunishmentStore.java
@@ -1,0 +1,40 @@
+package net.hypixel.nerdbot.app.punishment;
+
+import net.hypixel.nerdbot.marmalade.storage.database.model.punishment.Punishment;
+import net.hypixel.nerdbot.marmalade.storage.database.model.punishment.PunishmentType;
+
+import java.util.List;
+
+/**
+ * Narrow, injectable view over {@link Punishment} storage.
+ *
+ * <p>{@link PunishmentService} depends on this interface instead of reaching through the global bot
+ * for the concrete {@code PunishmentRepository}, so its search and stats logic can be unit-tested
+ * against an in-memory fake. Production code is backed by {@link RepositoryPunishmentStore}.
+ */
+public interface PunishmentStore {
+
+    /**
+     * @return every recorded punishment
+     */
+    List<Punishment> getAll();
+
+    /**
+     * @param moderatorUserId the moderator's Discord ID
+     * @return the punishments issued by that moderator
+     */
+    List<Punishment> findByModeratorUserId(String moderatorUserId);
+
+    /**
+     * @param targetUserId the punished user's Discord ID
+     * @return how many punishments the user has received
+     */
+    long countByTargetUserId(String targetUserId);
+
+    /**
+     * @param targetUserId the punished user's Discord ID
+     * @param type         the punishment type
+     * @return how many punishments of that type the user has received
+     */
+    long countByTargetAndType(String targetUserId, PunishmentType type);
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/punishment/RepositoryPunishmentStore.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/punishment/RepositoryPunishmentStore.java
@@ -1,0 +1,39 @@
+package net.hypixel.nerdbot.app.punishment;
+
+import net.hypixel.nerdbot.marmalade.storage.database.model.punishment.Punishment;
+import net.hypixel.nerdbot.marmalade.storage.database.model.punishment.PunishmentType;
+import net.hypixel.nerdbot.marmalade.storage.database.repository.PunishmentRepository;
+
+import java.util.List;
+
+/**
+ * Production {@link PunishmentStore} backed by the real {@link PunishmentRepository}.
+ */
+public class RepositoryPunishmentStore implements PunishmentStore {
+
+    private final PunishmentRepository repository;
+
+    public RepositoryPunishmentStore(PunishmentRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<Punishment> getAll() {
+        return repository.getAll();
+    }
+
+    @Override
+    public List<Punishment> findByModeratorUserId(String moderatorUserId) {
+        return repository.findByModeratorUserId(moderatorUserId);
+    }
+
+    @Override
+    public long countByTargetUserId(String targetUserId) {
+        return repository.countByTargetUserId(targetUserId);
+    }
+
+    @Override
+    public long countByTargetAndType(String targetUserId, PunishmentType type) {
+        return repository.countByTargetAndType(targetUserId, type);
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/punishment/PunishmentServiceTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/punishment/PunishmentServiceTest.java
@@ -1,0 +1,91 @@
+package net.hypixel.nerdbot.app.punishment;
+
+import net.hypixel.nerdbot.app.testsupport.FakePunishmentStore;
+import net.hypixel.nerdbot.marmalade.storage.database.model.punishment.Punishment;
+import net.hypixel.nerdbot.marmalade.storage.database.model.punishment.PunishmentType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link PunishmentService} search and stats, exercised against an in-memory store.
+ */
+class PunishmentServiceTest {
+
+    @Test
+    void searchByModeratorReturnsOnlyThatModeratorsPunishments() {
+        PunishmentService service = new PunishmentService(new FakePunishmentStore()
+            .seed(punishment("t1", "mod1", PunishmentType.WARNING))
+            .seed(punishment("t2", "mod2", PunishmentType.WARNING)));
+
+        List<Punishment> results = service.search("mod1", null, 10);
+
+        assertEquals(1, results.size());
+        assertEquals("mod1", results.getFirst().getModeratorUserId());
+    }
+
+    @Test
+    void searchByModeratorAndTypeFiltersByType() {
+        PunishmentService service = new PunishmentService(new FakePunishmentStore()
+            .seed(punishment("t1", "mod1", PunishmentType.WARNING))
+            .seed(punishment("t2", "mod1", PunishmentType.BAN)));
+
+        List<Punishment> results = service.search("mod1", PunishmentType.BAN, 10);
+
+        assertEquals(1, results.size());
+        assertEquals(PunishmentType.BAN, results.getFirst().getType());
+    }
+
+    @Test
+    void searchByTypeOnlyScansEveryModerator() {
+        PunishmentService service = new PunishmentService(new FakePunishmentStore()
+            .seed(punishment("t1", "mod1", PunishmentType.BAN))
+            .seed(punishment("t2", "mod2", PunishmentType.BAN))
+            .seed(punishment("t3", "mod1", PunishmentType.WARNING)));
+
+        List<Punishment> results = service.search(null, PunishmentType.BAN, 10);
+
+        assertEquals(2, results.size());
+        assertTrue(results.stream().allMatch(punishment -> punishment.getType() == PunishmentType.BAN));
+    }
+
+    @Test
+    void searchRespectsLimit() {
+        FakePunishmentStore store = new FakePunishmentStore();
+        for (int i = 0; i < 15; i++) {
+            store.seed(punishment("t" + i, "mod1", PunishmentType.WARNING));
+        }
+
+        assertEquals(10, new PunishmentService(store).search("mod1", null, 10).size());
+    }
+
+    @Test
+    void searchWithNoFiltersReturnsEmpty() {
+        PunishmentService service = new PunishmentService(new FakePunishmentStore()
+            .seed(punishment("t1", "mod1", PunishmentType.WARNING)));
+
+        assertTrue(service.search(null, null, 10).isEmpty());
+    }
+
+    @Test
+    void statsTalliesTotalAndPerTypeOmittingZeros() {
+        PunishmentService service = new PunishmentService(new FakePunishmentStore()
+            .seed(punishment("user", "mod1", PunishmentType.WARNING))
+            .seed(punishment("user", "mod1", PunishmentType.WARNING))
+            .seed(punishment("user", "mod2", PunishmentType.BAN))
+            .seed(punishment("someone-else", "mod1", PunishmentType.KICK)));
+
+        PunishmentStats stats = service.stats("user");
+
+        assertEquals(3, stats.total());
+        assertEquals(Map.of(PunishmentType.WARNING, 2L, PunishmentType.BAN, 1L), stats.countsByType());
+    }
+
+    private static Punishment punishment(String target, String moderator, PunishmentType type) {
+        return new Punishment(target, moderator, type, "reason", "notes");
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/testsupport/FakePunishmentStore.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/testsupport/FakePunishmentStore.java
@@ -1,0 +1,48 @@
+package net.hypixel.nerdbot.app.testsupport;
+
+import net.hypixel.nerdbot.app.punishment.PunishmentStore;
+import net.hypixel.nerdbot.marmalade.storage.database.model.punishment.Punishment;
+import net.hypixel.nerdbot.marmalade.storage.database.model.punishment.PunishmentType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * In-memory {@link PunishmentStore} for tests. Seed punishments with {@link #seed(Punishment)};
+ * insertion order is preserved.
+ */
+public class FakePunishmentStore implements PunishmentStore {
+
+    private final List<Punishment> punishments = new ArrayList<>();
+
+    public FakePunishmentStore seed(Punishment punishment) {
+        punishments.add(punishment);
+        return this;
+    }
+
+    @Override
+    public List<Punishment> getAll() {
+        return new ArrayList<>(punishments);
+    }
+
+    @Override
+    public List<Punishment> findByModeratorUserId(String moderatorUserId) {
+        return punishments.stream()
+            .filter(punishment -> moderatorUserId.equals(punishment.getModeratorUserId()))
+            .toList();
+    }
+
+    @Override
+    public long countByTargetUserId(String targetUserId) {
+        return punishments.stream()
+            .filter(punishment -> targetUserId.equals(punishment.getTargetUserId()))
+            .count();
+    }
+
+    @Override
+    public long countByTargetAndType(String targetUserId, PunishmentType type) {
+        return punishments.stream()
+            .filter(punishment -> targetUserId.equals(punishment.getTargetUserId()) && punishment.getType() == type)
+            .count();
+    }
+}


### PR DESCRIPTION
## What

First of the bigger store-seam services from the catalogue (#2), cloning the `DiscordUserStore` recipe.

- New narrow **`PunishmentStore`** (`getAll` / `findByModeratorUserId` / `countByTargetUserId` / `countByTargetAndType`) with a production **`RepositoryPunishmentStore`** adapter and an in-memory **`FakePunishmentStore`** for tests.
- New **`PunishmentService`** with `search(moderatorId, type, limit)` and `stats(targetId): PunishmentStats` (total + per-type counts, zero counts omitted).
- `/punishment search` and `/punishment stats` become thin adapters that call the service and render the embed. **Behaviour is unchanged** (including the per-type field order, preserved via an `EnumMap`).

## Why

The filtering (which repository query to run, then filter by type and cap) and the stats aggregation were inlined in JDA command handlers reaching through the global, so they were untestable. Now they run against an injectable store.

## Follow-up

The `/punishment history` hand-rolled pagination is left for a separate PR that adopts the existing `PaginatedResponse` wrapper (as used by the other commands), per your steer.

## Tests

`mvn -pl app -am test` -> 141 passing (6 new).
