### PR TITLE
fix(sentry): stop reporting user-input generator errors as issues

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/util/CommandErrorResponder.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/util/CommandErrorResponder.java
@@ -1,16 +1,15 @@
 package net.hypixel.nerdbot.app.command.util;
 
-import io.sentry.Sentry;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 
 /**
- * Centralises how slash commands report an internal failure. The exception is logged and forwarded
- * to Sentry, while the user only ever sees a generic, caller-supplied message. Internal exception
- * detail ({@link Throwable#getMessage()}, stack traces, filesystem paths) must never be passed as
- * the user message.
+ * Centralises how slash commands report an internal failure. The exception is logged (which the
+ * logback Sentry appender forwards to Sentry), while the user only ever sees a generic,
+ * caller-supplied message. Internal exception detail ({@link Throwable#getMessage()}, stack traces,
+ * filesystem paths) must never be passed as the user message.
  */
 @Slf4j
 @UtilityClass
@@ -41,17 +40,14 @@ public class CommandErrorResponder {
     }
 
     /**
-     * Log an exception and forward it to Sentry without sending a user-facing reply. Use when the
-     * user is notified through a channel other than the interaction (e.g. a direct message).
+     * Log an exception (which the logback Sentry appender forwards to Sentry) without sending a
+     * user-facing reply. Use when the user is notified through a channel other than the interaction
+     * (e.g. a direct message).
      *
      * @param context describes what failed, used as the log message
-     * @param error   the exception to log and capture
+     * @param error   the exception to log
      */
     public static void capture(String context, Throwable error) {
         log.error(context, error);
-
-        if (Sentry.isEnabled()) {
-            Sentry.captureException(error);
-        }
     }
 }

--- a/app/src/main/java/net/hypixel/nerdbot/app/sentry/SentryManager.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/sentry/SentryManager.java
@@ -20,7 +20,10 @@ public class SentryManager {
         }
 
         String environment = Environment.getEnvironment().name().toLowerCase();
-        Sentry.configureScope(scope -> scope.setTag("environment", environment));
+        Sentry.configureScope(scope -> {
+            scope.setTag("environment", environment);
+            scope.addEventProcessor(new UserErrorSentryFilter());
+        });
         log.info("Sentry configured with environment: {}", environment);
     }
 

--- a/app/src/main/java/net/hypixel/nerdbot/app/sentry/UserErrorSentryFilter.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/sentry/UserErrorSentryFilter.java
@@ -1,0 +1,48 @@
+package net.hypixel.nerdbot.app.sentry;
+
+import io.sentry.EventProcessor;
+import io.sentry.Hint;
+import io.sentry.SentryEvent;
+import net.aerh.imagegenerator.exception.GeneratorException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Drops Sentry events that were caused by invalid user input rather than a bug. The generator
+ * throws {@link GeneratorException} to report things the user got wrong (an unknown item ID, a
+ * malformed slot list, a missing resource pack); those messages are shown back to the user and are
+ * not application errors, so they must not reach Sentry.
+ *
+ * <p>Filtering happens by runtime type, so exceptions co-caught alongside {@link GeneratorException}
+ * (for example {@code IllegalArgumentException} or an NBT parse error) are still reported when they
+ * are the actual failure.
+ */
+public class UserErrorSentryFilter implements EventProcessor {
+
+    @Override
+    @Nullable
+    public SentryEvent process(@NotNull SentryEvent event, @NotNull Hint hint) {
+        return isUserError(event.getThrowable()) ? null : event;
+    }
+
+    /**
+     * @param throwable the exception attached to a Sentry event, may be {@code null}
+     *
+     * @return {@code true} if the throwable, or any exception in its cause chain, represents invalid
+     *         user input rather than an application error
+     */
+    static boolean isUserError(@Nullable Throwable throwable) {
+        Set<Throwable> seen = new HashSet<>();
+
+        for (Throwable current = throwable; current != null && seen.add(current); current = current.getCause()) {
+            if (current instanceof GeneratorException) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/sentry/UserErrorSentryFilterTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/sentry/UserErrorSentryFilterTest.java
@@ -1,0 +1,44 @@
+package net.hypixel.nerdbot.app.sentry;
+
+import io.sentry.Hint;
+import io.sentry.SentryEvent;
+import net.aerh.imagegenerator.exception.GeneratorException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Which Sentry events the user-error filter drops: invalid generator input (directly or wrapped in
+ * a cause chain) is discarded, while genuine application errors and untyped events pass through.
+ */
+class UserErrorSentryFilterTest {
+
+    private final UserErrorSentryFilter filter = new UserErrorSentryFilter();
+
+    @Test
+    void dropsDirectGeneratorException() {
+        SentryEvent event = new SentryEvent(new GeneratorException("Item with ID `GOLEM_SWORD` not found"));
+        assertNull(filter.process(event, new Hint()));
+    }
+
+    @Test
+    void dropsGeneratorExceptionWrappedInCauseChain() {
+        SentryEvent event = new SentryEvent(new RuntimeException(new GeneratorException("bad slot")));
+        assertNull(filter.process(event, new Hint()));
+    }
+
+    @Test
+    void keepsInternalException() {
+        SentryEvent event = new SentryEvent(new IOException("connection reset"));
+        assertSame(event, filter.process(event, new Hint()));
+    }
+
+    @Test
+    void keepsEventWithoutThrowable() {
+        SentryEvent event = new SentryEvent();
+        assertSame(event, filter.process(event, new Hint()));
+    }
+}


### PR DESCRIPTION
Generator commands throw `GeneratorException` to report invalid user input, such as an unknown item ID (`GOLEM_SWORD`), a malformed slot list, or a missing resource pack. The command handlers log those at error level, and the logback `SentryAppender` (WARN threshold) was forwarding them to Sentry, so user mistakes showed up as unresolved issues.

This adds `UserErrorSentryFilter`, a scope-level `EventProcessor` registered in `SentryManager`, that drops any event whose throwable, or anything in its cause chain, is a `GeneratorException`. Filtering by runtime type matters: three of the generator catch blocks are combined (`GeneratorException | IllegalArgumentException`, `| NbtParseException`), and those genuine bugs are still reported when they are the actual failure. The filter sits at the Sentry boundary, so it also covers any future or library-internal log site without touching each `catch`.

While here, `CommandErrorResponder` no longer calls `Sentry.captureException` explicitly: the logback appender already forwards `log.error` to Sentry, so the internal command errors it handles were being reported twice.

`UserErrorSentryFilterTest` covers the direct, wrapped-cause, internal-exception and no-throwable cases. Full app suite passes (145).