### PR TITLE
refactor(command): centralise command error handling, stop leaking exception detail

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/AdminCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/AdminCommands.java
@@ -38,6 +38,7 @@ import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.requests.restaction.InviteAction;
 import net.dv8tion.jda.api.utils.FileUpload;
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
+import net.hypixel.nerdbot.app.command.util.CommandErrorResponder;
 import net.hypixel.nerdbot.app.curator.ForumChannelCurator;
 import net.hypixel.nerdbot.app.listener.RoleRestrictedChannelListener;
 import net.hypixel.nerdbot.app.metrics.PrometheusMetrics;
@@ -440,8 +441,7 @@ public class AdminCommands {
                         );
                     })
                     .exceptionally(throwable -> {
-                        log.error("Error during profile linking", throwable);
-                        event.getHook().editOriginal(String.format("Could not find player with username `%s`! (%s)", username, throwable.getMessage())).queue();
+                        CommandErrorResponder.respond(event.getHook(), String.format("Could not find a player with username `%s`. Please try again later.", username), throwable);
                         return null;
                     });
             })
@@ -500,8 +500,7 @@ public class AdminCommands {
                         }
                     })
                     .exceptionally(throwable -> {
-                        log.error("Error checking missing profiles", throwable);
-                        event.getHook().editOriginal("An error occurred while checking for missing profiles: " + throwable.getMessage()).queue();
+                        CommandErrorResponder.respond(event.getHook(), "An error occurred while checking for missing profiles. Please try again later.", throwable);
                         return null;
                     });
             })
@@ -614,8 +613,7 @@ public class AdminCommands {
                         event.getHook().editOriginal("Migration complete! Migrated " + mojangProfiles.size() + " users.").queue();
                     })
                     .exceptionally(throwable -> {
-                        log.error("Error during username migration", throwable);
-                        event.getHook().editOriginal("Migration failed: " + throwable.getMessage()).queue();
+                        CommandErrorResponder.respond(event.getHook(), "Migration failed. Please try again later.", throwable);
                         return null;
                     });
             })
@@ -718,8 +716,7 @@ public class AdminCommands {
             repository.saveAllToDatabase();
             event.getHook().editOriginal(String.format("Saved %d documents to the database!", repository.getCache().estimatedSize())).queue();
         } catch (RepositoryException exception) {
-            event.getHook().editOriginal(String.format("An error occurred while saving the repository: %s", exception.getMessage())).queue();
-            log.error("An error occurred while saving the repository!", exception);
+            CommandErrorResponder.respond(event.getHook(), "An error occurred while saving the repository. Please try again later.", exception);
         }
     }
 
@@ -746,8 +743,7 @@ public class AdminCommands {
             repository.loadAllDocumentsIntoCache();
             event.getHook().editOriginal(String.format("Loaded %d documents from the database!", repository.getCache().estimatedSize())).queue();
         } catch (RepositoryException exception) {
-            event.getHook().editOriginal(String.format("An error occurred while loading the repository: %s", exception.getMessage())).queue();
-            log.error("An error occurred while saving the repository!", exception);
+            CommandErrorResponder.respond(event.getHook(), "An error occurred while loading the repository. Please try again later.", exception);
         }
     }
 
@@ -768,8 +764,7 @@ public class AdminCommands {
 
             event.getHook().editOriginal(repository.getCache().stats().toString()).queue();
         } catch (RepositoryException exception) {
-            event.getHook().editOriginal(String.format("An error occurred while getting the statistics for that repository: %s", exception.getMessage())).queue();
-            log.error("An error occurred while saving the repository!", exception);
+            CommandErrorResponder.respond(event.getHook(), "An error occurred while getting the repository statistics. Please try again later.", exception);
         }
     }
 

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/ChannelCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/ChannelCommands.java
@@ -15,6 +15,7 @@ import net.dv8tion.jda.api.utils.FileUpload;
 import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.discord.config.objects.CustomForumTag;
 import net.hypixel.nerdbot.discord.config.objects.ForumAutoTag;
+import net.hypixel.nerdbot.app.command.util.CommandErrorResponder;
 import net.hypixel.nerdbot.app.config.SuggestionConfig;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
