### PR TITLE
Keep member role ids synced to the database

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
@@ -7,6 +7,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Activity;
 import net.hypixel.nerdbot.app.activity.ActivityListener;
 import net.hypixel.nerdbot.app.feature.RepositoryAutosaveFeature;
+import net.hypixel.nerdbot.app.feature.RoleReconcileFeature;
 import net.hypixel.nerdbot.app.badge.BadgeManager;
 import net.hypixel.nerdbot.app.generation.pack.ResourcePackService;
 import net.hypixel.nerdbot.app.listener.FunListener;
@@ -15,6 +16,7 @@ import net.hypixel.nerdbot.app.listener.ModLogListener;
 import net.hypixel.nerdbot.app.listener.PinListener;
 import net.hypixel.nerdbot.app.listener.ReactionChannelListener;
 import net.hypixel.nerdbot.app.listener.RoleRestrictedChannelListener;
+import net.hypixel.nerdbot.app.listener.RoleSyncListener;
 import net.hypixel.nerdbot.app.listener.SuggestionListener;
 import net.hypixel.nerdbot.app.metrics.PrometheusMetrics;
 import net.hypixel.nerdbot.app.sentry.SentryManager;
@@ -118,7 +120,8 @@ public class SkyBlockNerdsBot extends AbstractDiscordBot {
             new PinListener(),
             new MetricsListener(),
             new FunListener(),
-            new RoleRestrictedChannelListener()
+            new RoleRestrictedChannelListener(),
+            new RoleSyncListener()
         ));
 
         return listeners;
@@ -184,6 +187,10 @@ public class SkyBlockNerdsBot extends AbstractDiscordBot {
         // omission: flushes write-behind repository changes on a fixed interval so an ungraceful
         // shutdown loses at most one interval rather than everything since startup.
         features.add(new RepositoryAutosaveFeature());
+
+        // Always-on safety net: hourly sweep that catches role changes missed by RoleSyncListener
+        // while the bot was offline (see RoleReconcileFeature for details).
+        features.add(new RoleReconcileFeature());
 
         return features;
     }

--- a/app/src/main/java/net/hypixel/nerdbot/app/feature/RoleReconcileFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/feature/RoleReconcileFeature.java
@@ -1,0 +1,66 @@
+package net.hypixel.nerdbot.app.feature;
+
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Role;
+import net.hypixel.nerdbot.app.role.RoleIdSync;
+import net.hypixel.nerdbot.discord.BotEnvironment;
+import net.hypixel.nerdbot.discord.api.feature.BotFeature;
+import net.hypixel.nerdbot.discord.util.DiscordUtils;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Hourly sweep that re-syncs every guild member's role ids, catching changes
+ * made while the bot was offline. Event-driven updates (RoleSyncListener) are
+ * the primary path; this is the safety net.
+ */
+@Slf4j
+public class RoleReconcileFeature extends BotFeature {
+
+    private static final long PERIOD_MS = TimeUnit.HOURS.toMillis(1);
+
+    @Override
+    public void onFeatureStart() {
+        if (BotEnvironment.getBot().isReadOnly()) {
+            log.warn("Bot is in read-only mode, skipping role reconcile task!");
+            return;
+        }
+        scheduleAtFixedRate("role-reconcile-task", this::reconcileAll, PERIOD_MS, PERIOD_MS);
+    }
+
+    private void reconcileAll() {
+        if (!BotEnvironment.getBot().getDatabase().isConnected()) {
+            log.error("Skipping role reconcile as the database is not connected!");
+            return;
+        }
+
+        DiscordUserRepository repository = BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
+        Guild guild = DiscordUtils.getMainGuild();
+
+        guild.loadMembers(member -> {
+                if (member.getUser().isBot()) {
+                    return;
+                }
+                DiscordUser user = repository.findById(member.getId()).toOptional().orElse(null);
+                if (user == null) {
+                    return;
+                }
+                List<String> roleIds = member.getRoles().stream().map(Role::getId).toList();
+                if (RoleIdSync.applyRoleIds(user, roleIds)) {
+                    repository.cacheObject(user);
+                    repository.saveToDatabaseAsync(user);
+                    log.info("Reconciled role ids for {} ({} roles)", member.getId(), roleIds.size());
+                }
+            })
+            .onError(throwable -> log.error("Role reconcile sweep failed", throwable));
+    }
+
+    @Override
+    public void onFeatureEnd() {
+        stopScheduledTask();
+    }
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/feature/UserGrabberFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/feature/UserGrabberFeature.java
@@ -2,7 +2,9 @@ package net.hypixel.nerdbot.app.feature;
 
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Role;
 import net.hypixel.nerdbot.app.badge.BadgeManager;
+import net.hypixel.nerdbot.app.role.RoleIdSync;
 import net.hypixel.nerdbot.app.storage.DiscordUserStore;
 import net.hypixel.nerdbot.app.storage.RepositoryDiscordUserStore;
 import net.hypixel.nerdbot.discord.BotEnvironment;
@@ -13,6 +15,7 @@ import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepo
 import net.hypixel.nerdbot.discord.util.DiscordUtils;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Predicate;
 
 @Slf4j
@@ -41,7 +44,8 @@ public class UserGrabberFeature extends BotFeature {
                 }
 
                 log.info("Found user {} ({})", member.getEffectiveName(), member.getId());
-                reconcileMember(store, member.getId(), member.getEffectiveName(), UserGrabberFeature::isKnownBadge);
+                List<String> roleIds = member.getRoles().stream().map(Role::getId).toList();
+                reconcileMember(store, member.getId(), member.getEffectiveName(), UserGrabberFeature::isKnownBadge, roleIds);
             })
             .onSuccess(aVoid -> log.info("Finished grabbing users from guild {} (ID: {})", guild.getName(), guild.getId()))
             .onError(throwable -> log.error("Failed to grab users from guild {} (ID: {})", guild.getName(), guild.getId(), throwable));
