### PR TITLE
refactor(listener): extract role-restricted group naming into tested helpers

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/listener/RoleRestrictedChannelListener.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/listener/RoleRestrictedChannelListener.java
@@ -209,8 +209,14 @@ public class RoleRestrictedChannelListener {
             }
         }
 
-        String identifier = generateGroupIdentifier(guild, roleIds);
-        String displayName = generateGroupDisplayName(guild, roleIds);
+        List<String> roleNames = roleIds.stream()
+            .map(guild::getRoleById)
+            .filter(Objects::nonNull)
+            .map(net.dv8tion.jda.api.entities.Role::getName)
+            .toList();
+
+        String identifier = formatGroupIdentifier(roleNames, roleIds);
+        String displayName = formatGroupDisplayName(roleNames);
 
         RoleRestrictedChannelGroup newGroup = new RoleRestrictedChannelGroup(
             identifier,
@@ -244,40 +250,51 @@ public class RoleRestrictedChannelListener {
         return false;
     }
 
-    private String generateGroupIdentifier(Guild guild, Set<String> roleIds) {
-        List<String> roleNames = roleIds.stream()
-            .map(guild::getRoleById)
-            .filter(Objects::nonNull)
-            .map(role -> role.getName().toLowerCase().replaceAll("[^a-z0-9]", ""))
+    /**
+     * Build the stable identifier for a role-restricted group from its roles' names. Names are
+     * lowercased and stripped to {@code [a-z0-9]}, sorted for determinism, and joined with hyphens.
+     * When no role names resolve, the role IDs are used as a fallback.
+     *
+     * @param roleNames      the resolved role display names (unsorted, may be empty)
+     * @param fallbackRoleIds the role IDs to fall back to when no names resolve
+     *
+     * @return the group identifier, e.g. {@code "admin-mod-channels"}
+     */
+    static String formatGroupIdentifier(List<String> roleNames, Set<String> fallbackRoleIds) {
+        List<String> sanitized = roleNames.stream()
+            .map(name -> name.toLowerCase().replaceAll("[^a-z0-9]", ""))
             .sorted()
             .toList();
 
-        if (roleNames.isEmpty()) {
-            return String.join("-", roleIds) + "-channels";
+        if (sanitized.isEmpty()) {
+            return String.join("-", fallbackRoleIds) + "-channels";
         }
 
-        return String.join("-", roleNames) + "-channels";
+        return String.join("-", sanitized) + "-channels";
     }
 
-    private String generateGroupDisplayName(Guild guild, Set<String> roleIds) {
-        List<String> roleNames = roleIds.stream()
-            .map(guild::getRoleById)
-            .filter(Objects::nonNull)
-            .map(net.dv8tion.jda.api.entities.Role::getName)
-            .sorted()
-            .toList();
+    /**
+     * Build the human-readable display name for a role-restricted group from its roles' names. Names
+     * are sorted, then joined as "A Channels", "A & B Channels", or "A, B & C Channels".
+     *
+     * @param roleNames the resolved role display names (unsorted, may be empty)
+     *
+     * @return the group display name
+     */
+    static String formatGroupDisplayName(List<String> roleNames) {
+        List<String> sorted = roleNames.stream().sorted().toList();
 
-        if (roleNames.isEmpty()) {
+        if (sorted.isEmpty()) {
             return "Unknown Role Channels";
         }
 
-        if (roleNames.size() == 1) {
-            return roleNames.getFirst() + " Channels";
-        } else if (roleNames.size() == 2) {
-            return roleNames.get(0) + " & " + roleNames.get(1) + " Channels";
+        if (sorted.size() == 1) {
+            return sorted.getFirst() + " Channels";
+        } else if (sorted.size() == 2) {
+            return sorted.get(0) + " & " + sorted.get(1) + " Channels";
         } else {
-            return String.join(", ", roleNames.subList(0, roleNames.size() - 1)) +
-                " & " + roleNames.getLast() + " Channels";
+            return String.join(", ", sorted.subList(0, sorted.size() - 1)) +
+                " & " + sorted.getLast() + " Channels";
         }
     }
 }

--- a/app/src/test/java/net/hypixel/nerdbot/app/listener/RoleRestrictedGroupNamingTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/listener/RoleRestrictedGroupNamingTest.java
@@ -1,0 +1,58 @@
+package net.hypixel.nerdbot.app.listener;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * How a role-restricted channel group derives its stable identifier and human-readable display name
+ * from the names of the roles that gate it.
+ */
+class RoleRestrictedGroupNamingTest {
+
+    @Test
+    void identifierLowercasesStripsAndSortsRoleNames() {
+        // "Admin Team!" -> "adminteam", "Mod" -> "mod", sorted for a deterministic identifier
+        assertEquals(
+            "adminteam-mod-channels",
+            RoleRestrictedChannelListener.formatGroupIdentifier(List.of("Mod", "Admin Team!"), Set.of())
+        );
+    }
+
+    @Test
+    void identifierFallsBackToRoleIdsWhenNoNamesResolve() {
+        assertEquals(
+            "999-channels",
+            RoleRestrictedChannelListener.formatGroupIdentifier(List.of(), Set.of("999"))
+        );
+    }
+
+    @Test
+    void displayNameForNoRolesIsUnknown() {
+        assertEquals("Unknown Role Channels", RoleRestrictedChannelListener.formatGroupDisplayName(List.of()));
+    }
+
+    @Test
+    void displayNameForSingleRole() {
+        assertEquals("Admin Channels", RoleRestrictedChannelListener.formatGroupDisplayName(List.of("Admin")));
+    }
+
+    @Test
+    void displayNameForTwoRolesSortsAndJoinsWithAmpersand() {
+        assertEquals(
+            "Admin & Mod Channels",
+            RoleRestrictedChannelListener.formatGroupDisplayName(List.of("Mod", "Admin"))
+        );
+    }
+
+    @Test
+    void displayNameForThreeOrMoreRolesUsesCommasThenAmpersand() {
+        assertEquals(
+            "Admin, Mod & VIP Channels",
+            RoleRestrictedChannelListener.formatGroupDisplayName(List.of("VIP", "Admin", "Mod"))
+        );
+    }
+}


### PR DESCRIPTION
`RoleRestrictedChannelListener` derived a group's stable identifier and its display name inline, mixing JDA role-name resolution with the naming logic, so neither was tested. This splits the two: the guild role lookup happens once at the call site, and `formatGroupIdentifier` / `formatGroupDisplayName` are pure static helpers over the resolved names.

The identifier lowercases each name, strips it to `[a-z0-9]`, sorts for determinism and joins with hyphens (falling back to role IDs when nothing resolves); the display name sorts the names and joins them as "A Channels", "A & B Channels" or "A, B & C Channels". `RoleRestrictedGroupNamingTest` covers the sanitisation, sorting, ampersand and comma branches plus the empty-name fallbacks. Behaviour is unchanged. Full app suite passes (141).