### PR TITLE
refactor: move AlphaProjectConfigUpdater into the app module

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
@@ -26,7 +26,7 @@ import net.hypixel.nerdbot.discord.api.feature.SchedulableFeature;
 import net.hypixel.nerdbot.marmalade.functional.Result;
 import net.hypixel.nerdbot.discord.cache.MessageCache;
 import net.hypixel.nerdbot.discord.cache.suggestion.SuggestionCache;
-import net.hypixel.nerdbot.discord.config.AlphaProjectConfigUpdater;
+import net.hypixel.nerdbot.app.config.AlphaProjectConfigUpdater;
 import net.hypixel.nerdbot.discord.config.DiscordBotConfig;
 import net.hypixel.nerdbot.discord.config.FeatureConfig;
 import net.hypixel.nerdbot.discord.config.NerdBotConfig;

--- a/app/src/main/java/net/hypixel/nerdbot/app/config/AlphaProjectConfigUpdater.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/config/AlphaProjectConfigUpdater.java
@@ -1,10 +1,11 @@
-package net.hypixel.nerdbot.discord.config;
+package net.hypixel.nerdbot.app.config;
 
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 import net.hypixel.nerdbot.discord.cache.suggestion.Suggestion;
 import net.hypixel.nerdbot.discord.config.channel.AlphaProjectConfig;
+import net.hypixel.nerdbot.discord.config.NerdBotConfig;
 import net.hypixel.nerdbot.discord.util.DiscordUtils;
 
 import java.util.ArrayList;

--- a/app/src/main/java/net/hypixel/nerdbot/app/listener/SuggestionListener.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/listener/SuggestionListener.java
@@ -16,7 +16,7 @@ import net.dv8tion.jda.api.managers.channel.concrete.ForumChannelManager;
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
 import net.hypixel.nerdbot.marmalade.collections.ArrayUtils;
 import net.hypixel.nerdbot.discord.cache.suggestion.Suggestion;
-import net.hypixel.nerdbot.discord.config.AlphaProjectConfigUpdater;
+import net.hypixel.nerdbot.app.config.AlphaProjectConfigUpdater;
 import net.hypixel.nerdbot.discord.config.NerdBotConfig;
 import net.hypixel.nerdbot.discord.config.channel.AlphaProjectConfig;
 import net.hypixel.nerdbot.discord.config.objects.ForumAutoTag;


### PR DESCRIPTION
## What

Moves a domain class out of `discord-framework`.

`AlphaProjectConfigUpdater` migrates the SkyBlock-Nerds alpha/project forum configuration - pure domain logic - but lived in the reusable framework module. It is only referenced by `app` (`SkyBlockNerdsBot`, `SuggestionListener`) and no framework class depends on it, so it moves to `net.hypixel.nerdbot.app.config` without affecting the framework. Behaviour is unchanged.

`SuggestionCache` and `Suggestion` are the natural next classes to relocate, but they are coupled by package-private access and `Suggestion` is still used by framework `DiscordUtils`, so they need to move together once that usage is untangled.

## Tests

`mvn -pl app -am test` -> 135 passing.