@@ -61,9 +65,10 @@ public class UserGrabberFeature extends BotFeature {
      * @param memberId      the member's Discord ID
      * @param effectiveName the member's display name (used only for logging)
      * @param knownBadge    returns {@code true} if the given badge ID is still recognised
+     * @param roleIds       the member's current Discord role ids
      * @return the reconciled (and saved) user
      */
-    static DiscordUser reconcileMember(DiscordUserStore store, String memberId, String effectiveName, Predicate<String> knownBadge) {
+    static DiscordUser reconcileMember(DiscordUserStore store, String memberId, String effectiveName, Predicate<String> knownBadge, List<String> roleIds) {
         DiscordUser discordUser = store.findById(memberId).orElse(null);
         if (discordUser == null) {
             discordUser = new DiscordUser(memberId);
@@ -87,6 +92,10 @@ public class UserGrabberFeature extends BotFeature {
             }
             return unknown;
         });
+
+        if (RoleIdSync.applyRoleIds(discordUser, roleIds)) {
+            log.info("Updated role ids for {} (ID: {})", effectiveName, memberId);
+        }
 
         store.save(discordUser);
         return discordUser;

--- a/app/src/main/java/net/hypixel/nerdbot/app/listener/RoleSyncListener.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/listener/RoleSyncListener.java
@@ -1,0 +1,52 @@
+package net.hypixel.nerdbot.app.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleAddEvent;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleRemoveEvent;
+import net.dv8tion.jda.api.hooks.SubscribeEvent;
+import net.hypixel.nerdbot.app.role.RoleIdSync;
+import net.hypixel.nerdbot.discord.BotEnvironment;
+import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
+
+import java.util.List;
+
+/**
+ * Mirrors Discord role changes onto the user's document as they happen. The
+ * Minecraft network reads roleIds from Mongo for whitelist/rank decisions, so
+ * changes are persisted immediately instead of waiting for the autosave flush.
+ */
+@Slf4j
+public class RoleSyncListener {
+
+    @SubscribeEvent
+    public void onRoleAdd(GuildMemberRoleAddEvent event) {
+        syncRoles(event.getMember());
+    }
+
+    @SubscribeEvent
+    public void onRoleRemove(GuildMemberRoleRemoveEvent event) {
+        syncRoles(event.getMember());
+    }
+
+    private void syncRoles(Member member) {
+        if (member.getUser().isBot()) {
+            return;
+        }
+
+        DiscordUserRepository repository = BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
+        List<String> roleIds = member.getRoles().stream().map(Role::getId).toList();
+
+        repository.findByIdAsync(member.getId()).thenAccept(user -> {
+            if (user == null) {
+                return; // unverified members are created by the grabber/activity flows
+            }
+            if (RoleIdSync.applyRoleIds(user, roleIds)) {
+                repository.cacheObject(user);
+                repository.saveToDatabaseAsync(user);
+                log.info("Updated role ids for {} ({} roles)", member.getId(), roleIds.size());
+            }
+        });
+    }
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/role/RoleIdSync.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/role/RoleIdSync.java
@@ -1,0 +1,28 @@
+package net.hypixel.nerdbot.app.role;
+
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Applies a member's current Discord role ids to their stored user document.
+ * Kept pure so listener and reconcile paths share one tested implementation.
+ */
+public final class RoleIdSync {
+
+    private RoleIdSync() {
+    }
+
+    /**
+     * @return true if the stored role ids changed and the user needs saving
+     */
+    public static boolean applyRoleIds(DiscordUser user, List<String> currentRoleIds) {
+        List<String> normalized = new ArrayList<>(currentRoleIds);
+        if (normalized.equals(user.getRoleIds())) {
+            return false;
+        }
+        user.setRoleIds(normalized);
+        return true;
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/feature/MemberReconciliationTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/feature/MemberReconciliationTest.java
@@ -25,7 +25,7 @@ class MemberReconciliationTest {
     void createsNewUserWhenAbsentThenSavesIt() {
         FakeDiscordUserStore store = new FakeDiscordUserStore();
 
-        DiscordUser result = UserGrabberFeature.reconcileMember(store, "123", "Nerd", ALL_KNOWN);
+        DiscordUser result = UserGrabberFeature.reconcileMember(store, "123", "Nerd", ALL_KNOWN, List.of());
 
         assertEquals("123", result.getDiscordId());
         assertNotNull(result.getLastActivity(), "a new user should have default activity");
@@ -40,7 +40,7 @@ class MemberReconciliationTest {
         existing.setLastActivity(null);
         FakeDiscordUserStore store = new FakeDiscordUserStore().seed(existing);
 
-        DiscordUser result = UserGrabberFeature.reconcileMember(store, "123", "Nerd", ALL_KNOWN);
+        DiscordUser result = UserGrabberFeature.reconcileMember(store, "123", "Nerd", ALL_KNOWN, List.of());
 
         assertNotNull(result.getLastActivity(), "null activity should have been replaced with a default");
         assertEquals(List.of("123"), store.savedIds());
@@ -52,7 +52,7 @@ class MemberReconciliationTest {
         existing.setBadges(null);
         FakeDiscordUserStore store = new FakeDiscordUserStore().seed(existing);
 
-        DiscordUser result = UserGrabberFeature.reconcileMember(store, "123", "Nerd", ALL_KNOWN);
+        DiscordUser result = UserGrabberFeature.reconcileMember(store, "123", "Nerd", ALL_KNOWN, List.of());
 
         assertNotNull(result.getBadges(), "null badges should have been replaced with an empty list");
         assertTrue(result.getBadges().isEmpty());
@@ -65,10 +65,17 @@ class MemberReconciliationTest {
         existing.setBadges(new ArrayList<>(List.of(new BadgeEntry("known"), new BadgeEntry("stale"))));
         FakeDiscordUserStore store = new FakeDiscordUserStore().seed(existing);
 
-        DiscordUser result = UserGrabberFeature.reconcileMember(store, "123", "Nerd", badgeId -> badgeId.equals("known"));
+        DiscordUser result = UserGrabberFeature.reconcileMember(store, "123", "Nerd", badgeId -> badgeId.equals("known"), List.of());
 
         assertEquals(1, result.getBadges().size(), "the unrecognised badge should have been removed");
         assertEquals("known", result.getBadges().get(0).badgeId());
         assertEquals(List.of("123"), store.savedIds());
+    }
+
+    @Test
+    void backfillsAndUpdatesRoleIds() {
+        FakeDiscordUserStore store = new FakeDiscordUserStore();
+        DiscordUser result = UserGrabberFeature.reconcileMember(store, "123", "Nerd", ALL_KNOWN, List.of("100", "200"));
+        assertEquals(List.of("100", "200"), result.getRoleIds(), "reconcile should adopt the member's current roles");
     }
 }

--- a/app/src/test/java/net/hypixel/nerdbot/app/role/RoleIdSyncTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/role/RoleIdSyncTest.java
@@ -1,0 +1,44 @@
+package net.hypixel.nerdbot.app.role;
+
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoleIdSyncTest {
+
+    @Test
+    void setsRolesOnUserWithNullRoleIds() {
+        DiscordUser user = new DiscordUser();
+        user.setDiscordId("123");
+        assertTrue(RoleIdSync.applyRoleIds(user, List.of("100", "200")), "null role ids should count as a change");
+        assertEquals(List.of("100", "200"), user.getRoleIds());
+    }
+
+    @Test
+    void reportsNoChangeWhenRolesAreIdentical() {
+        DiscordUser user = new DiscordUser("123");
+        user.setRoleIds(List.of("100", "200"));
+        assertFalse(RoleIdSync.applyRoleIds(user, List.of("100", "200")));
+    }
+
+    @Test
+    void replacesRolesWhenTheyDiffer() {
+        DiscordUser user = new DiscordUser("123");
+        user.setRoleIds(List.of("100"));
+        assertTrue(RoleIdSync.applyRoleIds(user, List.of("100", "300")));
+        assertEquals(List.of("100", "300"), user.getRoleIds());
+    }
+
+    @Test
+    void clearsRolesWhenMemberHasNone() {
+        DiscordUser user = new DiscordUser("123");
+        user.setRoleIds(List.of("100"));
+        assertTrue(RoleIdSync.applyRoleIds(user, List.of()));
+        assertEquals(List.of(), user.getRoleIds());
+    }
+}


### PR DESCRIPTION
Keeps each member's current Discord role ids on their user document: a listener mirrors role add/remove events as they happen, the user grabber adopts roles at startup, and an hourly reconcile sweep catches anything missed while the bot was offline. Role changes persist immediately (not just to the cache) because the Minecraft network reads this field from Mongo for whitelist and rank decisions. Known behavior: leaving the guild still deletes the user document (existing ActivityListener behavior), which also de-whitelists correctly.