### PR TITLE
chore: bump SlashCommands to v1.0.14

### DIFF
--- a/discord-framework/pom.xml
+++ b/discord-framework/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.github.Aerhhh</groupId>
             <artifactId>SlashCommands</artifactId>
-            <version>v1.0.13</version>
+            <version>v1.0.14</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Bumps `com.github.Aerhhh:SlashCommands` from `v1.0.13` to `v1.0.14`, which dispatches command, button, string-select and modal handlers off the JDA event thread (autocomplete stays inline).

This is the consumption side of that fix: the bot builds JDA with `AnnotatedEventManager`, so handlers previously ran synchronously on the event thread, and the many `deferReply().complete()` / `RestAction.complete()` calls in command bodies blocked gateway event processing for each REST round-trip. With v1.0.14 those handlers run on the library's dispatch pool, so the blocking no longer stalls the event thread and the command code is left unchanged. Full app suite passes (145) against the new version.