### PR TITLE
refactor: move suggestion caching and channel-type logic into the app module

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
@@ -25,7 +25,7 @@ import net.hypixel.nerdbot.discord.api.feature.FeatureEventListener;
 import net.hypixel.nerdbot.discord.api.feature.SchedulableFeature;
 import net.hypixel.nerdbot.marmalade.functional.Result;
 import net.hypixel.nerdbot.discord.cache.MessageCache;
-import net.hypixel.nerdbot.discord.cache.suggestion.SuggestionCache;
+import net.hypixel.nerdbot.app.suggestion.SuggestionCache;
 import net.hypixel.nerdbot.app.config.AlphaProjectConfigUpdater;
 import net.hypixel.nerdbot.discord.config.DiscordBotConfig;
 import net.hypixel.nerdbot.discord.config.FeatureConfig;

--- a/app/src/main/java/net/hypixel/nerdbot/app/activity/ActivityListener.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/activity/ActivityListener.java
@@ -21,14 +21,14 @@ import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
 import net.hypixel.nerdbot.app.metrics.PrometheusMetrics;
 import net.hypixel.nerdbot.marmalade.collections.ArrayUtils;
 import net.hypixel.nerdbot.discord.BotEnvironment;
-import net.hypixel.nerdbot.discord.cache.suggestion.Suggestion;
+import net.hypixel.nerdbot.app.suggestion.Suggestion;
+import net.hypixel.nerdbot.app.suggestion.SuggestionTypeResolver;
 import net.hypixel.nerdbot.discord.config.EmojiConfig;
 import net.hypixel.nerdbot.discord.config.channel.AlphaProjectConfig;
 import net.hypixel.nerdbot.discord.config.objects.RoleRestrictedChannelGroup;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
 import net.hypixel.nerdbot.discord.util.DiscordBotEnvironment;