@@ -51,9 +52,9 @@ public class ChannelCommands {
                         .queue();
                 }
             } catch (Exception exception) {
-                log.error("An error occurred when archiving the channel {}!", channel.getId(), exception);
+                CommandErrorResponder.capture("An error occurred when archiving the channel " + channel.getId(), exception);
                 if (!hook.isExpired()) {
-                    hook.editOriginal(String.format("An error occurred while archiving channel %s: %s", channel.getAsMention(), exception.getMessage())).queue();
+                    hook.editOriginal(String.format("An error occurred while archiving channel %s. Please try again later.", channel.getAsMention())).queue();
                 }
             }
         });
@@ -73,12 +74,12 @@ public class ChannelCommands {
                 }
                 sendZipToUserAsync(event, zipFile, hook, category.getName());
             } catch (Exception exception) {
-                log.error("Failed to archive category {}", category.getId(), exception);
+                CommandErrorResponder.capture("Failed to archive category " + category.getId(), exception);
                 if (!hook.isExpired()) {
-                    hook.editOriginal("Failed to create the archive zip file: " + exception.getMessage()).queue();
+                    hook.editOriginal("Failed to create the archive zip file. Please try again later.").queue();
                 } else {
                     event.getUser().openPrivateChannel().queue(
-                        dm -> dm.sendMessage("Failed to archive category " + category.getName() + ": " + exception.getMessage()).queue(),
+                        dm -> dm.sendMessage("Failed to archive category " + category.getName() + ". Please try again later.").queue(),
                         error -> log.error("Failed to notify user {} of archive failure via DM", event.getUser().getId(), error)
                     );
                 }

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/ExportCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/ExportCommands.java
@@ -14,6 +14,7 @@ import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
 import net.dv8tion.jda.api.utils.messages.MessageEditData;
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
+import net.hypixel.nerdbot.app.command.util.CommandErrorResponder;
 import net.hypixel.nerdbot.discord.role.RoleManager;
 import net.hypixel.nerdbot.marmalade.io.FileUtils;
 import net.hypixel.nerdbot.marmalade.csv.CSVData;
@@ -63,8 +64,7 @@ public class ExportCommands {
                 .setFiles(FileUpload.fromData(file))
                 .queue();
         } catch (IOException exception) {
-            log.error("Failed to create temp file!", exception);
-            event.getHook().editOriginal(String.format("Failed to create temporary file: %s", exception.getMessage())).queue();
+            CommandErrorResponder.respond(event.getHook(), "Failed to create the export file. Please try again later.", exception);
         }
     }
 
@@ -135,8 +135,7 @@ public class ExportCommands {
 
             event.getHook().editOriginal(data).queue();
         } catch (IOException exception) {
-            event.getHook().editOriginal(String.format("Failed to create temporary file: %s", exception.getMessage())).queue();
-            log.error("Failed to create temp file!", exception);
+            CommandErrorResponder.respond(event.getHook(), "Failed to create the export file. Please try again later.", exception);
         }
     }
 
@@ -178,12 +177,10 @@ public class ExportCommands {
                 );
                 event.getHook().sendFiles(FileUpload.fromData(file)).queue();
             } catch (IOException exception) {
-                log.error("Failed to create temp file!", exception);
-                event.getHook().editOriginal("An error occurred while creating the temp file: " + exception.getMessage()).queue();
+                CommandErrorResponder.respond(event.getHook(), "Failed to create the export file. Please try again later.", exception);
             }
         }).onError(throwable -> {
-            log.error("Failed to load guild members for UUID export", throwable);
-            event.getHook().editOriginal("Failed to load guild members: " + throwable.getMessage()).queue();
+            CommandErrorResponder.respond(event.getHook(), "Failed to load the guild members. Please try again later.", throwable);
         });
     }
 
@@ -230,12 +227,10 @@ public class ExportCommands {
                 );
                 event.getHook().sendFiles(FileUpload.fromData(file)).queue();
             } catch (IOException exception) {
-                log.error("Failed to create temp file!", exception);
-                event.getHook().editOriginal("An error occurred while creating the temp file: " + exception.getMessage()).queue();
+                CommandErrorResponder.respond(event.getHook(), "Failed to create the export file. Please try again later.", exception);
             }
         }).onError(throwable -> {
-            log.error("Failed to load guild members for role export", throwable);
-            event.getHook().editOriginal("Failed to load guild members: " + throwable.getMessage()).queue();
+            CommandErrorResponder.respond(event.getHook(), "Failed to load the guild members. Please try again later.", throwable);
         });
     }
 
