### PR TITLE
chore: surface config-generation failures and document legacy username heuristic

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/AdminCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/AdminCommands.java
@@ -567,6 +567,9 @@ public class AdminCommands {
         guildOnly = true,
         defaultMemberPermissions = {"ADMINISTRATOR"}
     )
+    // Intentionally uses the legacy display-name heuristic: this admin tool migrates pre-verification
+    // members who never self-assigned a Mojang profile, and no non-heuristic source exists for them.
+    @SuppressWarnings("deprecation")
     public void migrateUsernames(SlashCommandInteractionEvent event) {
         event.deferReply(true).complete();
         DiscordUserRepository discordUserRepository = BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);

--- a/tooling/src/main/java/net/hypixel/nerdbot/tooling/config/ConfigGenerator.java
+++ b/tooling/src/main/java/net/hypixel/nerdbot/tooling/config/ConfigGenerator.java
@@ -197,7 +197,8 @@ public class ConfigGenerator {
                 default -> {
                 }
             }
-        } catch (Exception ignored) {
+        } catch (Exception exception) {
+            System.err.println("Failed to populate config value: " + exception.getMessage());
         }
     }
 
@@ -409,7 +410,8 @@ public class ConfigGenerator {
                     }
 
                     return (T) constructor.newInstance(params);
-                } catch (Exception ignored) {
+                } catch (Exception exception) {
+                    System.err.println("Failed to instantiate " + clazz.getName() + " via constructor: " + exception.getMessage());
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
Two small cleanups.

`ConfigGenerator` swallowed two reflection failures with `catch (Exception ignored) {}`. One populates a config field value; the other instantiates a class via constructor, and because that catch sits inside the outer try, a class that cannot be built returned `null` with no diagnostic anywhere (the outer `Failed to create instance` message never fired for it). Both now print to `System.err`, matching the tool's existing error-reporting style, so a broken example-config generation surfaces instead of silently producing wrong output. This is a dev/CI tool, so the best-effort behaviour is unchanged, only made visible.

Separately, `/admin migrate names` calls the deprecated `Utils.getScuffedMinecraftIGN`. That heuristic guesses a Minecraft IGN from a Discord display name and has no non-deprecated replacement; the command genuinely needs it to migrate pre-verification members who never self-assigned a Mojang profile. The call site is annotated `@SuppressWarnings("deprecation")` with a comment documenting the intent, and the method stays deprecated so other callers are still discouraged. Full app suite passes (145).