### PR TITLE
fix(listener): stop PinListener blocking the JDA event thread

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/listener/PinListener.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/listener/PinListener.java
@@ -2,7 +2,6 @@ package net.hypixel.nerdbot.app.listener;
 
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageType;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
@@ -34,7 +33,7 @@ public class PinListener {
         if (member.getUser().isBot()) {
             // This deletes automated pinned messages sent by the bot.
             if (event.getMessage().getType() == MessageType.CHANNEL_PINNED_ADD) {
-                event.getMessage().delete().complete();
+                event.getMessage().delete().queue();
             }
             return; // Ignore any other bot messages
         }
@@ -60,7 +59,7 @@ public class PinListener {
             return;
         }
 
-        event.getMessage().pin().complete();
+        event.getMessage().pin().queue();
     }
 
     @SubscribeEvent
@@ -86,11 +85,12 @@ public class PinListener {
             }
 
             // We get the message we are checking to pin it.
-            Message message = event.retrieveMessage().complete();
-            if (!message.isPinned()) {
-                // We pin the message here.
-                message.pin().complete();
-            }
+            event.retrieveMessage().queue(message -> {
+                if (!message.isPinned()) {
+                    // We pin the message here.
+                    message.pin().queue();
+                }
+            });
         }
     }
 
@@ -117,11 +117,12 @@ public class PinListener {
             }
 
             // We get the message we are checking to unpin it.
-            Message message = event.retrieveMessage().complete();
-            if (message.isPinned()) {
-                // We unpin the message here.
-                message.unpin().complete();
-            }
+            event.retrieveMessage().queue(message -> {
+                if (message.isPinned()) {
+                    // We unpin the message here.
+                    message.unpin().queue();
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
The bot builds JDA with `AnnotatedEventManager` (`AbstractDiscordBot.java:117`), which dispatches events synchronously on JDA's event thread. `PinListener`'s `@SubscribeEvent` handlers made five blocking `RestAction.complete()` calls (`delete`, `pin`, `retrieveMessage` x2, `unpin`), so every message/reaction event it handled did synchronous REST round-trips on that thread, stalling gateway event processing while it waited.

This converts them to async `queue()`: the fire-and-forget `delete`/`pin` become `queue()`, and the retrieve-then-pin and retrieve-then-unpin flows become `retrieveMessage().queue(message -> ...)` callbacks that keep the existing `isPinned()` guards. Behaviour is unchanged; the work just no longer blocks the event thread. Full app suite passes (145).