-import net.hypixel.nerdbot.discord.util.DiscordUtils;
 import net.hypixel.nerdbot.discord.util.EmojiConfigUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -154,11 +154,11 @@ public class ActivityListener {
         Suggestion.ChannelType channelType;
 
         if (guildChannel instanceof ThreadChannel threadChannel) {
-            channelType = DiscordUtils.getThreadSuggestionType(threadChannel);
+            channelType = SuggestionTypeResolver.getThreadSuggestionType(threadChannel);
         } else if (guildChannel instanceof TextChannel) {
-            channelType = DiscordUtils.getChannelSuggestionType(guildChannel.asTextChannel());
+            channelType = SuggestionTypeResolver.getChannelSuggestionType(guildChannel.asTextChannel());
         } else {
-            channelType = DiscordUtils.getChannelSuggestionTypeFromName(guildChannel.getName());
+            channelType = SuggestionTypeResolver.getChannelSuggestionTypeFromName(guildChannel.getName());
         }
 
         Optional<RoleRestrictedChannelGroup> matchingGroup = findMatchingRoleRestrictedGroup(guildChannel.getId(), member);
@@ -185,7 +185,7 @@ public class ActivityListener {
         // New Suggestion Comments
         if (guildChannel instanceof ThreadChannel && event.getChannel().getIdLong() != event.getMessage().getIdLong()) {
             ForumChannel forumChannel = guildChannel.asThreadChannel().getParentChannel().asForumChannel();
-            channelType = DiscordUtils.getForumSuggestionType(forumChannel);
+            channelType = SuggestionTypeResolver.getForumSuggestionType(forumChannel);
 
             // New Suggestion Comments
             if (channelType == Suggestion.ChannelType.NORMAL) {
@@ -264,7 +264,7 @@ public class ActivityListener {
                 PrometheusMetrics.TOTAL_VOICE_TIME_SPENT_BY_USER.labels(member.getEffectiveName(), channelLeft.getName()).inc((TimeUnit.MILLISECONDS.toSeconds(timeSpent)));
 
                 if ((timeSpent / 1_000L) > SkyBlockNerdsBot.config().getVoiceThreshold()) {
-                    Suggestion.ChannelType channelType = DiscordUtils.getChannelSuggestionType(channelLeft.asVoiceChannel());
+                    Suggestion.ChannelType channelType = SuggestionTypeResolver.getChannelSuggestionType(channelLeft.asVoiceChannel());
 
                     if (channelType == Suggestion.ChannelType.ALPHA) {
                         discordUser.getLastActivity().setAlphaVoiceJoinDate(time);

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/ExportCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/ExportCommands.java
@@ -18,7 +18,7 @@ import net.hypixel.nerdbot.discord.role.RoleManager;
 import net.hypixel.nerdbot.marmalade.io.FileUtils;
 import net.hypixel.nerdbot.marmalade.csv.CSVData;
 import net.hypixel.nerdbot.discord.BotEnvironment;
-import net.hypixel.nerdbot.discord.cache.suggestion.Suggestion;
+import net.hypixel.nerdbot.app.suggestion.Suggestion;
 import net.hypixel.nerdbot.marmalade.storage.database.model.greenlit.GreenlitMessage;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.stats.ChannelActivityEntry;

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/ProfileCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/ProfileCommands.java
@@ -32,7 +32,7 @@ import net.hypixel.nerdbot.marmalade.exception.HttpException;
 import net.hypixel.nerdbot.marmalade.json.HypixelPlayerResponse;
 import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.discord.cache.ChannelCache;
-import net.hypixel.nerdbot.discord.cache.suggestion.Suggestion;
+import net.hypixel.nerdbot.app.suggestion.Suggestion;
 import net.hypixel.nerdbot.discord.config.RoleConfig;
 import net.hypixel.nerdbot.discord.config.objects.RoleRestrictedChannelGroup;
 import net.hypixel.nerdbot.marmalade.storage.badge.Badge;

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/SuggestionCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/SuggestionCommands.java
@@ -30,8 +30,7 @@ import net.hypixel.nerdbot.app.command.util.SuggestionCommandUtils;
 import net.hypixel.nerdbot.app.curator.ForumChannelCurator;
 import net.hypixel.nerdbot.app.metrics.PrometheusMetrics;
 import net.hypixel.nerdbot.discord.BotEnvironment;
-import net.hypixel.nerdbot.discord.cache.ChannelCache;
-import net.hypixel.nerdbot.discord.cache.suggestion.Suggestion;
+import net.hypixel.nerdbot.app.suggestion.Suggestion;
 import net.hypixel.nerdbot.discord.config.EmojiConfig;
 import net.hypixel.nerdbot.discord.config.suggestion.SuggestionConfig;
 import net.hypixel.nerdbot.marmalade.format.DiscordTimestamp;
@@ -153,7 +152,7 @@ public class SuggestionCommands {
         }
 
         // Send Request Review Message
-        ChannelCache.getRequestedReviewChannel().ifPresentOrElse(textChannel -> {
+        SuggestionCommandUtils.getRequestedReviewChannel().ifPresentOrElse(textChannel -> {
             textChannel.sendMessageEmbeds(
                     new EmbedBuilder()
                         .setAuthor(String.format("Greenlit Review Request from %s", event.getUser().getEffectiveName()))

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/util/SuggestionCommandUtils.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/util/SuggestionCommandUtils.java
@@ -1,6 +1,8 @@
 package net.hypixel.nerdbot.app.command.util;
 
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
+import net.hypixel.nerdbot.discord.cache.ChannelCache;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -9,7 +11,7 @@ import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
 import net.hypixel.nerdbot.app.command.SuggestionStats;
 import net.hypixel.nerdbot.discord.cache.EmojiCache;
-import net.hypixel.nerdbot.discord.cache.suggestion.Suggestion;
+import net.hypixel.nerdbot.app.suggestion.Suggestion;
 import net.hypixel.nerdbot.discord.config.EmojiConfig;
 import net.hypixel.nerdbot.discord.util.DiscordBotEnvironment;
 import net.hypixel.nerdbot.discord.util.DiscordUtils;
@@ -22,6 +24,7 @@ import java.awt.*;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -29,6 +32,11 @@ import java.util.stream.Collectors;
 @Slf4j
 @UtilityClass
 public class SuggestionCommandUtils {
+
+    public static Optional<TextChannel> getRequestedReviewChannel() {
+        return ChannelCache.getChannelById(SkyBlockNerdsBot.config().getSuggestionConfig().getReviewRequestConfig().getChannelId())
+            .map(TextChannel.class::cast);
+    }
 
     /**
      * The include and exclude tag names parsed from a suggestion tag filter string.

--- a/app/src/main/java/net/hypixel/nerdbot/app/config/AlphaProjectConfigUpdater.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/config/AlphaProjectConfigUpdater.java
@@ -3,10 +3,10 @@ package net.hypixel.nerdbot.app.config;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
-import net.hypixel.nerdbot.discord.cache.suggestion.Suggestion;
+import net.hypixel.nerdbot.app.suggestion.Suggestion;
+import net.hypixel.nerdbot.app.suggestion.SuggestionTypeResolver;
 import net.hypixel.nerdbot.discord.config.channel.AlphaProjectConfig;
 import net.hypixel.nerdbot.discord.config.NerdBotConfig;
-import net.hypixel.nerdbot.discord.util.DiscordUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +24,7 @@ public class AlphaProjectConfigUpdater {
         if (updateAlpha) {
             log.info("Updating Alpha Forum IDs");
             alphaProjectConfig.setAlphaForumIds(forumChannels.stream()
-                .filter(forumChannel -> DiscordUtils.getForumSuggestionType(forumChannel) == Suggestion.ChannelType.ALPHA)
+                .filter(forumChannel -> SuggestionTypeResolver.getForumSuggestionType(forumChannel) == Suggestion.ChannelType.ALPHA)
                 .map(ForumChannel::getId)
                 .toArray(String[]::new));
         }
@@ -32,7 +32,7 @@ public class AlphaProjectConfigUpdater {
         if (updateProject) {
             log.info("Updating Project Forum IDs");
             alphaProjectConfig.setProjectForumIds(forumChannels.stream()
-                .filter(forumChannel -> DiscordUtils.getForumSuggestionType(forumChannel) == Suggestion.ChannelType.PROJECT)
+                .filter(forumChannel -> SuggestionTypeResolver.getForumSuggestionType(forumChannel) == Suggestion.ChannelType.PROJECT)
                 .map(ForumChannel::getId)
                 .toArray(String[]::new));
         }

--- a/app/src/main/java/net/hypixel/nerdbot/app/listener/SuggestionListener.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/listener/SuggestionListener.java
@@ -15,7 +15,8 @@ import net.dv8tion.jda.api.hooks.SubscribeEvent;
 import net.dv8tion.jda.api.managers.channel.concrete.ForumChannelManager;
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
 import net.hypixel.nerdbot.marmalade.collections.ArrayUtils;
-import net.hypixel.nerdbot.discord.cache.suggestion.Suggestion;
+import net.hypixel.nerdbot.app.suggestion.Suggestion;
+import net.hypixel.nerdbot.app.suggestion.SuggestionTypeResolver;
 import net.hypixel.nerdbot.app.config.AlphaProjectConfigUpdater;
 import net.hypixel.nerdbot.discord.config.NerdBotConfig;
 import net.hypixel.nerdbot.discord.config.channel.AlphaProjectConfig;
@@ -68,7 +69,7 @@ public class SuggestionListener {
     @SubscribeEvent
     public void onChannelDelete(ChannelDeleteEvent event) {
         if (event.getChannelType() == net.dv8tion.jda.api.entities.channel.ChannelType.FORUM) {
-            Suggestion.ChannelType channelType = DiscordUtils.getForumSuggestionType(event.getChannel().asForumChannel());
+            Suggestion.ChannelType channelType = SuggestionTypeResolver.getForumSuggestionType(event.getChannel().asForumChannel());
 
             if (channelType == Suggestion.ChannelType.ALPHA || channelType == Suggestion.ChannelType.PROJECT) {
                 NerdBotConfig botConfig = SkyBlockNerdsBot.config();
@@ -92,7 +93,7 @@ public class SuggestionListener {
     private void updateConfigForumIds(GenericChannelEvent event) {
         if (event.getChannelType() == net.dv8tion.jda.api.entities.channel.ChannelType.FORUM) {
             ForumChannel forumChannel = event.getChannel().asForumChannel();
-            Suggestion.ChannelType channelType = DiscordUtils.getForumSuggestionType(forumChannel);
+            Suggestion.ChannelType channelType = SuggestionTypeResolver.getForumSuggestionType(forumChannel);
 
             log.info("Forum channel event detected: '{}' (ID: {}), detected type: {}, parent category: {}",
                 forumChannel.getName(),

--- a/app/src/main/java/net/hypixel/nerdbot/app/suggestion/Suggestion.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/suggestion/Suggestion.java
@@ -1,4 +1,4 @@
-package net.hypixel.nerdbot.discord.cache.suggestion;
+package net.hypixel.nerdbot.app.suggestion;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +12,8 @@ import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.managers.channel.concrete.ThreadChannelManager;
 import net.hypixel.nerdbot.marmalade.EnumUtils;
-import net.hypixel.nerdbot.discord.config.DiscordBotConfig;
+import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
+import net.hypixel.nerdbot.discord.config.NerdBotConfig;
 import net.hypixel.nerdbot.discord.util.DiscordBotEnvironment;
 import net.hypixel.nerdbot.discord.util.DiscordUtils;
 
@@ -48,7 +49,7 @@ public class Suggestion {
     }
 
     public Suggestion(ThreadChannel thread, ChannelType channelType) {
-        DiscordBotConfig botConfig = DiscordBotEnvironment.getBot().getConfig();
+        NerdBotConfig botConfig = SkyBlockNerdsBot.config();
         this.threadId = thread.getId();
         this.parentId = thread.getParentChannel().asForumChannel().getId();
         this.threadName = thread.getName();
@@ -58,7 +59,7 @@ public class Suggestion {
         this.timeCreated = thread.getTimeCreated();
         this.jumpUrl = String.format("https://discord.com/channels/%s/%s", this.getGuildId(), this.getThreadId());
         this.greenlit = channelType == ChannelType.NORMAL && DiscordUtils.hasTagByName(thread, botConfig.getSuggestionConfig().getGreenlitTag());
-        this.channelType = channelType == null ? DiscordUtils.getThreadSuggestionType(thread) : channelType;
+        this.channelType = channelType == null ? SuggestionTypeResolver.getThreadSuggestionType(thread) : channelType;
         this.expired = false;
 
         // Activity

--- a/app/src/main/java/net/hypixel/nerdbot/app/suggestion/SuggestionCache.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/suggestion/SuggestionCache.java
@@ -1,4 +1,4 @@
-package net.hypixel.nerdbot.discord.cache.suggestion;
+package net.hypixel.nerdbot.app.suggestion;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -8,7 +8,7 @@ import net.hypixel.nerdbot.marmalade.collections.ArrayUtils;
 import net.hypixel.nerdbot.discord.cache.ChannelCache;
 import net.hypixel.nerdbot.discord.config.channel.AlphaProjectConfig;
 import net.hypixel.nerdbot.discord.config.suggestion.SuggestionConfig;
-import net.hypixel.nerdbot.discord.util.DiscordBotEnvironment;
+import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -44,8 +44,8 @@ public class SuggestionCache extends TimerTask {
             this.updating = true;
             this.cache.forEach((key, suggestion) -> suggestion.setExpired());
 
-            SuggestionConfig suggestionConfig = DiscordBotEnvironment.getBot().getConfig().getSuggestionConfig();
-            AlphaProjectConfig alphaProjectConfig = DiscordBotEnvironment.getBot().getConfig().getAlphaProjectConfig();
+            SuggestionConfig suggestionConfig = SkyBlockNerdsBot.config().getSuggestionConfig();
+            AlphaProjectConfig alphaProjectConfig = SkyBlockNerdsBot.config().getAlphaProjectConfig();
 
             // Suggestions
             Optional<ForumChannel> suggestionChannel = ChannelCache.getForumChannelById(suggestionConfig.getForumChannelId());

--- a/app/src/main/java/net/hypixel/nerdbot/app/suggestion/SuggestionTypeResolver.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/suggestion/SuggestionTypeResolver.java
@@ -1,0 +1,72 @@
+package net.hypixel.nerdbot.app.suggestion;
+
+import net.dv8tion.jda.api.entities.channel.concrete.Category;
+import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildChannel;
+import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
+import net.hypixel.nerdbot.discord.config.channel.AlphaProjectConfig;
+import net.hypixel.nerdbot.discord.config.suggestion.SuggestionConfig;
+import net.hypixel.nerdbot.marmalade.collections.ArrayUtils;
+
+import java.util.Arrays;
+
+/**
+ * Resolves which kind of suggestion channel (normal / alpha / project) a thread, forum, or channel
+ * belongs to, using the configured suggestion and alpha/project forum settings.
+ */
+public final class SuggestionTypeResolver {
+
+    private SuggestionTypeResolver() {
+    }
+
+    public static Suggestion.ChannelType getThreadSuggestionType(ThreadChannel threadChannel) {
+        return getForumSuggestionType(threadChannel.getParentChannel().asForumChannel());
+    }
+
+    public static Suggestion.ChannelType getForumSuggestionType(ForumChannel forumChannel) {
+        SuggestionConfig suggestionConfig = SkyBlockNerdsBot.config().getSuggestionConfig();
+        AlphaProjectConfig alphaProjectConfig = SkyBlockNerdsBot.config().getAlphaProjectConfig();
+        String parentChannelId = forumChannel.getId();
+
+        if (ArrayUtils.safeArrayStream(alphaProjectConfig.getAlphaForumIds()).anyMatch(parentChannelId::equalsIgnoreCase)) {
+            return Suggestion.ChannelType.ALPHA;
+        } else if (ArrayUtils.safeArrayStream(alphaProjectConfig.getProjectForumIds()).anyMatch(parentChannelId::equalsIgnoreCase)) {
+            return Suggestion.ChannelType.PROJECT;
+        } else if (parentChannelId.equals(suggestionConfig.getForumChannelId())) {
+            return Suggestion.ChannelType.NORMAL;
+        }
+
+        Category parentCategory = forumChannel.getParentCategory();
+
+        if (parentCategory != null) {
+            return getChannelSuggestionTypeFromName(parentCategory.getName());
+        }
+
+        String[] projectChannelNames = SkyBlockNerdsBot.config().getChannelConfig().getProjectChannelNames();
+        String channelName = forumChannel.getName().toLowerCase();
+
+        if (channelName.contains("alpha") || Arrays.stream(projectChannelNames).anyMatch(channelName::contains)) {
+            return getChannelSuggestionTypeFromName(forumChannel.getName());
+        }
+
+        return Suggestion.ChannelType.UNKNOWN;
+    }
+
+    public static Suggestion.ChannelType getChannelSuggestionType(StandardGuildChannel channel) {
+        return getChannelSuggestionTypeFromName(channel.getName());
+    }
+
+    public static Suggestion.ChannelType getChannelSuggestionTypeFromName(String name) {
+        if (name.toLowerCase().contains("alpha")) {
+            return Suggestion.ChannelType.ALPHA;
+        }
+
+        String[] projectChannelNames = SkyBlockNerdsBot.config().getChannelConfig().getProjectChannelNames();
+        if (Arrays.stream(projectChannelNames).anyMatch(name.toLowerCase()::contains)) {
+            return Suggestion.ChannelType.PROJECT;
+        }
+
+        return Suggestion.ChannelType.NORMAL;
+    }
+}

--- a/discord-framework/src/main/java/net/hypixel/nerdbot/discord/cache/ChannelCache.java
+++ b/discord-framework/src/main/java/net/hypixel/nerdbot/discord/cache/ChannelCache.java
@@ -97,11 +97,6 @@ public class ChannelCache {
             .map(TextChannel.class::cast);
     }
 
-    public static Optional<TextChannel> getRequestedReviewChannel() {
-        return getChannelById(DiscordBotEnvironment.getBot().getConfig().getSuggestionConfig().getReviewRequestConfig().getChannelId())
-            .map(TextChannel.class::cast);
-    }
-
     @SubscribeEvent
     public void onChannelCreate(ChannelCreateEvent event) {
         CHANNEL_CACHE.put(event.getChannel().getId(), event.getChannel().asGuildChannel());

--- a/discord-framework/src/main/java/net/hypixel/nerdbot/discord/util/DiscordUtils.java
+++ b/discord-framework/src/main/java/net/hypixel/nerdbot/discord/util/DiscordUtils.java
@@ -7,23 +7,16 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageHistory;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.entities.channel.concrete.Category;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
-import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
-import net.hypixel.nerdbot.marmalade.collections.ArrayUtils;
 import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.discord.cache.EmojiCache;
-import net.hypixel.nerdbot.discord.cache.suggestion.Suggestion;
-import net.hypixel.nerdbot.discord.config.channel.AlphaProjectConfig;
-import net.hypixel.nerdbot.discord.config.suggestion.SuggestionConfig;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -104,55 +97,5 @@ public class DiscordUtils {
         return threadChannel.getAppliedTags()
             .stream()
             .anyMatch(forumTag -> (ignoreCase ? forumTag.getName().equalsIgnoreCase(name) : forumTag.getName().equals(name)));
-    }
-
-    public static Suggestion.ChannelType getThreadSuggestionType(ThreadChannel threadChannel) {
-        return getForumSuggestionType(threadChannel.getParentChannel().asForumChannel());
-    }
-
-    public static Suggestion.ChannelType getForumSuggestionType(ForumChannel forumChannel) {
-        SuggestionConfig suggestionConfig = DiscordBotEnvironment.getBot().getConfig().getSuggestionConfig();
-        AlphaProjectConfig alphaProjectConfig = DiscordBotEnvironment.getBot().getConfig().getAlphaProjectConfig();
-        String parentChannelId = forumChannel.getId();
-
-        if (ArrayUtils.safeArrayStream(alphaProjectConfig.getAlphaForumIds()).anyMatch(parentChannelId::equalsIgnoreCase)) {
-            return Suggestion.ChannelType.ALPHA;
-        } else if (ArrayUtils.safeArrayStream(alphaProjectConfig.getProjectForumIds()).anyMatch(parentChannelId::equalsIgnoreCase)) {
-            return Suggestion.ChannelType.PROJECT;
-        } else if (parentChannelId.equals(suggestionConfig.getForumChannelId())) {
-            return Suggestion.ChannelType.NORMAL;
-        }
-
-        Category parentCategory = forumChannel.getParentCategory();
-
-        if (parentCategory != null) {
-            return getChannelSuggestionTypeFromName(parentCategory.getName());
-        }
-
-        String[] projectChannelNames = DiscordBotEnvironment.getBot().getConfig().getChannelConfig().getProjectChannelNames();
-        String channelName = forumChannel.getName().toLowerCase();
-
-        if (channelName.contains("alpha") || Arrays.stream(projectChannelNames).anyMatch(channelName::contains)) {
-            return getChannelSuggestionTypeFromName(forumChannel.getName());
-        }
-
-        return Suggestion.ChannelType.UNKNOWN;
-    }
-
-    public static Suggestion.ChannelType getChannelSuggestionType(StandardGuildChannel channel) {
-        return getChannelSuggestionTypeFromName(channel.getName());
-    }
-
-    public static Suggestion.ChannelType getChannelSuggestionTypeFromName(String name) {
-        if (name.toLowerCase().contains("alpha")) {
-            return Suggestion.ChannelType.ALPHA;
-        }
-
-        String[] projectChannelNames = DiscordBotEnvironment.getBot().getConfig().getChannelConfig().getProjectChannelNames();
-        if (Arrays.stream(projectChannelNames).anyMatch(name.toLowerCase()::contains)) {
-            return Suggestion.ChannelType.PROJECT;
-        }
-
-        return Suggestion.ChannelType.NORMAL;
     }
 }


### PR DESCRIPTION
## What

Moves the SkyBlock-Nerds suggestion domain out of `discord-framework`, so the framework stops knowing about suggestions.

- `Suggestion` and `SuggestionCache` move to `app.suggestion`.
- The forum/thread/channel suggestion-type resolution is extracted out of the framework's `DiscordUtils` into a new `app.suggestion.SuggestionTypeResolver`.
- The review-request-channel lookup moves out of the framework's `ChannelCache` into `SuggestionCommandUtils`.
- Config reads in the moved code now go through `NerdBotConfig`.

After this, `discord-framework` has no references to suggestions or the suggestion/alpha config. All callers updated; behaviour is unchanged.

## Tests

`mvn -pl app -am test` -> 135 passing.
