### PR TITLE
refactor: genericize SchedulableFeature to the base DiscordBotConfig

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/activity/ActivityPurgeFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/activity/ActivityPurgeFeature.java
@@ -8,6 +8,7 @@ import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.discord.api.feature.BotFeature;
 import net.hypixel.nerdbot.discord.api.feature.SchedulableFeature;
 import net.hypixel.nerdbot.discord.config.NerdBotConfig;
+import net.hypixel.nerdbot.discord.config.DiscordBotConfig;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
 
@@ -62,13 +63,13 @@ public class ActivityPurgeFeature extends BotFeature implements SchedulableFeatu
     }
 
     @Override
-    public long defaultInitialDelayMs(NerdBotConfig config) {
-        return Duration.of(config.getMojangUsernameCacheTTL(), ChronoUnit.HOURS).toMillis();
+    public long defaultInitialDelayMs(DiscordBotConfig config) {
+        return Duration.of(((NerdBotConfig) config).getMojangUsernameCacheTTL(), ChronoUnit.HOURS).toMillis();
     }
 
     @Override
-    public long defaultPeriodMs(NerdBotConfig config) {
-        return Duration.of(config.getMojangUsernameCacheTTL(), ChronoUnit.HOURS).toMillis();
+    public long defaultPeriodMs(DiscordBotConfig config) {
+        return Duration.of(((NerdBotConfig) config).getMojangUsernameCacheTTL(), ChronoUnit.HOURS).toMillis();
     }
 
     @Override

--- a/app/src/main/java/net/hypixel/nerdbot/app/feature/CurateFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/feature/CurateFeature.java
@@ -10,6 +10,7 @@ import net.hypixel.nerdbot.discord.api.feature.BotFeature;
 import net.hypixel.nerdbot.discord.api.feature.SchedulableFeature;
 import net.hypixel.nerdbot.discord.cache.ChannelCache;
 import net.hypixel.nerdbot.discord.config.NerdBotConfig;
+import net.hypixel.nerdbot.discord.config.DiscordBotConfig;
 import net.hypixel.nerdbot.discord.config.suggestion.SuggestionConfig;
 import net.hypixel.nerdbot.app.curator.Curator;
 import net.hypixel.nerdbot.marmalade.storage.database.Database;
@@ -66,13 +67,13 @@ public class CurateFeature extends BotFeature implements SchedulableFeature {
     }
 
     @Override
-    public long defaultInitialDelayMs(NerdBotConfig config) {
+    public long defaultInitialDelayMs(DiscordBotConfig config) {
         return 30_000L;
     }
 
     @Override
-    public long defaultPeriodMs(NerdBotConfig config) {
-        return config.getInterval();
+    public long defaultPeriodMs(DiscordBotConfig config) {
+        return ((NerdBotConfig) config).getInterval();
     }
 
     @Override

--- a/app/src/main/java/net/hypixel/nerdbot/app/feature/ProfileUpdateFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/feature/ProfileUpdateFeature.java
@@ -13,6 +13,7 @@ import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.discord.api.feature.BotFeature;
 import net.hypixel.nerdbot.discord.api.feature.SchedulableFeature;
 import net.hypixel.nerdbot.discord.config.NerdBotConfig;
+import net.hypixel.nerdbot.discord.config.DiscordBotConfig;
 import net.hypixel.nerdbot.marmalade.exception.HttpException;
 import net.hypixel.nerdbot.marmalade.functional.Result;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
@@ -144,13 +145,13 @@ public class ProfileUpdateFeature extends BotFeature implements SchedulableFeatu
     }
 
     @Override
-    public long defaultInitialDelayMs(NerdBotConfig config) {
+    public long defaultInitialDelayMs(DiscordBotConfig config) {
         return 0L;
     }
 
     @Override
-    public long defaultPeriodMs(NerdBotConfig config) {
-        return Duration.of(config.getMojangUsernameCacheTTL(), ChronoUnit.HOURS).toMillis();
+    public long defaultPeriodMs(DiscordBotConfig config) {
+        return Duration.of(((NerdBotConfig) config).getMojangUsernameCacheTTL(), ChronoUnit.HOURS).toMillis();
     }
 
     @Override

--- a/discord-framework/src/main/java/net/hypixel/nerdbot/discord/api/feature/SchedulableFeature.java
+++ b/discord-framework/src/main/java/net/hypixel/nerdbot/discord/api/feature/SchedulableFeature.java
@@ -1,6 +1,6 @@
 package net.hypixel.nerdbot.discord.api.feature;
 
-import net.hypixel.nerdbot.discord.config.NerdBotConfig;
+import net.hypixel.nerdbot.discord.config.DiscordBotConfig;
 
 /**
  * Implement on features that execute periodic tasks. The framework
@@ -18,10 +18,10 @@ public interface SchedulableFeature {
     /**
      * Default initial delay in milliseconds before the first run.
      */
-    long defaultInitialDelayMs(NerdBotConfig config);
+    long defaultInitialDelayMs(DiscordBotConfig config);
 
     /**
      * Default repeating period in milliseconds.
      */
-    long defaultPeriodMs(NerdBotConfig config);
+    long defaultPeriodMs(DiscordBotConfig config);
 }


### PR DESCRIPTION
## What

Removes the framework's dependency on the app-specific config from its scheduling interface.

- `SchedulableFeature` (in `discord-framework`) declared `defaultInitialDelayMs(NerdBotConfig)` / `defaultPeriodMs(NerdBotConfig)` - forcing the reusable framework to know about the SkyBlock-Nerds `NerdBotConfig`.
- Both now take the base `DiscordBotConfig`. The three implementers (`ActivityPurgeFeature`, `CurateFeature`, `ProfileUpdateFeature`) cast to `NerdBotConfig` internally where they read app-specific values (`mojangUsernameCacheTTL`, `interval`).

## Why

Part of making `discord-framework` a genuinely generic Discord-bot module rather than one wired to this bot's config.

## Tests

`mvn -pl app -am test` -> 135 passing. Behaviour unchanged.
