### PR TITLE
Fix /gen item, display and powerstone not registering

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -101,7 +101,7 @@ public class GeneratorCommands {
     private static final String COLOR_DESCRIPTION = "The overlay color (e.g., red, blue, #FF0000)";
     private static final String PACK_DESCRIPTION = "The resource pack used to resolve item textures";
     private static final String TOOLTIP_STYLE_DESCRIPTION = "The pack tooltip style to render with (defaults to the rarity's configured style)";
-    private static final String ANIMATED_DESCRIPTION = "Whether animated pack textures render as a GIF (defaults to the texture's own animation data; False forces a static render)";
+    private static final String ANIMATED_DESCRIPTION = "Whether animated pack textures render as a GIF (False forces a static render)";
 
     private static final boolean AUTO_HIDE_ON_ERROR = true;
 


### PR DESCRIPTION
Noticed a few /gen subcommands (`item`, `display` and `powerstone`) stopped showing up in Discord. Turns out the `animated` option's description was 123 characters, and Discord caps option descriptions at 100. The SlashCommands library validates that limit at startup and silently skips any subcommand that fails, which is exactly the three that use that option.

Trimmed the description from:

> Whether animated pack textures render as a GIF (defaults to the texture's own animation data; False forces a static render)

to:

> Whether animated pack textures render as a GIF (False forces a static render)

which puts it back under the limit so all three subcommands register again. The skip is visible in the startup logs as `Validation errors for command 'gen' ... Skipping registration` if you want to double-check before/after.