@@ -370,8 +365,7 @@ public class ExportCommands {
             File file = FileUtils.createTempFile(String.format("export-member-activity-%s.csv", FileUtils.FILE_NAME_DATE_FORMAT.format(Instant.now())), csvData.toCSV());
             event.getHook().sendFiles(FileUpload.fromData(file)).queue();
         } catch (IOException exception) {
-            log.error("Failed to create temp file!", exception);
-            event.getHook().editOriginal("An error occurred while creating the temp file: " + exception.getMessage()).queue();
+            CommandErrorResponder.respond(event.getHook(), "Failed to create the export file. Please try again later.", exception);
         }
     }
 
@@ -472,8 +466,7 @@ public class ExportCommands {
                     .setFiles(FileUpload.fromData(file))
                     .queue();
             }).exceptionally(throwable -> {
-                log.error("Failed to create temp file for user suggestions export", throwable);
-                event.getHook().editOriginal("Failed to create temporary file: " + throwable.getMessage()).queue();
+                CommandErrorResponder.respond(event.getHook(), "Failed to create the export file. Please try again later.", throwable);
                 return null;
             });
 

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/ProfileCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/ProfileCommands.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.api.exceptions.HierarchyException;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
+import net.hypixel.nerdbot.app.command.util.CommandErrorResponder;
 import net.hypixel.nerdbot.app.command.util.SuggestionCommandUtils;
 import net.hypixel.nerdbot.app.badge.BadgeManager;
 import net.hypixel.nerdbot.discord.role.RoleManager;
@@ -574,8 +575,7 @@ public class ProfileCommands {
                     });
             })
             .exceptionally(throwable -> {
-                log.error("Error during profile verification request", throwable);
-                event.getHook().editOriginal("Failed to process verification request: " + throwable.getMessage()).queue();
+                CommandErrorResponder.respond(event.getHook(), "Failed to process the verification request. Please try again later.", throwable);
                 return null;
             });
     }
@@ -643,8 +643,7 @@ public class ProfileCommands {
                     });
             })
             .exceptionally(throwable -> {
-                log.error("Error during profile linking", throwable);
-                event.getHook().editOriginal("Failed to link profile: " + throwable.getMessage()).queue();
+                CommandErrorResponder.respond(event.getHook(), "Failed to link the profile. Please try again later.", throwable);
                 return null;
             });
     }
@@ -707,8 +706,7 @@ public class ProfileCommands {
                 ).queue();
             })
             .exceptionally(throwable -> {
-                log.error("Error loading user profile", throwable);
-                event.getHook().editOriginal("Failed to load profile: " + throwable.getMessage()).queue();
+                CommandErrorResponder.respond(event.getHook(), "Failed to load the profile. Please try again later.", throwable);
                 return null;
             });
     }
@@ -740,8 +738,7 @@ public class ProfileCommands {
                 event.getHook().editOriginalEmbeds(createBadgesEmbed(event.getMember(), discordUser, true)).queue();
             })
             .exceptionally(throwable -> {
-                log.error("Error loading user badges", throwable);
-                event.getHook().editOriginal("Failed to load badges: " + throwable.getMessage()).queue();
+                CommandErrorResponder.respond(event.getHook(), "Failed to load the badges. Please try again later.", throwable);
                 return null;
             });
     }
@@ -805,8 +802,7 @@ public class ProfileCommands {
                 );
             })
             .exceptionally(throwable -> {
-                log.error("Error loading user suggestions", throwable);
-                event.getHook().editOriginal("Failed to load suggestions: " + throwable.getMessage()).queue();
+                CommandErrorResponder.respond(event.getHook(), "Failed to load the suggestions. Please try again later.", throwable);
                 return null;
             });
     }
