### PR TITLE
feat(persistence): periodically flush repository caches to bound crash data loss

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
@@ -6,6 +6,7 @@ import net.aerh.imagegenerator.pack.PackRepository;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Activity;
 import net.hypixel.nerdbot.app.activity.ActivityListener;
+import net.hypixel.nerdbot.app.feature.RepositoryAutosaveFeature;
 import net.hypixel.nerdbot.app.badge.BadgeManager;
 import net.hypixel.nerdbot.app.generation.pack.ResourcePackService;
 import net.hypixel.nerdbot.app.listener.FunListener;
@@ -178,6 +179,11 @@ public class SkyBlockNerdsBot extends AbstractDiscordBot {
         } else {
             log.info("No feature config present");
         }
+
+        // Always-on durability safety net, registered outside the config so it cannot be disabled by
+        // omission: flushes write-behind repository changes on a fixed interval so an ungraceful
+        // shutdown loses at most one interval rather than everything since startup.
+        features.add(new RepositoryAutosaveFeature());
 
         return features;
     }

--- a/app/src/main/java/net/hypixel/nerdbot/app/feature/RepositoryAutosaveFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/feature/RepositoryAutosaveFeature.java
@@ -1,0 +1,54 @@
+package net.hypixel.nerdbot.app.feature;
+
+import lombok.extern.slf4j.Slf4j;
+import net.hypixel.nerdbot.discord.BotEnvironment;
+import net.hypixel.nerdbot.discord.api.feature.BotFeature;
+import net.hypixel.nerdbot.marmalade.storage.repository.Repository;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Periodically flushes every repository cache to the database. Repositories are write-behind for a
+ * lot of mutations (an in-memory {@code cacheObject} without an immediate save), and the only other
+ * safety nets are cache-eviction on expiry and the graceful save in {@code onEnd}. An ungraceful
+ * shutdown that bypasses {@code onEnd} (a SIGKILL, an OOM-kill or a crash) would otherwise lose
+ * every write-behind change accumulated since startup; this bounds that loss to one interval.
+ *
+ * <p>Registered unconditionally in code rather than through the feature config so the safety net
+ * cannot be turned off by omitting a config entry.
+ */
+@Slf4j
+public class RepositoryAutosaveFeature extends BotFeature {
+
+    private static final long AUTOSAVE_INTERVAL_MS = Duration.ofMinutes(15).toMillis();
+
+    @Override
+    public void onFeatureStart() {
+        scheduleAtFixedRate("RepositoryAutosaveFeature-task", this::flushRepositories, AUTOSAVE_INTERVAL_MS, AUTOSAVE_INTERVAL_MS);
+    }
+
+    private void flushRepositories() {
+        if (BotEnvironment.getBot().isReadOnly()) {
+            log.debug("Bot is in read-only mode, skipping repository autosave");
+            return;
+        }
+
+        Map<Class<?>, Object> repositories = BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepositories();
+        log.debug("Autosaving {} repositories to the database", repositories.size());
+
+        repositories.values().forEach(repositoryObject -> {
+            Repository<?> repository = (Repository<?>) repositoryObject;
+            repository.saveAllToDatabaseAsync()
+                .exceptionally(throwable -> {
+                    log.error("Failed to autosave repository {}", repository.getClass().getSimpleName(), throwable);
+                    return null;
+                });
+        });
+    }
+
+    @Override
+    public void onFeatureEnd() {
+        stopScheduledTask();
+    }
+}


### PR DESCRIPTION
The Marmalade repositories are a write-behind cache: many mutations only call `cacheObject` (an in-memory `cache.put`) with no immediate database write. The only things that persist those changes are cache-eviction on expiry (`expireAfterAccess`, so only idle entries) and the graceful bulk save in `AbstractDiscordBot.onEnd`. `onEnd` is correctly wired to SIGTERM/SIGINT and waits for the flush, so normal deploys lose nothing. But an ungraceful shutdown that bypasses it, most realistically an OOM-kill (the repos load whole collections into memory) but also `docker kill`, a grace-period timeout or a crash, loses every write-behind change accumulated since startup, primarily member activity/stats.

`RepositoryAutosaveFeature` flushes all repositories via `saveAllToDatabaseAsync` every 15 minutes, bounding that loss window to one interval. It is registered unconditionally in `createFeatures` rather than through the feature config, so this safety net cannot be silently disabled by omitting a config entry, and it no-ops in read-only mode. Write-through paths (reminder create/delete, punishments) are already safe and unaffected.

Tradeoff: there is no dirty-tracking, so each interval re-upserts all cached documents including unchanged ones. That write amplification is cheap for this bot's data size (one bulk write per repository) and is the accepted cost of not tracking dirty state in the shared library. Full app suite passes (145).