@@ -845,8 +841,7 @@ public class ProfileCommands {
                 event.getHook().editOriginal("Your birthday has been removed!").queue();
             })
             .exceptionally(throwable -> {
-                log.error("Error removing birthday", throwable);
-                event.getHook().editOriginal("Failed to remove birthday: " + throwable.getMessage()).queue();
+                CommandErrorResponder.respond(event.getHook(), "Failed to remove the birthday. Please try again later.", throwable);
                 return null;
             });
     }
@@ -902,8 +897,7 @@ public class ProfileCommands {
                 event.getHook().editOriginal("Your birthday timezone has been updated to `" + zoneId.getId() + "`.").queue();
             })
             .exceptionally(throwable -> {
-                log.error("Error updating birthday timezone", throwable);
-                event.getHook().editOriginal("Failed to update timezone: " + throwable.getMessage()).queue();
+                CommandErrorResponder.respond(event.getHook(), "Failed to update the timezone. Please try again later.", throwable);
                 return null;
             });
     }
@@ -973,8 +967,7 @@ public class ProfileCommands {
                 }
             })
             .exceptionally(throwable -> {
-                log.error("Error setting birthday", throwable);
-                event.getHook().editOriginal("Failed to set birthday: " + throwable.getMessage()).queue();
+                CommandErrorResponder.respond(event.getHook(), "Failed to set the birthday. Please try again later.", throwable);
                 return null;
             });
     }

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/util/CommandErrorResponder.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/util/CommandErrorResponder.java
@@ -1,0 +1,57 @@
+package net.hypixel.nerdbot.app.command.util;
+
+import io.sentry.Sentry;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
+
+/**
+ * Centralises how slash commands report an internal failure. The exception is logged and forwarded
+ * to Sentry, while the user only ever sees a generic, caller-supplied message. Internal exception
+ * detail ({@link Throwable#getMessage()}, stack traces, filesystem paths) must never be passed as
+ * the user message.
+ */
+@Slf4j
+@UtilityClass
+public class CommandErrorResponder {
+
+    /**
+     * Report a command failure after the interaction has been deferred, editing the original reply.
+     *
+     * @param hook        the interaction hook whose original reply is edited
+     * @param userMessage the generic, user-safe message to display (never the exception message)
+     * @param error       the exception to log and capture
+     */
+    public static void respond(InteractionHook hook, String userMessage, Throwable error) {
+        capture(userMessage, error);
+        hook.editOriginal(userMessage).queue();
+    }
+
+    /**
+     * Report a command failure on an interaction that has not been deferred, sending a direct reply.
+     *
+     * @param event       the interaction to reply to
+     * @param userMessage the generic, user-safe message to display (never the exception message)
+     * @param error       the exception to log and capture
+     */
+    public static void respond(IReplyCallback event, String userMessage, Throwable error) {
+        capture(userMessage, error);
+        event.reply(userMessage).queue();
+    }
+
+    /**
+     * Log an exception and forward it to Sentry without sending a user-facing reply. Use when the
+     * user is notified through a channel other than the interaction (e.g. a direct message).
+     *
+     * @param context describes what failed, used as the log message
+     * @param error   the exception to log and capture
+     */
+    public static void capture(String context, Throwable error) {
+        log.error(context, error);
+
+        if (Sentry.isEnabled()) {
+            Sentry.captureException(error);
+        }
+    }
+}


### PR DESCRIPTION
Slash commands reported internal failures by concatenating the caught exception's `getMessage()` directly into the user reply. That leaked internal detail to users (database timeouts, IO errors, temporary-file paths) and handled logging inconsistently, with some sites logging before the reply and some after.

This adds `CommandErrorResponder`, a small helper that logs the exception, forwards it to Sentry when enabled, and replies with a generic, caller-supplied message that carries no exception detail. The ~24 internal-exception sites across `ProfileCommands`, `ExportCommands`, `AdminCommands` and `ChannelCommands` now go through it, so users see e.g. "Failed to load the profile. Please try again later." instead of a raw stack message, while the full exception still reaches the logs and Sentry.

`GeneratorCommands` is deliberately left as-is: its `GeneratorException` messages are curated user-facing validation feedback, not leaked internals. The `/config` JSON key echo is also left as-is (it surfaces the missing key name, not an internal error). No behaviour change to logging coverage beyond adding Sentry capture. Full app suite passes (141).