### PR TITLE
Sync shared-Drive folder permissions from Discord roles

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,11 @@
 #     This folder is mounted read-only at /app/packs, so each config resourcePacks.packs[].path
 #     must be an absolute container path under /app/packs/ (e.g. /app/packs/hypixel_skyblock.zip);
 #     a path that does not resolve inside the container is logged and skipped (that pack renders as vanilla).
+#   - DRIVE_CREDENTIALS_FOLDER_PATH: Path on the vps to the folder holding drive-credentials.json (optional;
+#     defaults to CONFIG_FOLDER_PATH, i.e. the key file sits next to the config file). The Google Drive
+#     permission sync feature stays off if the file or DRIVE_EMAIL_KEY is absent.
+#   - DRIVE_EMAIL_KEY: Base64-encoded 32-byte AES key used to encrypt linked Drive emails at rest (optional;
+#     the Google Drive permission sync feature stays off if unset).
 
 name: Publish
 
@@ -106,12 +111,14 @@ jobs:
             ${{ env.DOCKER_NETWORK != '' && format('--network {0}', env.DOCKER_NETWORK) || '' }} \
             -v ${{ secrets.CONFIG_FOLDER_PATH }}/$(echo "${{ env.ENVIRONMENT_NAME }}" | tr '[:upper:]' '[:lower:]').config.json:/app/$(echo "${{ env.ENVIRONMENT_NAME }}" | tr '[:upper:]' '[:lower:]').config.json \
             -v ${{ secrets.PACKS_FOLDER_PATH != '' && secrets.PACKS_FOLDER_PATH || format('{0}/packs', secrets.CONFIG_FOLDER_PATH) }}:/app/packs:ro \
+            -v ${{ secrets.DRIVE_CREDENTIALS_FOLDER_PATH != '' && secrets.DRIVE_CREDENTIALS_FOLDER_PATH || secrets.CONFIG_FOLDER_PATH }}/drive-credentials.json:/app/secrets/drive-credentials.json:ro \
             -e "JAVA_OPTS=-Dbot.token=${{ secrets[format('BOT_TOKEN_{0}', env.ENVIRONMENT_NAME)] }} \
             -Ddb.mongodb.uri=${{ secrets.MONGO_URI }} \
             -Dbot.environment=${{ env.ENVIRONMENT_NAME }} \
             -Dbot.config=/app/$(echo "${{ env.ENVIRONMENT_NAME }}" | tr '[:upper:]' '[:lower:]').config.json \
             -Dhypixel.key=${{ secrets.HYPIXEL_KEY }} \
-            -Dmetrics.port=${{ env.METRICS_PORT }}" \
+            -Dmetrics.port=${{ env.METRICS_PORT }} \
+            -Ddrive.credentials.path=/app/secrets/drive-credentials.json -Ddrive.email.key=${{ secrets.DRIVE_EMAIL_KEY }}" \
             -e "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" \
             ${{ env.REGISTRY }}/$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
           EOF

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ them.
 The bot tracks a number of custom metrics that are implemented using Prometheus. These metrics can then be viewed using
 a dashboard of your choice that supports Prometheus.
 
+## Google Drive Access Sync
+
+Members link their Google account email with `/drive link` (a modal, so the address never appears in chat, and every
+reply is ephemeral), and the bot keeps their shared-Drive folder access in sync with their Discord roles: holding a
+mapped role grants access at that role's level, holding several mapped roles gets the union of every folder they
+unlock (the most permissive level wins where two roles map to the same folder), and losing a role, leaving, being
+kicked, or being banned revokes every grant and deletes the stored email. Role changes sync instantly through
+Discord's events, and an hourly reconcile sweep re-checks every linked member and heals anything that slipped
+through, including permissions removed by hand in Drive. Linked emails are encrypted at rest with AES-256-GCM, and
+every grant and revoke is logged.
+
 # Running the bot
 
 Please follow the instructions [here](./CONTRIBUTING.md)
@@ -88,3 +99,102 @@ Please follow the instructions [here](./CONTRIBUTING.md)
 # Commands
 
 See the [commands](./app/src/main/java/net/hypixel/nerdbot/app/command) package.
+
+# Google Drive Access Sync Setup
+
+This section covers turning the feature on. It's fully inert until you complete it: `googleDriveConfig.enabled` is
+`false` by default in the config, and even with it set to `true` the bot needs both secrets below before it will do
+anything.
+
+## Secrets
+
+Two JVM system properties, passed the same way as `bot.token`:
+
+- `drive.credentials.path`: path to the Google service account's JSON key file.
+- `drive.email.key`: a base64-encoded 32-byte AES key used to encrypt linked emails at rest. Generate one with:
+
+  ```bash
+  openssl rand -base64 32
+  ```
+
+**Pick this key before the first member links.** There's no rotation path. If you change it later, every
+previously stored email becomes undecryptable and those members will need to relink.
+
+## One-time Google setup
+
+1. Create (or reuse) a GCP project.
+2. Enable the Google Drive API for that project.
+3. Create a service account in the project, using the "Application data" credential type.
+4. Download the service account's JSON key file.
+5. In the shared drive that holds the folders you want to sync, have a Manager add the service account's
+   `client_email` (from the JSON key) as a **Manager** on the shared drive itself, not on individual folders.
+   Drive-level membership covers every subfolder, including ones you add to `folderMappings` later.
+
+## Configuration
+
+The `googleDriveConfig` top-level block in the config file controls the feature (see
+[`example-config.json`](./example-config.json)):
+
+```json
+"googleDriveConfig": {
+  "enabled": false,
+  "folderMappings": [
+    {
+      "roleId": "1234567890123456789",
+      "folderIds": ["example_folder_id_1", "example_folder_id_2"],
+      "accessLevel": "READER"
+    }
+  ]
+}
+```
+
+- `enabled`: turns the subsystem on. Even when `true`, it stays inert until both secrets above are set. The Drive
+  service is built once at startup, so enabling it requires a full bot restart; `/config reload` alone will not
+  activate it.
+- `folderMappings`: one entry per Discord role: the shared-Drive folders that role grants access to, and the level
+  it grants. `accessLevel` is one of `READER`, `COMMENTER`, or `WRITER`.
+- `sendNotificationEmails`: whether members receive Google's share-notification email when the bot grants them
+  folder access (default `true`). Revokes never generate an email; that's a Drive limitation.
+- `notificationEmailMessage`: custom text Google includes in that email, so it explains itself despite the raw
+  service-account sender address. Blank uses Google's default wording.
+- A member holding several mapped roles gets the union of every folder those roles unlock; where two roles map to
+  the same folder at different levels, the more permissive level wins.
+
+## Docker deployment
+
+Production deploys run through the [Publish workflow](.github/workflows/publish.yml): set the `DRIVE_CREDENTIALS_FOLDER_PATH`
+and `DRIVE_EMAIL_KEY` repo secrets, drop `drive-credentials.json` (the service account key, renamed, `chmod 600`) into
+the configured folder on the vps, and the workflow mounts it and passes both `-Ddrive.*` flags automatically. Both
+secrets are optional; leave them unset and the feature stays off. See the secrets list at the top of the workflow
+file for details.
+
+The `docker run`/`docker-compose` snippets below are a manual/local reference, not what production uses. The host
+directory is up to you; these examples use `/opt/nerdbot/` (ours), holding `production.config.json` and
+`drive-credentials.json`. No Dockerfile change is needed; the entrypoint already expands `JAVA_OPTS`.
+
+`docker run`:
+
+```bash
+docker run \
+  -v /opt/nerdbot/production.config.json:/app/production.config.json \
+  -v /opt/nerdbot/drive-credentials.json:/app/secrets/drive-credentials.json:ro \
+  -e JAVA_OPTS="-Dbot.token=<your-bot-token> -Ddb.mongodb.uri=<your-mongodb-uri> ... -Ddrive.credentials.path=/app/secrets/drive-credentials.json -Ddrive.email.key=<your-base64-key>" \
+  nerd-bot
+```
+
+(`...` stands in for whatever other flags you already pass in `JAVA_OPTS`, just append the two Drive ones.)
+
+Equivalent `docker-compose`:
+
+```yaml
+services:
+  nerdbot:
+    volumes:
+      - /opt/nerdbot/production.config.json:/app/production.config.json
+      - /opt/nerdbot/drive-credentials.json:/app/secrets/drive-credentials.json:ro
+    environment:
+      JAVA_OPTS: >-
+        -Dbot.token=<your-bot-token> -Ddb.mongodb.uri=<your-mongodb-uri> ...
+        -Ddrive.credentials.path=/app/secrets/drive-credentials.json
+        -Ddrive.email.key=<your-base64-key>
+```

--- a/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
@@ -6,6 +6,7 @@ import net.aerh.imagegenerator.pack.PackRepository;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Activity;
 import net.hypixel.nerdbot.app.activity.ActivityListener;
+import net.hypixel.nerdbot.app.feature.DrivePermissionSyncFeature;
 import net.hypixel.nerdbot.app.feature.RepositoryAutosaveFeature;
 import net.hypixel.nerdbot.app.feature.RoleReconcileFeature;
 import net.hypixel.nerdbot.app.badge.BadgeManager;
@@ -204,6 +205,9 @@ public class SkyBlockNerdsBot extends AbstractDiscordBot {
         // Always-on safety net: hourly sweep that catches role changes missed by RoleSyncListener
         // while the bot was offline (see RoleReconcileFeature for details).
         features.add(new RoleReconcileFeature());
+
+        // Safety net for Drive folder permissions; inert unless the Drive service is configured.
+        features.add(new DrivePermissionSyncFeature());
 
         return features;
     }

--- a/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
@@ -83,7 +83,7 @@ public class SkyBlockNerdsBot extends AbstractDiscordBot {
 
     /**
      * Static helper for the Drive permission service. Empty whenever the feature
-     * is disabled in config or its secrets are absent — callers no-op in that case.
+     * is disabled in config or its secrets are absent; callers no-op in that case.
      */
     public static java.util.Optional<DrivePermissionService> drivePermissionService() {
         return java.util.Optional.ofNullable(((SkyBlockNerdsBot) DiscordBotEnvironment.getBot()).drivePermissionService);

--- a/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
@@ -9,7 +9,9 @@ import net.hypixel.nerdbot.app.activity.ActivityListener;
 import net.hypixel.nerdbot.app.feature.RepositoryAutosaveFeature;
 import net.hypixel.nerdbot.app.feature.RoleReconcileFeature;
 import net.hypixel.nerdbot.app.badge.BadgeManager;
+import net.hypixel.nerdbot.app.drive.DrivePermissionService;
 import net.hypixel.nerdbot.app.generation.pack.ResourcePackService;
+import net.hypixel.nerdbot.app.listener.DrivePermissionListener;
 import net.hypixel.nerdbot.app.listener.FunListener;
 import net.hypixel.nerdbot.app.listener.MetricsListener;
 import net.hypixel.nerdbot.app.listener.ModLogListener;
@@ -61,6 +63,8 @@ public class SkyBlockNerdsBot extends AbstractDiscordBot {
      */
     private final ResourcePackService resourcePackService = new ResourcePackService(PackRepository.global());
 
+    private DrivePermissionService drivePermissionService;
+
     /**
      * Static helper to get the MessageCache from the current bot instance.
      */
@@ -74,6 +78,14 @@ public class SkyBlockNerdsBot extends AbstractDiscordBot {
      */
     public static ResourcePackService resourcePackService() {
         return ((SkyBlockNerdsBot) DiscordBotEnvironment.getBot()).resourcePackService;
+    }
+
+    /**
+     * Static helper for the Drive permission service. Empty whenever the feature
+     * is disabled in config or its secrets are absent — callers no-op in that case.
+     */
+    public static java.util.Optional<DrivePermissionService> drivePermissionService() {
+        return java.util.Optional.ofNullable(((SkyBlockNerdsBot) DiscordBotEnvironment.getBot()).drivePermissionService);
     }
 
     /**
@@ -121,7 +133,8 @@ public class SkyBlockNerdsBot extends AbstractDiscordBot {
             new MetricsListener(),
             new FunListener(),
             new RoleRestrictedChannelListener(),
-            new RoleSyncListener()
+            new RoleSyncListener(),
+            new DrivePermissionListener()
         ));
 
         return listeners;
@@ -219,6 +232,9 @@ public class SkyBlockNerdsBot extends AbstractDiscordBot {
 
         // Register resource packs with the image generator
         resourcePackService.registerConfiguredPacks(config.getGeneratorConfig().getResourcePacks());
+
+        // Empty when the feature is disabled in config or its secrets are absent; commands/listener no-op in that case
+        drivePermissionService = DrivePermissionService.fromSystemProperties(config.getGoogleDriveConfig()).orElse(null);
 
         // Validate glyph override data (icons.json/stats.json, including any external override
         // files) now instead of on the first /gen parse that needs it

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/DriveCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/DriveCommands.java
@@ -79,7 +79,10 @@ public class DriveCommands {
 
         switch (result.status()) {
             case INVALID_EMAIL -> event.getHook().editOriginal("That doesn't look like a valid email address — nothing was saved.").queue();
-            case DUPLICATE_EMAIL -> event.getHook().editOriginal("That email is already linked to another member. If it's yours, ask a moderator for help.").queue();
+            case DUPLICATE_EMAIL -> {
+                log.warn("Member {} attempted to link an email already linked to another member", event.getUser().getId());
+                event.getHook().editOriginal("That email is already linked to another member. If it's yours, ask a moderator for help.").queue();
+            }
             case LINKED -> {
                 repository.cacheObject(user);
                 repository.saveToDatabaseAsync(user);
@@ -141,6 +144,7 @@ public class DriveCommands {
             return;
         }
 
+        log.info("Member {} invoked /drive sync", event.getUser().getId());
         event.deferReply(true).queue();
         DriveSyncSweep.Result result = new DriveSyncSweep().run();
         event.getHook().editOriginal("Reconcile finished: " + result.summary()).queue();

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/DriveCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/DriveCommands.java
@@ -12,7 +12,7 @@ import net.dv8tion.jda.api.interactions.modals.Modal;
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
 import net.hypixel.nerdbot.app.drive.DriveLinkWorkflow;
 import net.hypixel.nerdbot.app.drive.DrivePermissionService;
-// import net.hypixel.nerdbot.app.drive.DriveSyncSweep; // enabled once DriveSyncSweep lands (next commit)
+import net.hypixel.nerdbot.app.drive.DriveSyncSweep;
 import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
@@ -134,16 +134,15 @@ public class DriveCommands {
             + "\nLast synced: <t:" + user.getDriveAccess().getLastSyncedAt() / 1000 + ":R>").queue();
     }
 
-    // enabled once DriveSyncSweep lands (next commit)
-    // @SlashCommand(name = "drive", subcommand = "sync", description = "Force a full Drive permission reconcile now", guildOnly = true, defaultMemberPermissions = {"ADMINISTRATOR"}, requiredPermissions = {"ADMINISTRATOR"})
-    // public void driveSync(SlashCommandInteractionEvent event) {
-    //     if (SkyBlockNerdsBot.drivePermissionService().isEmpty()) {
-    //         event.reply("Drive access syncing is not configured on this server.").setEphemeral(true).queue();
-    //         return;
-    //     }
-    //
-    //     event.deferReply(true).queue();
-    //     DriveSyncSweep.Result result = new DriveSyncSweep().run();
-    //     event.getHook().editOriginal("Reconcile finished: " + result.summary()).queue();
-    // }
+    @SlashCommand(name = "drive", subcommand = "sync", description = "Force a full Drive permission reconcile now", guildOnly = true, defaultMemberPermissions = {"ADMINISTRATOR"}, requiredPermissions = {"ADMINISTRATOR"})
+    public void driveSync(SlashCommandInteractionEvent event) {
+        if (SkyBlockNerdsBot.drivePermissionService().isEmpty()) {
+            event.reply("Drive access syncing is not configured on this server.").setEphemeral(true).queue();
+            return;
+        }
+
+        event.deferReply(true).queue();
+        DriveSyncSweep.Result result = new DriveSyncSweep().run();
+        event.getHook().editOriginal("Reconcile finished: " + result.summary()).queue();
+    }
 }

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/DriveCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/DriveCommands.java
@@ -1,0 +1,149 @@
+package net.hypixel.nerdbot.app.command;
+
+import lombok.extern.slf4j.Slf4j;
+import net.aerh.slashcommands.api.annotations.SlashCommand;
+import net.aerh.slashcommands.api.annotations.SlashModalHandler;
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.interactions.components.text.TextInput;
+import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
+import net.dv8tion.jda.api.interactions.modals.Modal;
+import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
+import net.hypixel.nerdbot.app.drive.DriveLinkWorkflow;
+import net.hypixel.nerdbot.app.drive.DrivePermissionService;
+// import net.hypixel.nerdbot.app.drive.DriveSyncSweep; // enabled once DriveSyncSweep lands (next commit)
+import net.hypixel.nerdbot.discord.BotEnvironment;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Members link a Google email through a modal (the address never appears in
+ * chat) and the bot mirrors their roles onto shared-Drive folder permissions.
+ * All responses are ephemeral.
+ */
+@Slf4j
+public class DriveCommands {
+
+    private static final String MODAL_ID_PREFIX = "drive-email-modal";
+
+    private static DiscordUserRepository repository() {
+        return BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
+    }
+
+    @SlashCommand(name = "drive", subcommand = "link", description = "Link your Google account email for shared Drive access", guildOnly = true)
+    public void driveLink(SlashCommandInteractionEvent event) {
+        if (SkyBlockNerdsBot.drivePermissionService().isEmpty()) {
+            event.reply("Drive access syncing is not configured on this server.").setEphemeral(true).queue();
+            return;
+        }
+
+        TextInput emailInput = TextInput.create("email", "Google account email", TextInputStyle.SHORT)
+            .setPlaceholder("you@gmail.com")
+            .setRequiredRange(3, 254)
+            .build();
+
+        Modal modal = Modal.create(MODAL_ID_PREFIX + "-" + event.getUser().getId(), "Link Google Drive access")
+            .addComponents(ActionRow.of(emailInput))
+            .build();
+        event.replyModal(modal).queue();
+    }
+
+    @SlashModalHandler(id = MODAL_ID_PREFIX, patterns = {MODAL_ID_PREFIX + "-*"})
+    public void handleEmailModal(ModalInteractionEvent event) {
+        String ownerId = event.getModalId().substring(MODAL_ID_PREFIX.length() + 1);
+        if (!event.getUser().getId().equals(ownerId)) {
+            event.reply("This modal belongs to someone else!").setEphemeral(true).queue();
+            return;
+        }
+
+        Optional<DrivePermissionService> service = SkyBlockNerdsBot.drivePermissionService();
+        if (service.isEmpty() || event.getMember() == null) {
+            event.reply("Drive access syncing is not configured on this server.").setEphemeral(true).queue();
+            return;
+        }
+
+        event.deferReply(true).queue();
+
+        DiscordUserRepository repository = repository();
+        DiscordUser user = repository.findOrCreateById(event.getUser().getId(), event.getUser().getId());
+        List<String> roleIds = event.getMember().getRoles().stream().map(role -> role.getId()).toList();
+
+        DriveLinkWorkflow workflow = new DriveLinkWorkflow(service.get(), SkyBlockNerdsBot.config().getGoogleDriveConfig());
+        DriveLinkWorkflow.LinkResult result = workflow.link(
+            user, event.getValue("email").getAsString(), roleIds, repository.getAllDocuments());
+
+        switch (result.status()) {
+            case INVALID_EMAIL -> event.getHook().editOriginal("That doesn't look like a valid email address — nothing was saved.").queue();
+            case DUPLICATE_EMAIL -> event.getHook().editOriginal("That email is already linked to another member. If it's yours, ask a moderator for help.").queue();
+            case LINKED -> {
+                repository.cacheObject(user);
+                repository.saveToDatabaseAsync(user);
+                String summary = "Linked! You now have access to " + result.outcome().grantedFolders().size() + " folder(s).";
+                if (result.outcome().hasFailures()) {
+                    summary += " " + result.outcome().failedFolders().size() + " folder(s) couldn't be granted right now — this retries automatically within the hour.";
+                }
+                event.getHook().editOriginal(summary).queue();
+            }
+        }
+    }
+
+    @SlashCommand(name = "drive", subcommand = "unlink", description = "Remove your linked email and revoke your Drive access", guildOnly = true)
+    public void driveUnlink(SlashCommandInteractionEvent event) {
+        Optional<DrivePermissionService> service = SkyBlockNerdsBot.drivePermissionService();
+        if (service.isEmpty()) {
+            event.reply("Drive access syncing is not configured on this server.").setEphemeral(true).queue();
+            return;
+        }
+
+        event.deferReply(true).queue();
+        DiscordUserRepository repository = repository();
+        DiscordUser user = repository.findById(event.getUser().getId()).toOptional().orElse(null);
+
+        DriveLinkWorkflow workflow = new DriveLinkWorkflow(service.get(), SkyBlockNerdsBot.config().getGoogleDriveConfig());
+        if (user == null || !workflow.unlink(user)) {
+            event.getHook().editOriginal("You don't have a linked email.").queue();
+            return;
+        }
+
+        repository.cacheObject(user);
+        repository.saveToDatabaseAsync(user);
+        event.getHook().editOriginal("Unlinked — your Drive access has been revoked and your email deleted.").queue();
+    }
+
+    @SlashCommand(name = "drive", subcommand = "status", description = "Show your current Drive link and folder access", guildOnly = true)
+    public void driveStatus(SlashCommandInteractionEvent event) {
+        event.deferReply(true).queue();
+        DiscordUser user = repository().findById(event.getUser().getId()).toOptional().orElse(null);
+
+        if (user == null || user.getDriveAccess() == null) {
+            event.getHook().editOriginal("No email linked. Use `/drive link` to get Drive access.").queue();
+            return;
+        }
+
+        String grants = user.getDriveAccess().getGrants().isEmpty()
+            ? "none yet"
+            : user.getDriveAccess().getGrants().stream()
+                .map(grant -> grant.folderId() + " (" + grant.accessLevel().toLowerCase() + ")")
+                .collect(Collectors.joining(", "));
+        event.getHook().editOriginal("Email linked ✔ — folder access: " + grants
+            + "\nLast synced: <t:" + user.getDriveAccess().getLastSyncedAt() / 1000 + ":R>").queue();
+    }
+
+    // enabled once DriveSyncSweep lands (next commit)
+    // @SlashCommand(name = "drive", subcommand = "sync", description = "Force a full Drive permission reconcile now", guildOnly = true, defaultMemberPermissions = {"ADMINISTRATOR"}, requiredPermissions = {"ADMINISTRATOR"})
+    // public void driveSync(SlashCommandInteractionEvent event) {
+    //     if (SkyBlockNerdsBot.drivePermissionService().isEmpty()) {
+    //         event.reply("Drive access syncing is not configured on this server.").setEphemeral(true).queue();
+    //         return;
+    //     }
+    //
+    //     event.deferReply(true).queue();
+    //     DriveSyncSweep.Result result = new DriveSyncSweep().run();
+    //     event.getHook().editOriginal("Reconcile finished: " + result.summary()).queue();
+    // }
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/command/DriveCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/DriveCommands.java
@@ -11,10 +11,12 @@ import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
 import net.dv8tion.jda.api.interactions.modals.Modal;
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
 import net.hypixel.nerdbot.app.drive.DriveLinkWorkflow;
+import net.hypixel.nerdbot.app.drive.DriveLogEmbeds;
 import net.hypixel.nerdbot.app.drive.DrivePermissionService;
 import net.hypixel.nerdbot.app.drive.DriveSyncSweep;
 import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.drive.DriveGrant;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
 
 import java.util.List;
@@ -30,6 +32,7 @@ import java.util.stream.Collectors;
 public class DriveCommands {
 
     private static final String MODAL_ID_PREFIX = "drive-email-modal";
+    private static final String NOT_CONFIGURED_MESSAGE = "Drive access syncing is not configured on this server.";
 
     private static DiscordUserRepository repository() {
         return BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
@@ -38,7 +41,7 @@ public class DriveCommands {
     @SlashCommand(name = "drive", subcommand = "link", description = "Link your Google account email for shared Drive access", guildOnly = true)
     public void driveLink(SlashCommandInteractionEvent event) {
         if (SkyBlockNerdsBot.drivePermissionService().isEmpty()) {
-            event.reply("Drive access syncing is not configured on this server.").setEphemeral(true).queue();
+            event.reply(NOT_CONFIGURED_MESSAGE).setEphemeral(true).queue();
             return;
         }
 
@@ -63,7 +66,7 @@ public class DriveCommands {
 
         Optional<DrivePermissionService> service = SkyBlockNerdsBot.drivePermissionService();
         if (service.isEmpty() || event.getMember() == null) {
-            event.reply("Drive access syncing is not configured on this server.").setEphemeral(true).queue();
+            event.reply(NOT_CONFIGURED_MESSAGE).setEphemeral(true).queue();
             return;
         }
 
@@ -78,7 +81,7 @@ public class DriveCommands {
             user, event.getValue("email").getAsString(), roleIds, repository.getAllDocuments());
 
         switch (result.status()) {
-            case INVALID_EMAIL -> event.getHook().editOriginal("That doesn't look like a valid email address — nothing was saved.").queue();
+            case INVALID_EMAIL -> event.getHook().editOriginal("That doesn't look like a valid email address, so nothing was saved.").queue();
             case DUPLICATE_EMAIL -> {
                 log.warn("Member {} attempted to link an email already linked to another member", event.getUser().getId());
                 event.getHook().editOriginal("That email is already linked to another member. If it's yours, ask a moderator for help.").queue();
@@ -86,9 +89,27 @@ public class DriveCommands {
             case LINKED -> {
                 repository.cacheObject(user);
                 repository.saveToDatabaseAsync(user);
-                String summary = "Linked! You now have access to " + result.outcome().grantedFolders().size() + " folder(s).";
-                if (result.outcome().hasFailures()) {
-                    summary += " " + result.outcome().failedFolders().size() + " folder(s) couldn't be granted right now — this retries automatically within the hour.";
+                DriveLogEmbeds.postAccessChange(service.get(), user.getDiscordId(),
+                    result.outcome().grantedFolders(), result.outcome().revokedFolders());
+                int granted = result.outcome().grantedFolders().size();
+                int failedCount = result.outcome().failedFolders().size();
+                long rateLimited = result.outcome().failedFolders().stream()
+                    .filter(failure -> failure.reason() != null && failure.reason().toLowerCase().contains("ratelimit"))
+                    .count();
+                long rejectedByGoogle = result.outcome().failedFolders().stream()
+                    .filter(failure -> failure.statusCode() >= 400 && failure.statusCode() < 500)
+                    .count() - rateLimited;
+
+                String summary;
+                if (!result.outcome().hasFailures()) {
+                    summary = "Linked! You now have access to " + granted + " folder(s).";
+                } else if (rateLimited > 0) {
+                    summary = "Linked! " + (granted > 0 ? granted + " folder(s) granted now and " : "Your ") + rateLimited
+                        + " folder(s) queued while Google rate limits us; they'll arrive within the hour.";
+                } else if (rejectedByGoogle > 0) {
+                    summary = "Google rejected that address for " + rejectedByGoogle + " folder(s). Make sure it's a Google account email.";
+                } else {
+                    summary = "Linked! " + failedCount + " folder(s) couldn't be granted right now; retrying within the hour.";
                 }
                 event.getHook().editOriginal(summary).queue();
             }
@@ -99,7 +120,7 @@ public class DriveCommands {
     public void driveUnlink(SlashCommandInteractionEvent event) {
         Optional<DrivePermissionService> service = SkyBlockNerdsBot.drivePermissionService();
         if (service.isEmpty()) {
-            event.reply("Drive access syncing is not configured on this server.").setEphemeral(true).queue();
+            event.reply(NOT_CONFIGURED_MESSAGE).setEphemeral(true).queue();
             return;
         }
 
@@ -108,14 +129,19 @@ public class DriveCommands {
         DiscordUser user = repository.findById(event.getUser().getId()).toOptional().orElse(null);
 
         DriveLinkWorkflow workflow = new DriveLinkWorkflow(service.get(), SkyBlockNerdsBot.config().getGoogleDriveConfig());
+        List<String> heldFolders = user == null || user.getDriveAccess() == null
+            ? List.of()
+            : user.getDriveAccess().getGrants().stream().map(DriveGrant::folderId).toList();
         if (user == null || !workflow.unlink(user)) {
             event.getHook().editOriginal("You don't have a linked email.").queue();
             return;
         }
 
         repository.cacheObject(user);
-        repository.saveToDatabaseAsync(user);
-        event.getHook().editOriginal("Unlinked — your Drive access has been revoked and your email deleted.").queue();
+        // workflow.unlink() always nulls driveAccess on success; a $set save can't clear it from Mongo, so unset the field directly.
+        repository.unsetField(user.getDiscordId(), "driveAccess");
+        DriveLogEmbeds.postAccessChange(service.get(), user.getDiscordId(), List.of(), heldFolders);
+        event.getHook().editOriginal("Unlinked. Your Drive access has been revoked and your email deleted.").queue();
     }
 
     @SlashCommand(name = "drive", subcommand = "status", description = "Show your current Drive link and folder access", guildOnly = true)
@@ -133,14 +159,14 @@ public class DriveCommands {
             : user.getDriveAccess().getGrants().stream()
                 .map(grant -> grant.folderId() + " (" + grant.accessLevel().toLowerCase() + ")")
                 .collect(Collectors.joining(", "));
-        event.getHook().editOriginal("Email linked ✔ — folder access: " + grants
+        event.getHook().editOriginal("Email linked. Folder access: " + grants
             + "\nLast synced: <t:" + user.getDriveAccess().getLastSyncedAt() / 1000 + ":R>").queue();
     }
 
     @SlashCommand(name = "drive", subcommand = "sync", description = "Force a full Drive permission reconcile now", guildOnly = true, defaultMemberPermissions = {"ADMINISTRATOR"}, requiredPermissions = {"ADMINISTRATOR"})
     public void driveSync(SlashCommandInteractionEvent event) {
         if (SkyBlockNerdsBot.drivePermissionService().isEmpty()) {
-            event.reply("Drive access syncing is not configured on this server.").setEphemeral(true).queue();
+            event.reply(NOT_CONFIGURED_MESSAGE).setEphemeral(true).queue();
             return;
         }
 

--- a/app/src/main/java/net/hypixel/nerdbot/app/config/ExampleValue.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/config/ExampleValue.java
@@ -1,0 +1,18 @@
+package net.hypixel.nerdbot.app.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Overrides the config generator's heuristic example value for a field in the
+ * generated example-config.json. The raw string is emitted as the example for
+ * string fields; "true"/"false" are parsed for booleans.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ExampleValue {
+
+    String value();
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/config/GoogleDriveConfig.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/config/GoogleDriveConfig.java
@@ -19,6 +19,24 @@ import java.util.List;
 @ToString
 public class GoogleDriveConfig {
 
+    @ExampleValue("false")
     private boolean enabled = false;
+
     private List<DriveFolderMapping> folderMappings = new ArrayList<>();
+
+    /**
+     * Whether Google sends its share-notification email when the bot grants
+     * folder access. Revokes never notify; that is a Drive limitation.
+     */
+    @ExampleValue("true")
+    private boolean sendNotificationEmails = true;
+
+    /**
+     * Custom text Google includes in the share-notification email. Helps the
+     * email explain itself, since service accounts cannot have a friendly
+     * sender name. Blank uses Google's default wording; ignored entirely when
+     * sendNotificationEmails is off.
+     */
+    @ExampleValue("This folder was shared automatically by the SkyBlock Nerds bot based on your Discord roles.")
+    private String notificationEmailMessage = "This folder was shared automatically by the SkyBlock Nerds bot based on your Discord roles.";
 }

--- a/app/src/main/java/net/hypixel/nerdbot/app/config/GoogleDriveConfig.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/config/GoogleDriveConfig.java
@@ -1,0 +1,24 @@
+package net.hypixel.nerdbot.app.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import net.hypixel.nerdbot.app.config.objects.DriveFolderMapping;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Google Drive folder-permission sync. Disabled by default; even when enabled,
+ * the subsystem stays inert unless the JVM was started with the
+ * drive.credentials.path and drive.email.key system properties (secrets never
+ * live in this file).
+ */
+@Getter
+@Setter
+@ToString
+public class GoogleDriveConfig {
+
+    private boolean enabled = false;
+    private List<DriveFolderMapping> folderMappings = new ArrayList<>();
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/config/NerdBotConfig.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/config/NerdBotConfig.java
@@ -48,6 +48,11 @@ public class NerdBotConfig extends DiscordBotConfig {
     private GeneratorConfig generatorConfig = new GeneratorConfig();
 
     /**
+     * Configuration for Google Drive folder permission syncing
+     */
+    private GoogleDriveConfig googleDriveConfig = new GoogleDriveConfig();
+
+    /**
      * The limit of messages that the bot will curate in one go
      * Default value is 100 messages
      */

--- a/app/src/main/java/net/hypixel/nerdbot/app/config/objects/DriveFolderMapping.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/config/objects/DriveFolderMapping.java
@@ -3,6 +3,7 @@ package net.hypixel.nerdbot.app.config.objects;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import net.hypixel.nerdbot.app.config.ExampleValue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,5 +27,6 @@ public class DriveFolderMapping {
      * Held as a string so a config typo disables one mapping (with a warning)
      * instead of failing the whole config load.
      */
+    @ExampleValue("READER")
     private String accessLevel = "READER";
 }

--- a/app/src/main/java/net/hypixel/nerdbot/app/config/objects/DriveFolderMapping.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/config/objects/DriveFolderMapping.java
@@ -1,0 +1,30 @@
+package net.hypixel.nerdbot.app.config.objects;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Maps one Discord role to the shared-Drive folders its holders can access and
+ * the level they get. A member holding several mapped roles receives the union
+ * of all their mappings; where two mappings hit the same folder, the more
+ * permissive level wins.
+ */
+@Getter
+@Setter
+@ToString
+public class DriveFolderMapping {
+
+    private String roleId;
+    private List<String> folderIds = new ArrayList<>();
+
+    /**
+     * A {@code DriveAccessLevel} enum name: READER, COMMENTER, or WRITER.
+     * Held as a string so a config typo disables one mapping (with a warning)
+     * instead of failing the whole config load.
+     */
+    private String accessLevel = "READER";
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveLinkWorkflow.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveLinkWorkflow.java
@@ -1,0 +1,95 @@
+package net.hypixel.nerdbot.app.drive;
+
+import lombok.extern.slf4j.Slf4j;
+import net.hypixel.nerdbot.app.config.GoogleDriveConfig;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.drive.DriveAccess;
+
+import java.util.Collection;
+
+/**
+ * The link/unlink lifecycle around {@link DrivePermissionService}, kept free of
+ * JDA types so every rule (validation, duplicate emails, relink semantics,
+ * delete-on-forget) is unit-testable. The command and listener layers are thin
+ * glue over this class; persistence stays with the caller.
+ */
+@Slf4j
+public class DriveLinkWorkflow {
+
+    private final DrivePermissionService service;
+    private final GoogleDriveConfig config;
+
+    public enum Status {
+        LINKED,
+        INVALID_EMAIL,
+        DUPLICATE_EMAIL
+    }
+
+    public record LinkResult(Status status, DrivePermissionService.SyncOutcome outcome) {
+    }
+
+    public DriveLinkWorkflow(DrivePermissionService service, GoogleDriveConfig config) {
+        this.service = service;
+        this.config = config;
+    }
+
+    /**
+     * Links (or relinks) a member's email and immediately syncs their grants.
+     * A relink revokes all grants made under the previous address before the
+     * new one is stored — the old email must lose access atomically with being
+     * forgotten.
+     */
+    public LinkResult link(DiscordUser user, String rawEmail, Collection<String> roleIds, Collection<DiscordUser> allUsers) {
+        String email = DrivePermissionService.normalizeEmail(rawEmail);
+        if (!DrivePermissionService.isValidEmail(email)) {
+            return new LinkResult(Status.INVALID_EMAIL, null);
+        }
+
+        String emailHash = service.hashEmail(email);
+        boolean linkedElsewhere = allUsers.stream()
+            .filter(other -> !other.getDiscordId().equals(user.getDiscordId()))
+            .anyMatch(other -> other.getDriveAccess() != null && emailHash.equals(other.getDriveAccess().getEmailHash()));
+        if (linkedElsewhere) {
+            return new LinkResult(Status.DUPLICATE_EMAIL, null);
+        }
+
+        if (user.getDriveAccess() != null && !service.revokeAll(user.getDriveAccess())) {
+            log.error("Partial revoke while relinking {} — continuing; reconcile cannot heal the old address, check Drive manually", user.getDiscordId());
+        }
+
+        user.setDriveAccess(new DriveAccess(service.encryptEmail(email), emailHash));
+        DrivePermissionService.SyncOutcome outcome = service.syncGrants(user.getDriveAccess(), roleIds, config);
+        log.info("Linked Drive access for {}: {} granted, {} failed", user.getDiscordId(),
+            outcome.grantedFolders().size(), outcome.failedFolders().size());
+        return new LinkResult(Status.LINKED, outcome);
+    }
+
+    /**
+     * User-initiated unlink: revoke everything and erase the stored email.
+     *
+     * @return false when the member had nothing linked
+     */
+    public boolean unlink(DiscordUser user) {
+        if (user.getDriveAccess() == null) {
+            return false;
+        }
+        revokeAndForget(user);
+        return true;
+    }
+
+    /**
+     * Leave/kick/ban path (spec §5): revoke with retries, then delete state
+     * regardless — a failed revoke is logged loudly because nothing can heal it
+     * once the permission ids are gone.
+     */
+    public void revokeAndForget(DiscordUser user) {
+        if (user.getDriveAccess() == null) {
+            return;
+        }
+        if (!service.revokeAll(user.getDriveAccess())) {
+            log.error("Could not revoke every Drive permission for departing member {} — REMAINING GRANTS MUST BE REMOVED MANUALLY IN DRIVE", user.getDiscordId());
+        }
+        user.setDriveAccess(null);
+        log.info("Cleared Drive link state for {}", user.getDiscordId());
+    }
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveLinkWorkflow.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveLinkWorkflow.java
@@ -53,12 +53,16 @@ public class DriveLinkWorkflow {
             return new LinkResult(Status.DUPLICATE_EMAIL, null);
         }
 
-        if (user.getDriveAccess() != null && !service.revokeAll(user.getDriveAccess())) {
-            log.error("Partial revoke while relinking {} — continuing; reconcile cannot heal the old address, check Drive manually", user.getDiscordId());
+        if (user.getDriveAccess() != null) {
+            int existingGrantCount = user.getDriveAccess().getGrants().size();
+            log.info("Member {} is relinking their Drive email; revoking {} existing grant(s) first", user.getDiscordId(), existingGrantCount);
+            if (!service.revokeAll(user.getDiscordId(), user.getDriveAccess())) {
+                log.error("Partial revoke while relinking {} — continuing; reconcile cannot heal the old address, check Drive manually", user.getDiscordId());
+            }
         }
 
         user.setDriveAccess(new DriveAccess(service.encryptEmail(email), emailHash));
-        DrivePermissionService.SyncOutcome outcome = service.syncGrants(user.getDriveAccess(), roleIds, config);
+        DrivePermissionService.SyncOutcome outcome = service.syncGrants(user.getDiscordId(), user.getDriveAccess(), roleIds, config);
         log.info("Linked Drive access for {}: {} granted, {} failed", user.getDiscordId(),
             outcome.grantedFolders().size(), outcome.failedFolders().size());
         return new LinkResult(Status.LINKED, outcome);
@@ -74,6 +78,7 @@ public class DriveLinkWorkflow {
             return false;
         }
         revokeAndForget(user);
+        log.info("Member {} unlinked their Drive email", user.getDiscordId());
         return true;
     }
 
@@ -86,7 +91,7 @@ public class DriveLinkWorkflow {
         if (user.getDriveAccess() == null) {
             return;
         }
-        if (!service.revokeAll(user.getDriveAccess())) {
+        if (!service.revokeAll(user.getDiscordId(), user.getDriveAccess())) {
             log.error("Could not revoke every Drive permission for departing member {} — REMAINING GRANTS MUST BE REMOVED MANUALLY IN DRIVE", user.getDiscordId());
         }
         user.setDriveAccess(null);

--- a/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveLinkWorkflow.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveLinkWorkflow.java
@@ -36,7 +36,7 @@ public class DriveLinkWorkflow {
     /**
      * Links (or relinks) a member's email and immediately syncs their grants.
      * A relink revokes all grants made under the previous address before the
-     * new one is stored — the old email must lose access atomically with being
+     * new one is stored: the old email must lose access atomically with being
      * forgotten.
      */
     public LinkResult link(DiscordUser user, String rawEmail, Collection<String> roleIds, Collection<DiscordUser> allUsers) {
@@ -57,7 +57,7 @@ public class DriveLinkWorkflow {
             int existingGrantCount = user.getDriveAccess().getGrants().size();
             log.info("Member {} is relinking their Drive email; revoking {} existing grant(s) first", user.getDiscordId(), existingGrantCount);
             if (!service.revokeAll(user.getDiscordId(), user.getDriveAccess())) {
-                log.error("Partial revoke while relinking {} — continuing; reconcile cannot heal the old address, check Drive manually", user.getDiscordId());
+                log.error("Partial revoke while relinking {}, continuing; reconcile cannot heal the old address, check Drive manually", user.getDiscordId());
             }
         }
 
@@ -84,7 +84,7 @@ public class DriveLinkWorkflow {
 
     /**
      * Leave/kick/ban path (spec §5): revoke with retries, then delete state
-     * regardless — a failed revoke is logged loudly because nothing can heal it
+     * regardless; a failed revoke is logged loudly because nothing can heal it
      * once the permission ids are gone.
      */
     public void revokeAndForget(DiscordUser user) {
@@ -92,7 +92,7 @@ public class DriveLinkWorkflow {
             return;
         }
         if (!service.revokeAll(user.getDiscordId(), user.getDriveAccess())) {
-            log.error("Could not revoke every Drive permission for departing member {} — REMAINING GRANTS MUST BE REMOVED MANUALLY IN DRIVE", user.getDiscordId());
+            log.error("Could not revoke every Drive permission for departing member {}; REMAINING GRANTS MUST BE REMOVED MANUALLY IN DRIVE", user.getDiscordId());
         }
         user.setDriveAccess(null);
         log.info("Cleared Drive link state for {}", user.getDiscordId());

--- a/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveLogEmbeds.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveLogEmbeds.java
@@ -1,0 +1,54 @@
+package net.hypixel.nerdbot.app.drive;
+
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.hypixel.nerdbot.discord.cache.ChannelCache;
+import net.hypixel.nerdbot.marmalade.discord.EmbedFactory;
+
+import java.awt.Color;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Posts Drive access changes to the log channel, mirroring ModLogListener's
+ * embed style. Folder names resolve through the service's cached Drive lookup
+ * with the raw id shown alongside. Posting is best-effort: a log-channel
+ * failure never breaks the permission change it describes.
+ */
+@Slf4j
+public final class DriveLogEmbeds {
+
+    private DriveLogEmbeds() {
+    }
+
+    public static void postAccessChange(DrivePermissionService service, String memberId,
+                                        List<String> grantedFolders, List<String> revokedFolders) {
+        if (grantedFolders.isEmpty() && revokedFolders.isEmpty()) {
+            return;
+        }
+
+        try {
+            Color color = revokedFolders.isEmpty() ? Color.GREEN : grantedFolders.isEmpty() ? Color.RED : Color.ORANGE;
+            EmbedBuilder embed = EmbedFactory.create("Drive access updated", null, color)
+                .addField("User", "<@" + memberId + ">", false)
+                .addField("User ID", memberId, false);
+
+            if (!grantedFolders.isEmpty()) {
+                embed.addField("Granted", folderLines(service, grantedFolders), false);
+            }
+            if (!revokedFolders.isEmpty()) {
+                embed.addField("Revoked", folderLines(service, revokedFolders), false);
+            }
+
+            ChannelCache.sendToLogChannel(embed.build());
+        } catch (Exception e) {
+            log.warn("Failed to post Drive access log embed for {}", memberId, e);
+        }
+    }
+
+    private static String folderLines(DrivePermissionService service, List<String> folderIds) {
+        return folderIds.stream()
+            .map(folderId -> service.folderDisplayName(folderId) + " (`" + folderId + "`)")
+            .collect(Collectors.joining("\n"));
+    }
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/drive/DrivePermissionService.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/drive/DrivePermissionService.java
@@ -136,7 +136,7 @@ public class DrivePermissionService {
      * Converges this member's Drive permissions onto what their roles say they
      * should have. Mutates {@code access}; the caller persists the user.
      */
-    public SyncOutcome syncGrants(DriveAccess access, Collection<String> roleIds, GoogleDriveConfig config) {
+    public SyncOutcome syncGrants(String memberId, DriveAccess access, Collection<String> roleIds, GoogleDriveConfig config) {
         Map<String, DriveAccessLevel> desired = computeDesiredGrants(roleIds, config);
         List<String> granted = new ArrayList<>();
         List<String> revoked = new ArrayList<>();
@@ -158,12 +158,17 @@ public class DrivePermissionService {
                 continue;
             }
 
+            if (wanted != null) {
+                log.info("Access level change for member {} on folder {}: {} -> {}", memberId, grant.folderId(), grant.accessLevel(), wanted);
+            }
+
             try {
                 withRetry(() -> {
                     client.revokePermission(grant.folderId(), grant.permissionId());
                     return null;
                 });
                 revoked.add(grant.folderId());
+                log.info("Revoked {} on folder {} for member {} (permission {})", grant.accessLevel(), grant.folderId(), memberId, grant.permissionId());
             } catch (DriveApiException e) {
                 log.error("Failed to revoke Drive permission on folder {} (kept for reconcile)", grant.folderId(), e);
                 failed.add(grant.folderId());
@@ -185,6 +190,7 @@ public class DrivePermissionService {
                 String permissionId = withRetry(() -> client.grantPermission(entry.getKey(), email.get(), entry.getValue()));
                 keptGrants.add(new DriveGrant(entry.getKey(), permissionId, entry.getValue().name()));
                 granted.add(entry.getKey());
+                log.info("Granted {} on folder {} to member {} (permission {})", entry.getValue(), entry.getKey(), memberId, permissionId);
             } catch (DriveApiException e) {
                 log.error("Failed to grant Drive permission on folder {} (reconcile will retry)", entry.getKey(), e);
                 failed.add(entry.getKey());
@@ -193,6 +199,11 @@ public class DrivePermissionService {
 
         access.setGrants(keptGrants);
         access.setLastSyncedAt(System.currentTimeMillis());
+
+        if (granted.isEmpty() && revoked.isEmpty() && failed.isEmpty()) {
+            log.debug("Drive sync no-op for member {} ({} grants unchanged)", memberId, access.getGrants().size());
+        }
+
         return new SyncOutcome(granted, revoked, failed);
     }
 
@@ -203,7 +214,7 @@ public class DrivePermissionService {
      *
      * @return false if any revoke ultimately failed (caller should log loudly)
      */
-    public boolean revokeAll(DriveAccess access) {
+    public boolean revokeAll(String memberId, DriveAccess access) {
         boolean allRevoked = true;
         List<DriveGrant> remaining = new ArrayList<>();
 
@@ -213,6 +224,7 @@ public class DrivePermissionService {
                     client.revokePermission(grant.folderId(), grant.permissionId());
                     return null;
                 });
+                log.info("Revoked {} on folder {} for member {} (permission {})", grant.accessLevel(), grant.folderId(), memberId, grant.permissionId());
             } catch (DriveApiException e) {
                 log.error("Failed to revoke Drive permission on folder {} during full revoke", grant.folderId(), e);
                 remaining.add(grant);

--- a/app/src/main/java/net/hypixel/nerdbot/app/drive/DrivePermissionService.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/drive/DrivePermissionService.java
@@ -8,6 +8,7 @@ import net.hypixel.nerdbot.marmalade.google.GoogleTokenProvider;
 import net.hypixel.nerdbot.marmalade.google.ServiceAccountKey;
 import net.hypixel.nerdbot.marmalade.google.drive.DriveAccessLevel;
 import net.hypixel.nerdbot.marmalade.google.drive.DriveApiException;
+import net.hypixel.nerdbot.marmalade.google.drive.DrivePermission;
 import net.hypixel.nerdbot.marmalade.google.drive.DrivePermissionClient;
 import net.hypixel.nerdbot.marmalade.google.drive.HttpDrivePermissionClient;
 import net.hypixel.nerdbot.marmalade.google.drive.TransientDriveApiException;
@@ -263,5 +264,14 @@ public class DrivePermissionService {
             log.warn("Stored Drive email could not be decrypted (key rotation or corrupt data) — treating member as unsyncable", e);
             return Optional.empty();
         }
+    }
+
+    /**
+     * Lists all current permissions on a folder. Used by the reconcile sweep to
+     * detect permissions that were deleted directly in Drive so they can be
+     * re-granted if the user still holds the mapped role.
+     */
+    public List<DrivePermission> listFolderPermissions(String folderId) throws DriveApiException {
+        return withRetry(() -> client.listPermissions(folderId));
     }
 }

--- a/app/src/main/java/net/hypixel/nerdbot/app/drive/DrivePermissionService.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/drive/DrivePermissionService.java
@@ -1,0 +1,267 @@
+package net.hypixel.nerdbot.app.drive;
+
+import lombok.extern.slf4j.Slf4j;
+import net.hypixel.nerdbot.app.config.GoogleDriveConfig;
+import net.hypixel.nerdbot.app.config.objects.DriveFolderMapping;
+import net.hypixel.nerdbot.marmalade.google.GoogleAuthException;
+import net.hypixel.nerdbot.marmalade.google.GoogleTokenProvider;
+import net.hypixel.nerdbot.marmalade.google.ServiceAccountKey;
+import net.hypixel.nerdbot.marmalade.google.drive.DriveAccessLevel;
+import net.hypixel.nerdbot.marmalade.google.drive.DriveApiException;
+import net.hypixel.nerdbot.marmalade.google.drive.DrivePermissionClient;
+import net.hypixel.nerdbot.marmalade.google.drive.HttpDrivePermissionClient;
+import net.hypixel.nerdbot.marmalade.google.drive.TransientDriveApiException;
+import net.hypixel.nerdbot.marmalade.resilience.Retry;
+import net.hypixel.nerdbot.marmalade.security.AesGcmCipher;
+import net.hypixel.nerdbot.marmalade.security.CipherException;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.drive.DriveAccess;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.drive.DriveGrant;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Grants and revokes shared-Drive folder permissions so they mirror a member's
+ * Discord roles. All Drive calls retry transient failures; permanent failures
+ * are reported per-folder and the stored grant state stays consistent either
+ * way, so the hourly reconcile sweep can heal anything that slipped through.
+ * Emails only ever exist in plaintext transiently in memory — never in logs,
+ * never in the database.
+ */
+@Slf4j
+public class DrivePermissionService {
+
+    public static final String CREDENTIALS_PATH_PROPERTY = "drive.credentials.path";
+    public static final String EMAIL_KEY_PROPERTY = "drive.email.key";
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
+    private static final int MAX_ATTEMPTS = 3;
+
+    private final AesGcmCipher cipher;
+    private final DrivePermissionClient client;
+
+    public DrivePermissionService(AesGcmCipher cipher, DrivePermissionClient client) {
+        this.cipher = cipher;
+        this.client = client;
+    }
+
+    /**
+     * Builds the service from JVM system properties, or empty when the feature
+     * is disabled or incompletely configured — callers treat empty as "feature
+     * off" and stay inert.
+     */
+    public static Optional<DrivePermissionService> fromSystemProperties(GoogleDriveConfig config) {
+        if (config == null || !config.isEnabled()) {
+            log.info("Google Drive permission sync is disabled in config");
+            return Optional.empty();
+        }
+
+        String credentialsPath = System.getProperty(CREDENTIALS_PATH_PROPERTY);
+        String emailKey = System.getProperty(EMAIL_KEY_PROPERTY);
+
+        if (credentialsPath == null || emailKey == null) {
+            log.warn("Google Drive sync enabled in config but missing {} or {} system property — feature stays off",
+                CREDENTIALS_PATH_PROPERTY, EMAIL_KEY_PROPERTY);
+            return Optional.empty();
+        }
+
+        try {
+            AesGcmCipher cipher = AesGcmCipher.fromBase64Key(emailKey);
+            ServiceAccountKey key = ServiceAccountKey.fromFile(Path.of(credentialsPath));
+            DrivePermissionClient client = HttpDrivePermissionClient.createDefault(new GoogleTokenProvider(key));
+            log.info("Google Drive permission sync active ({} folder mappings)", config.getFolderMappings().size());
+            return Optional.of(new DrivePermissionService(cipher, client));
+        } catch (GoogleAuthException | IllegalArgumentException e) {
+            log.error("Google Drive sync misconfigured — feature stays off", e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * The folder access a member with these roles should have: union across all
+     * mapped roles they hold, most permissive level per folder. Pure function.
+     */
+    public static Map<String, DriveAccessLevel> computeDesiredGrants(Collection<String> roleIds, GoogleDriveConfig config) {
+        Map<String, DriveAccessLevel> desired = new HashMap<>();
+        if (config == null || !config.isEnabled() || roleIds == null) {
+            return desired;
+        }
+
+        Set<String> held = new HashSet<>(roleIds);
+        for (DriveFolderMapping mapping : config.getFolderMappings()) {
+            if (!held.contains(mapping.getRoleId())) {
+                continue;
+            }
+
+            Optional<DriveAccessLevel> level = parseLevel(mapping.getAccessLevel());
+            if (level.isEmpty()) {
+                log.warn("Ignoring Drive mapping for role {}: unknown access level '{}'", mapping.getRoleId(), mapping.getAccessLevel());
+                continue;
+            }
+
+            for (String folderId : mapping.getFolderIds()) {
+                desired.merge(folderId, level.get(), (a, b) -> b.outranks(a) ? b : a);
+            }
+        }
+        return desired;
+    }
+
+    private static Optional<DriveAccessLevel> parseLevel(String name) {
+        try {
+            return Optional.of(DriveAccessLevel.valueOf(name));
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return Optional.empty();
+        }
+    }
+
+    /** What one sync pass changed in Drive, for command feedback and logs. */
+    public record SyncOutcome(List<String> grantedFolders, List<String> revokedFolders, List<String> failedFolders) {
+
+        public boolean hasFailures() {
+            return !failedFolders.isEmpty();
+        }
+    }
+
+    /**
+     * Converges this member's Drive permissions onto what their roles say they
+     * should have. Mutates {@code access}; the caller persists the user.
+     */
+    public SyncOutcome syncGrants(DriveAccess access, Collection<String> roleIds, GoogleDriveConfig config) {
+        Map<String, DriveAccessLevel> desired = computeDesiredGrants(roleIds, config);
+        List<String> granted = new ArrayList<>();
+        List<String> revoked = new ArrayList<>();
+        List<String> failed = new ArrayList<>();
+
+        Optional<String> email = decryptEmail(access);
+        if (email.isEmpty()) {
+            // Can't grant without the address; can't safely revoke either (state may be fine)
+            return new SyncOutcome(granted, revoked, new ArrayList<>(desired.keySet()));
+        }
+
+        // Revoke grants that are stale or at the wrong level
+        List<DriveGrant> keptGrants = new ArrayList<>();
+        for (DriveGrant grant : access.getGrants()) {
+            DriveAccessLevel wanted = desired.get(grant.folderId());
+            boolean levelMatches = wanted != null && wanted.name().equals(grant.accessLevel());
+            if (levelMatches) {
+                keptGrants.add(grant);
+                continue;
+            }
+
+            try {
+                withRetry(() -> {
+                    client.revokePermission(grant.folderId(), grant.permissionId());
+                    return null;
+                });
+                revoked.add(grant.folderId());
+            } catch (DriveApiException e) {
+                log.error("Failed to revoke Drive permission on folder {} (kept for reconcile)", grant.folderId(), e);
+                failed.add(grant.folderId());
+                keptGrants.add(grant); // still tracked so reconcile retries the revoke
+            }
+        }
+
+        // Grant what's missing
+        Set<String> alreadyGranted = new HashSet<>();
+        for (DriveGrant grant : keptGrants) {
+            alreadyGranted.add(grant.folderId());
+        }
+        for (Map.Entry<String, DriveAccessLevel> entry : desired.entrySet()) {
+            if (alreadyGranted.contains(entry.getKey()) || failed.contains(entry.getKey())) {
+                continue;
+            }
+
+            try {
+                String permissionId = withRetry(() -> client.grantPermission(entry.getKey(), email.get(), entry.getValue()));
+                keptGrants.add(new DriveGrant(entry.getKey(), permissionId, entry.getValue().name()));
+                granted.add(entry.getKey());
+            } catch (DriveApiException e) {
+                log.error("Failed to grant Drive permission on folder {} (reconcile will retry)", entry.getKey(), e);
+                failed.add(entry.getKey());
+            }
+        }
+
+        access.setGrants(keptGrants);
+        access.setLastSyncedAt(System.currentTimeMillis());
+        return new SyncOutcome(granted, revoked, failed);
+    }
+
+    /**
+     * Revokes every tracked grant, retrying failures inline — this backs the
+     * leave/ban/unlink flows where the state is about to be deleted, so the
+     * reconcile sweep cannot heal a miss afterwards.
+     *
+     * @return false if any revoke ultimately failed (caller should log loudly)
+     */
+    public boolean revokeAll(DriveAccess access) {
+        boolean allRevoked = true;
+        List<DriveGrant> remaining = new ArrayList<>();
+
+        for (DriveGrant grant : access.getGrants()) {
+            try {
+                withRetry(() -> {
+                    client.revokePermission(grant.folderId(), grant.permissionId());
+                    return null;
+                });
+            } catch (DriveApiException e) {
+                log.error("Failed to revoke Drive permission on folder {} during full revoke", grant.folderId(), e);
+                remaining.add(grant);
+                allRevoked = false;
+            }
+        }
+
+        access.setGrants(remaining);
+        return allRevoked;
+    }
+
+    private <T> T withRetry(net.hypixel.nerdbot.marmalade.functional.ThrowingSupplier<T, ? extends Exception> operation) throws DriveApiException {
+        try {
+            return Retry.<T>of(operation)
+                .maxAttempts(MAX_ATTEMPTS)
+                .delay(Duration.ofSeconds(2))
+                .backoffMultiplier(2.0)
+                .jitterFactor(0.2)
+                .retryOn(TransientDriveApiException.class)
+                .execute();
+        } catch (Retry.RetryExhaustedException e) {
+            if (e.getFailures().getLast() instanceof DriveApiException driveFailure) {
+                throw driveFailure;
+            }
+            throw new DriveApiException(-1, "Drive operation failed", e);
+        }
+    }
+
+    public static String normalizeEmail(String raw) {
+        return raw == null ? "" : raw.trim().toLowerCase();
+    }
+
+    public static boolean isValidEmail(String normalized) {
+        return normalized != null && normalized.length() <= 254 && EMAIL_PATTERN.matcher(normalized).matches();
+    }
+
+    public String encryptEmail(String email) {
+        return cipher.encrypt(email);
+    }
+
+    public String hashEmail(String email) {
+        return cipher.hmac(email);
+    }
+
+    public Optional<String> decryptEmail(DriveAccess access) {
+        try {
+            return Optional.of(cipher.decrypt(access.getEncryptedEmail()));
+        } catch (CipherException e) {
+            log.warn("Stored Drive email could not be decrypted (key rotation or corrupt data) — treating member as unsyncable", e);
+            return Optional.empty();
+        }
+    }
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/drive/DrivePermissionService.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/drive/DrivePermissionService.java
@@ -3,7 +3,6 @@ package net.hypixel.nerdbot.app.drive;
 import lombok.extern.slf4j.Slf4j;
 import net.hypixel.nerdbot.app.config.GoogleDriveConfig;
 import net.hypixel.nerdbot.app.config.objects.DriveFolderMapping;
-import net.hypixel.nerdbot.marmalade.google.GoogleAuthException;
 import net.hypixel.nerdbot.marmalade.google.GoogleTokenProvider;
 import net.hypixel.nerdbot.marmalade.google.ServiceAccountKey;
 import net.hypixel.nerdbot.marmalade.google.drive.DriveAccessLevel;
@@ -28,14 +27,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Grants and revokes shared-Drive folder permissions so they mirror a member's
  * Discord roles. All Drive calls retry transient failures; permanent failures
  * are reported per-folder and the stored grant state stays consistent either
  * way, so the hourly reconcile sweep can heal anything that slipped through.
- * Emails only ever exist in plaintext transiently in memory — never in logs,
+ * Emails only ever exist in plaintext transiently in memory, never in logs,
  * never in the database.
  */
 @Slf4j
@@ -47,6 +48,11 @@ public class DrivePermissionService {
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
     private static final int MAX_ATTEMPTS = 3;
 
+    /** Serializes syncGrants/revokeAll per member so concurrent triggers (event + sweep) cannot race each other's reads/writes of the same DriveAccess. */
+    private static final ConcurrentHashMap<String, Object> MEMBER_LOCKS = new ConcurrentHashMap<>();
+
+    private final ConcurrentHashMap<String, String> folderNameCache = new ConcurrentHashMap<>();
+
     private final AesGcmCipher cipher;
     private final DrivePermissionClient client;
 
@@ -57,7 +63,7 @@ public class DrivePermissionService {
 
     /**
      * Builds the service from JVM system properties, or empty when the feature
-     * is disabled or incompletely configured — callers treat empty as "feature
+     * is disabled or incompletely configured; callers treat empty as "feature
      * off" and stay inert.
      */
     public static Optional<DrivePermissionService> fromSystemProperties(GoogleDriveConfig config) {
@@ -70,7 +76,7 @@ public class DrivePermissionService {
         String emailKey = System.getProperty(EMAIL_KEY_PROPERTY);
 
         if (credentialsPath == null || emailKey == null) {
-            log.warn("Google Drive sync enabled in config but missing {} or {} system property — feature stays off",
+            log.warn("Google Drive sync enabled in config but missing {} or {} system property; feature stays off",
                 CREDENTIALS_PATH_PROPERTY, EMAIL_KEY_PROPERTY);
             return Optional.empty();
         }
@@ -78,11 +84,15 @@ public class DrivePermissionService {
         try {
             AesGcmCipher cipher = AesGcmCipher.fromBase64Key(emailKey);
             ServiceAccountKey key = ServiceAccountKey.fromFile(Path.of(credentialsPath));
-            DrivePermissionClient client = HttpDrivePermissionClient.createDefault(new GoogleTokenProvider(key));
+            DrivePermissionClient client = HttpDrivePermissionClient.createDefault(new GoogleTokenProvider(key), config.isSendNotificationEmails(), config.getNotificationEmailMessage());
             log.info("Google Drive permission sync active ({} folder mappings)", config.getFolderMappings().size());
             return Optional.of(new DrivePermissionService(cipher, client));
-        } catch (GoogleAuthException | IllegalArgumentException e) {
-            log.error("Google Drive sync misconfigured — feature stays off", e);
+        } catch (RuntimeException e) {
+            // Covers GoogleAuthException (key parse / token exchange failure) and IllegalArgumentException
+            // (bad key encoding) alike; GoogleAuthException is itself unchecked, so a single RuntimeException
+            // catch is both sufficient and the only form that compiles (multi-catch cannot mix a type with its
+            // own supertype).
+            log.error("Google Drive sync misconfigured; feature stays off", e);
             return Optional.empty();
         }
     }
@@ -124,8 +134,12 @@ public class DrivePermissionService {
         }
     }
 
+    /** One folder a sync pass could not converge, and why (HTTP status; -1 when there was no API call to blame, e.g. a decrypt failure). */
+    public record FailedFolder(String folderId, int statusCode, String reason) {
+    }
+
     /** What one sync pass changed in Drive, for command feedback and logs. */
-    public record SyncOutcome(List<String> grantedFolders, List<String> revokedFolders, List<String> failedFolders) {
+    public record SyncOutcome(List<String> grantedFolders, List<String> revokedFolders, List<FailedFolder> failedFolders) {
 
         public boolean hasFailures() {
             return !failedFolders.isEmpty();
@@ -137,103 +151,113 @@ public class DrivePermissionService {
      * should have. Mutates {@code access}; the caller persists the user.
      */
     public SyncOutcome syncGrants(String memberId, DriveAccess access, Collection<String> roleIds, GoogleDriveConfig config) {
-        Map<String, DriveAccessLevel> desired = computeDesiredGrants(roleIds, config);
-        List<String> granted = new ArrayList<>();
-        List<String> revoked = new ArrayList<>();
-        List<String> failed = new ArrayList<>();
+        synchronized (MEMBER_LOCKS.computeIfAbsent(memberId, k -> new Object())) {
+            Map<String, DriveAccessLevel> desired = computeDesiredGrants(roleIds, config);
+            List<String> granted = new ArrayList<>();
+            List<String> revoked = new ArrayList<>();
+            List<FailedFolder> failed = new ArrayList<>();
 
-        Optional<String> email = decryptEmail(access);
-        if (email.isEmpty()) {
-            // Can't grant without the address; can't safely revoke either (state may be fine)
-            return new SyncOutcome(granted, revoked, new ArrayList<>(desired.keySet()));
-        }
-
-        // Revoke grants that are stale or at the wrong level
-        List<DriveGrant> keptGrants = new ArrayList<>();
-        for (DriveGrant grant : access.getGrants()) {
-            DriveAccessLevel wanted = desired.get(grant.folderId());
-            boolean levelMatches = wanted != null && wanted.name().equals(grant.accessLevel());
-            if (levelMatches) {
-                keptGrants.add(grant);
-                continue;
+            Optional<String> email = decryptEmail(access);
+            if (email.isEmpty()) {
+                // Can't grant without the address; can't safely revoke either (state may be fine)
+                List<FailedFolder> undecryptable = desired.keySet().stream()
+                    .map(folderId -> new FailedFolder(folderId, -1, "undecryptableEmail"))
+                    .collect(Collectors.toList());
+                return new SyncOutcome(granted, revoked, undecryptable);
             }
 
-            if (wanted != null) {
-                log.info("Access level change for member {} on folder {}: {} -> {}", memberId, grant.folderId(), grant.accessLevel(), wanted);
+            // Revoke grants that are stale or at the wrong level
+            List<DriveGrant> keptGrants = new ArrayList<>();
+            for (DriveGrant grant : access.getGrants()) {
+                DriveAccessLevel wanted = desired.get(grant.folderId());
+                boolean levelMatches = wanted != null && wanted.name().equals(grant.accessLevel());
+                if (levelMatches) {
+                    keptGrants.add(grant);
+                    continue;
+                }
+
+                if (wanted != null) {
+                    log.info("Access level change for member {} on folder {}: {} -> {}", memberId, grant.folderId(), grant.accessLevel(), wanted);
+                }
+
+                try {
+                    revokeOne(grant.folderId(), grant.permissionId());
+                    revoked.add(grant.folderId());
+                    log.info("Revoked {} on folder {} for member {} (permission {})", grant.accessLevel(), grant.folderId(), memberId, grant.permissionId());
+                } catch (DriveApiException e) {
+                    log.error("Failed to revoke Drive permission on folder {} (kept for reconcile)", grant.folderId(), e);
+                    failed.add(new FailedFolder(grant.folderId(), e.getStatusCode(), e.getReason()));
+                    keptGrants.add(grant); // still tracked so reconcile retries the revoke
+                }
             }
 
-            try {
-                withRetry(() -> {
-                    client.revokePermission(grant.folderId(), grant.permissionId());
-                    return null;
-                });
-                revoked.add(grant.folderId());
-                log.info("Revoked {} on folder {} for member {} (permission {})", grant.accessLevel(), grant.folderId(), memberId, grant.permissionId());
-            } catch (DriveApiException e) {
-                log.error("Failed to revoke Drive permission on folder {} (kept for reconcile)", grant.folderId(), e);
-                failed.add(grant.folderId());
-                keptGrants.add(grant); // still tracked so reconcile retries the revoke
+            // Grant what's missing
+            Set<String> alreadyGranted = new HashSet<>();
+            for (DriveGrant grant : keptGrants) {
+                alreadyGranted.add(grant.folderId());
             }
-        }
+            Set<String> failedFolderIds = failed.stream().map(FailedFolder::folderId).collect(Collectors.toSet());
+            for (Map.Entry<String, DriveAccessLevel> entry : desired.entrySet()) {
+                if (alreadyGranted.contains(entry.getKey()) || failedFolderIds.contains(entry.getKey())) {
+                    continue;
+                }
 
-        // Grant what's missing
-        Set<String> alreadyGranted = new HashSet<>();
-        for (DriveGrant grant : keptGrants) {
-            alreadyGranted.add(grant.folderId());
-        }
-        for (Map.Entry<String, DriveAccessLevel> entry : desired.entrySet()) {
-            if (alreadyGranted.contains(entry.getKey()) || failed.contains(entry.getKey())) {
-                continue;
+                try {
+                    String permissionId = withRetry(() -> client.grantPermission(entry.getKey(), email.get(), entry.getValue()));
+                    keptGrants.add(new DriveGrant(entry.getKey(), permissionId, entry.getValue().name()));
+                    granted.add(entry.getKey());
+                    log.info("Granted {} on folder {} to member {} (permission {})", entry.getValue(), entry.getKey(), memberId, permissionId);
+                } catch (DriveApiException e) {
+                    log.error("Failed to grant Drive permission on folder {} (reconcile will retry)", entry.getKey(), e);
+                    failed.add(new FailedFolder(entry.getKey(), e.getStatusCode(), e.getReason()));
+                }
             }
 
-            try {
-                String permissionId = withRetry(() -> client.grantPermission(entry.getKey(), email.get(), entry.getValue()));
-                keptGrants.add(new DriveGrant(entry.getKey(), permissionId, entry.getValue().name()));
-                granted.add(entry.getKey());
-                log.info("Granted {} on folder {} to member {} (permission {})", entry.getValue(), entry.getKey(), memberId, permissionId);
-            } catch (DriveApiException e) {
-                log.error("Failed to grant Drive permission on folder {} (reconcile will retry)", entry.getKey(), e);
-                failed.add(entry.getKey());
+            access.setGrants(keptGrants);
+            access.setLastSyncedAt(System.currentTimeMillis());
+
+            if (granted.isEmpty() && revoked.isEmpty() && failed.isEmpty()) {
+                log.debug("Drive sync no-op for member {} ({} grants unchanged)", memberId, access.getGrants().size());
             }
+
+            return new SyncOutcome(granted, revoked, failed);
         }
-
-        access.setGrants(keptGrants);
-        access.setLastSyncedAt(System.currentTimeMillis());
-
-        if (granted.isEmpty() && revoked.isEmpty() && failed.isEmpty()) {
-            log.debug("Drive sync no-op for member {} ({} grants unchanged)", memberId, access.getGrants().size());
-        }
-
-        return new SyncOutcome(granted, revoked, failed);
     }
 
     /**
-     * Revokes every tracked grant, retrying failures inline — this backs the
+     * Revokes every tracked grant, retrying failures inline; this backs the
      * leave/ban/unlink flows where the state is about to be deleted, so the
      * reconcile sweep cannot heal a miss afterwards.
      *
      * @return false if any revoke ultimately failed (caller should log loudly)
      */
     public boolean revokeAll(String memberId, DriveAccess access) {
-        boolean allRevoked = true;
-        List<DriveGrant> remaining = new ArrayList<>();
+        synchronized (MEMBER_LOCKS.computeIfAbsent(memberId, k -> new Object())) {
+            boolean allRevoked = true;
+            List<DriveGrant> remaining = new ArrayList<>();
 
-        for (DriveGrant grant : access.getGrants()) {
-            try {
-                withRetry(() -> {
-                    client.revokePermission(grant.folderId(), grant.permissionId());
-                    return null;
-                });
-                log.info("Revoked {} on folder {} for member {} (permission {})", grant.accessLevel(), grant.folderId(), memberId, grant.permissionId());
-            } catch (DriveApiException e) {
-                log.error("Failed to revoke Drive permission on folder {} during full revoke", grant.folderId(), e);
-                remaining.add(grant);
-                allRevoked = false;
+            for (DriveGrant grant : access.getGrants()) {
+                try {
+                    revokeOne(grant.folderId(), grant.permissionId());
+                    log.info("Revoked {} on folder {} for member {} (permission {})", grant.accessLevel(), grant.folderId(), memberId, grant.permissionId());
+                } catch (DriveApiException e) {
+                    log.error("Failed to revoke Drive permission on folder {} during full revoke", grant.folderId(), e);
+                    remaining.add(grant);
+                    allRevoked = false;
+                }
             }
-        }
 
-        access.setGrants(remaining);
-        return allRevoked;
+            access.setGrants(remaining);
+            return allRevoked;
+        }
+    }
+
+    /** Shared revoke-with-retry call; callers differ only in what they log and how they track the failure. */
+    private void revokeOne(String folderId, String permissionId) throws DriveApiException {
+        withRetry(() -> {
+            client.revokePermission(folderId, permissionId);
+            return null;
+        });
     }
 
     private <T> T withRetry(net.hypixel.nerdbot.marmalade.functional.ThrowingSupplier<T, ? extends Exception> operation) throws DriveApiException {
@@ -273,7 +297,7 @@ public class DrivePermissionService {
         try {
             return Optional.of(cipher.decrypt(access.getEncryptedEmail()));
         } catch (CipherException e) {
-            log.warn("Stored Drive email could not be decrypted (key rotation or corrupt data) — treating member as unsyncable", e);
+            log.warn("Stored Drive email could not be decrypted (key rotation or corrupt data); treating member as unsyncable", e);
             return Optional.empty();
         }
     }
@@ -285,5 +309,22 @@ public class DrivePermissionService {
      */
     public List<DrivePermission> listFolderPermissions(String folderId) throws DriveApiException {
         return withRetry(() -> client.listPermissions(folderId));
+    }
+
+    /**
+     * Resolves a folder id to its Drive display name, cached for the process
+     * lifetime (a failed lookup caches the raw id as fallback; folder renames
+     * or transient failures heal on restart). Callers can always render the
+     * result.
+     */
+    public String folderDisplayName(String folderId) {
+        return folderNameCache.computeIfAbsent(folderId, id -> {
+            try {
+                return withRetry(() -> client.getFileName(id));
+            } catch (DriveApiException e) {
+                log.warn("Could not resolve Drive folder name for {}", id, e);
+                return id;
+            }
+        });
     }
 }

--- a/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveSyncSweep.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveSyncSweep.java
@@ -3,6 +3,8 @@ package net.hypixel.nerdbot.app.drive;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
 import net.hypixel.nerdbot.app.config.GoogleDriveConfig;
 import net.hypixel.nerdbot.discord.BotEnvironment;
@@ -64,7 +66,15 @@ public class DriveSyncSweep {
                 continue;
             }
 
-            Optional<List<String>> roleIds = lookup.roleIdsFor(user.getDiscordId());
+            Optional<List<String>> roleIds;
+            try {
+                roleIds = lookup.roleIdsFor(user.getDiscordId());
+            } catch (Exception e) {
+                log.warn("Could not resolve member {} this sweep — skipping", user.getDiscordId(), e);
+                failed++;
+                continue;
+            }
+
             if (roleIds.isEmpty()) {
                 workflow.revokeAndForget(user);
                 saver.save(user);
@@ -135,8 +145,14 @@ public class DriveSyncSweep {
             try {
                 return Optional.of(guild.retrieveMemberById(discordId).complete()
                     .getRoles().stream().map(Role::getId).toList());
-            } catch (Exception e) {
-                return Optional.empty(); // not in the guild anymore
+            } catch (ErrorResponseException e) {
+                // Only return empty if we can confirm the member is gone
+                if (e.getErrorResponse() == ErrorResponse.UNKNOWN_MEMBER ||
+                    e.getErrorResponse() == ErrorResponse.UNKNOWN_USER) {
+                    return Optional.empty(); // member left the guild
+                }
+                // For any other error, rethrow so it's caught by reconcileUsers and counted as failed
+                throw e;
             }
         };
 

--- a/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveSyncSweep.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveSyncSweep.java
@@ -1,0 +1,162 @@
+package net.hypixel.nerdbot.app.drive;
+
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Role;
+import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
+import net.hypixel.nerdbot.app.config.GoogleDriveConfig;
+import net.hypixel.nerdbot.discord.BotEnvironment;
+import net.hypixel.nerdbot.discord.util.DiscordUtils;
+import net.hypixel.nerdbot.marmalade.google.drive.DriveApiException;
+import net.hypixel.nerdbot.marmalade.google.drive.DrivePermission;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Full reconcile pass over every linked member: refresh grants against live
+ * guild roles, revoke-and-forget members who left while the bot was offline,
+ * and re-create grants that were deleted directly in Drive. Shared by the
+ * hourly feature and the /drive sync admin command. Users are processed
+ * sequentially with a short pause to stay friendly to Drive API quotas.
+ */
+@Slf4j
+public class DriveSyncSweep {
+
+    private static final long PAUSE_BETWEEN_USERS_MS = 200;
+
+    public record Result(int synced, int departed, int failed) {
+
+        public String summary() {
+            return synced + " member(s) synced, " + departed + " departed member(s) cleaned up, " + failed + " with failures";
+        }
+    }
+
+    /** Looks up a member's current role ids; empty means they left the guild. */
+    public interface MemberLookup {
+        Optional<List<String>> roleIdsFor(String discordId);
+    }
+
+    /** Persistence seam so the core logic tests without a database. */
+    public interface UserSaver {
+        void save(DiscordUser user);
+    }
+
+    /** JDA-free core, unit tested directly. */
+    public static Result reconcileUsers(Collection<DiscordUser> users, MemberLookup lookup,
+                                        DrivePermissionService service, GoogleDriveConfig config, UserSaver saver) {
+        int synced = 0;
+        int departed = 0;
+        int failed = 0;
+
+        Map<String, Set<String>> livePermissionIds = fetchLivePermissionIds(service, config);
+        DriveLinkWorkflow workflow = new DriveLinkWorkflow(service, config);
+
+        for (DiscordUser user : users) {
+            if (user.getDriveAccess() == null) {
+                continue;
+            }
+
+            Optional<List<String>> roleIds = lookup.roleIdsFor(user.getDiscordId());
+            if (roleIds.isEmpty()) {
+                workflow.revokeAndForget(user);
+                saver.save(user);
+                departed++;
+                continue;
+            }
+
+            dropDanglingGrants(user, livePermissionIds);
+            DrivePermissionService.SyncOutcome outcome = service.syncGrants(user.getDriveAccess(), roleIds.get(), config);
+            saver.save(user);
+            if (outcome.hasFailures()) {
+                failed++;
+            } else {
+                synced++;
+            }
+        }
+
+        return new Result(synced, departed, failed);
+    }
+
+    /**
+     * One listPermissions per mapped folder per sweep. A folder we cannot list
+     * is left out of the map, which means "no dangling-id check there this
+     * round" — grants are never dropped on the basis of a failed list call.
+     */
+    private static Map<String, Set<String>> fetchLivePermissionIds(DrivePermissionService service, GoogleDriveConfig config) {
+        Map<String, Set<String>> live = new HashMap<>();
+        Set<String> mappedFolders = new HashSet<>();
+        config.getFolderMappings().forEach(mapping -> mappedFolders.addAll(mapping.getFolderIds()));
+
+        for (String folderId : mappedFolders) {
+            try {
+                Set<String> ids = new HashSet<>();
+                for (DrivePermission permission : service.listFolderPermissions(folderId)) {
+                    ids.add(permission.id());
+                }
+                live.put(folderId, ids);
+            } catch (DriveApiException e) {
+                log.warn("Could not list permissions on folder {} this sweep — skipping dangling-grant check for it", folderId, e);
+            }
+        }
+        return live;
+    }
+
+    private static void dropDanglingGrants(DiscordUser user, Map<String, Set<String>> livePermissionIds) {
+        user.getDriveAccess().getGrants().removeIf(grant -> {
+            Set<String> live = livePermissionIds.get(grant.folderId());
+            boolean dangling = live != null && !live.contains(grant.permissionId());
+            if (dangling) {
+                log.info("Stored Drive grant for {} on folder {} no longer exists in Drive — will regrant", user.getDiscordId(), grant.folderId());
+            }
+            return dangling;
+        });
+    }
+
+    /** Production entry point: adapts the live guild + repository. */
+    public Result run() {
+        Optional<DrivePermissionService> service = SkyBlockNerdsBot.drivePermissionService();
+        if (service.isEmpty()) {
+            return new Result(0, 0, 0);
+        }
+
+        DiscordUserRepository repository = BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
+        Guild guild = DiscordUtils.getMainGuild();
+        GoogleDriveConfig config = SkyBlockNerdsBot.config().getGoogleDriveConfig();
+
+        MemberLookup lookup = discordId -> {
+            try {
+                return Optional.of(guild.retrieveMemberById(discordId).complete()
+                    .getRoles().stream().map(Role::getId).toList());
+            } catch (Exception e) {
+                return Optional.empty(); // not in the guild anymore
+            }
+        };
+
+        List<DiscordUser> linkedUsers = repository.getAllDocuments().stream()
+            .filter(user -> user.getDriveAccess() != null)
+            .toList();
+
+        // Wrap the saver with pacing so a large sweep doesn't hammer the API
+        UserSaver saver = user -> {
+            repository.cacheObject(user);
+            repository.saveToDatabaseAsync(user);
+            try {
+                Thread.sleep(PAUSE_BETWEEN_USERS_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+
+        Result result = reconcileUsers(linkedUsers, lookup, service.get(), config, saver);
+        log.info("Drive reconcile sweep finished: {}", result.summary());
+        return result;
+    }
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveSyncSweep.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveSyncSweep.java
@@ -76,6 +76,7 @@ public class DriveSyncSweep {
             }
 
             if (roleIds.isEmpty()) {
+                log.info("Member {} no longer in guild; revoking and forgetting their Drive access", user.getDiscordId());
                 workflow.revokeAndForget(user);
                 saver.save(user);
                 departed++;
@@ -83,7 +84,7 @@ public class DriveSyncSweep {
             }
 
             dropDanglingGrants(user, livePermissionIds);
-            DrivePermissionService.SyncOutcome outcome = service.syncGrants(user.getDriveAccess(), roleIds.get(), config);
+            DrivePermissionService.SyncOutcome outcome = service.syncGrants(user.getDiscordId(), user.getDriveAccess(), roleIds.get(), config);
             saver.save(user);
             if (outcome.hasFailures()) {
                 failed++;
@@ -159,6 +160,10 @@ public class DriveSyncSweep {
         List<DiscordUser> linkedUsers = repository.getAllDocuments().stream()
             .filter(user -> user.getDriveAccess() != null)
             .toList();
+
+        Set<String> mappedFolders = new HashSet<>();
+        config.getFolderMappings().forEach(mapping -> mappedFolders.addAll(mapping.getFolderIds()));
+        log.info("Reconcile sweep starting: {} linked member(s), {} mapped folder(s)", linkedUsers.size(), mappedFolders.size());
 
         // Wrap the saver with pacing so a large sweep doesn't hammer the API
         UserSaver saver = user -> {

--- a/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveSyncSweep.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/drive/DriveSyncSweep.java
@@ -12,6 +12,7 @@ import net.hypixel.nerdbot.discord.util.DiscordUtils;
 import net.hypixel.nerdbot.marmalade.google.drive.DriveApiException;
 import net.hypixel.nerdbot.marmalade.google.drive.DrivePermission;
 import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.drive.DriveGrant;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
 
 import java.util.Collection;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Full reconcile pass over every linked member: refresh grants against live
@@ -33,6 +35,9 @@ import java.util.Set;
 public class DriveSyncSweep {
 
     private static final long PAUSE_BETWEEN_USERS_MS = 200;
+
+    /** Guards against two sweeps (hourly schedule + /drive sync) running concurrently over the same users. */
+    private static final AtomicBoolean SWEEP_RUNNING = new AtomicBoolean(false);
 
     public record Result(int synced, int departed, int failed) {
 
@@ -51,9 +56,21 @@ public class DriveSyncSweep {
         void save(DiscordUser user);
     }
 
-    /** JDA-free core, unit tested directly. */
+    /** Change-notification seam; run() plugs the log-channel embeds in here. */
+    public interface ChangeListener {
+        void onChange(String memberId, List<String> grantedFolders, List<String> revokedFolders);
+    }
+
+    /** Backwards-compatible core without change notifications. */
     public static Result reconcileUsers(Collection<DiscordUser> users, MemberLookup lookup,
                                         DrivePermissionService service, GoogleDriveConfig config, UserSaver saver) {
+        return reconcileUsers(users, lookup, service, config, saver, (memberId, granted, revoked) -> { });
+    }
+
+    /** JDA-free core, unit tested directly. */
+    public static Result reconcileUsers(Collection<DiscordUser> users, MemberLookup lookup,
+                                        DrivePermissionService service, GoogleDriveConfig config, UserSaver saver,
+                                        ChangeListener changeListener) {
         int synced = 0;
         int departed = 0;
         int failed = 0;
@@ -70,15 +87,17 @@ public class DriveSyncSweep {
             try {
                 roleIds = lookup.roleIdsFor(user.getDiscordId());
             } catch (Exception e) {
-                log.warn("Could not resolve member {} this sweep — skipping", user.getDiscordId(), e);
+                log.warn("Could not resolve member {} this sweep, skipping", user.getDiscordId(), e);
                 failed++;
                 continue;
             }
 
             if (roleIds.isEmpty()) {
                 log.info("Member {} no longer in guild; revoking and forgetting their Drive access", user.getDiscordId());
+                List<String> heldFolders = user.getDriveAccess().getGrants().stream().map(DriveGrant::folderId).toList();
                 workflow.revokeAndForget(user);
                 saver.save(user);
+                changeListener.onChange(user.getDiscordId(), List.of(), heldFolders);
                 departed++;
                 continue;
             }
@@ -86,6 +105,9 @@ public class DriveSyncSweep {
             dropDanglingGrants(user, livePermissionIds);
             DrivePermissionService.SyncOutcome outcome = service.syncGrants(user.getDiscordId(), user.getDriveAccess(), roleIds.get(), config);
             saver.save(user);
+            if (!outcome.grantedFolders().isEmpty() || !outcome.revokedFolders().isEmpty()) {
+                changeListener.onChange(user.getDiscordId(), outcome.grantedFolders(), outcome.revokedFolders());
+            }
             if (outcome.hasFailures()) {
                 failed++;
             } else {
@@ -99,14 +121,12 @@ public class DriveSyncSweep {
     /**
      * One listPermissions per mapped folder per sweep. A folder we cannot list
      * is left out of the map, which means "no dangling-id check there this
-     * round" — grants are never dropped on the basis of a failed list call.
+     * round"; grants are never dropped on the basis of a failed list call.
      */
     private static Map<String, Set<String>> fetchLivePermissionIds(DrivePermissionService service, GoogleDriveConfig config) {
         Map<String, Set<String>> live = new HashMap<>();
-        Set<String> mappedFolders = new HashSet<>();
-        config.getFolderMappings().forEach(mapping -> mappedFolders.addAll(mapping.getFolderIds()));
 
-        for (String folderId : mappedFolders) {
+        for (String folderId : mappedFolderIds(config)) {
             try {
                 Set<String> ids = new HashSet<>();
                 for (DrivePermission permission : service.listFolderPermissions(folderId)) {
@@ -114,10 +134,17 @@ public class DriveSyncSweep {
                 }
                 live.put(folderId, ids);
             } catch (DriveApiException e) {
-                log.warn("Could not list permissions on folder {} this sweep — skipping dangling-grant check for it", folderId, e);
+                log.warn("Could not list permissions on folder {} this sweep; skipping the dangling-grant check for it", folderId, e);
             }
         }
         return live;
+    }
+
+    /** Every folder id referenced anywhere in the config's role mappings, deduped. Shared by discovery and the sweep-start log. */
+    private static Set<String> mappedFolderIds(GoogleDriveConfig config) {
+        Set<String> mappedFolders = new HashSet<>();
+        config.getFolderMappings().forEach(mapping -> mappedFolders.addAll(mapping.getFolderIds()));
+        return mappedFolders;
     }
 
     private static void dropDanglingGrants(DiscordUser user, Map<String, Set<String>> livePermissionIds) {
@@ -125,7 +152,7 @@ public class DriveSyncSweep {
             Set<String> live = livePermissionIds.get(grant.folderId());
             boolean dangling = live != null && !live.contains(grant.permissionId());
             if (dangling) {
-                log.info("Stored Drive grant for {} on folder {} no longer exists in Drive — will regrant", user.getDiscordId(), grant.folderId());
+                log.info("Stored Drive grant for {} on folder {} no longer exists in Drive; regranting", user.getDiscordId(), grant.folderId());
             }
             return dangling;
         });
@@ -133,51 +160,76 @@ public class DriveSyncSweep {
 
     /** Production entry point: adapts the live guild + repository. */
     public Result run() {
-        Optional<DrivePermissionService> service = SkyBlockNerdsBot.drivePermissionService();
-        if (service.isEmpty()) {
+        if (!SWEEP_RUNNING.compareAndSet(false, true)) {
+            log.info("Drive reconcile sweep already in progress, skipping this trigger");
             return new Result(0, 0, 0);
         }
 
-        DiscordUserRepository repository = BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
-        Guild guild = DiscordUtils.getMainGuild();
-        GoogleDriveConfig config = SkyBlockNerdsBot.config().getGoogleDriveConfig();
+        try {
+            Optional<DrivePermissionService> service = SkyBlockNerdsBot.drivePermissionService();
+            if (service.isEmpty()) {
+                return new Result(0, 0, 0);
+            }
 
-        MemberLookup lookup = discordId -> {
-            try {
-                return Optional.of(guild.retrieveMemberById(discordId).complete()
-                    .getRoles().stream().map(Role::getId).toList());
-            } catch (ErrorResponseException e) {
-                // Only return empty if we can confirm the member is gone
-                if (e.getErrorResponse() == ErrorResponse.UNKNOWN_MEMBER ||
-                    e.getErrorResponse() == ErrorResponse.UNKNOWN_USER) {
-                    return Optional.empty(); // member left the guild
+            GoogleDriveConfig config = SkyBlockNerdsBot.config().getGoogleDriveConfig();
+            if (!config.isEnabled()) {
+                return new Result(0, 0, 0);
+            }
+
+            DiscordUserRepository repository = BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
+            Guild guild = DiscordUtils.getMainGuild();
+
+            MemberLookup lookup = discordId -> {
+                try {
+                    return Optional.of(guild.retrieveMemberById(discordId).complete()
+                        .getRoles().stream().map(Role::getId).toList());
+                } catch (ErrorResponseException e) {
+                    // Only return empty if we can confirm the member is gone
+                    if (e.getErrorResponse() == ErrorResponse.UNKNOWN_MEMBER ||
+                        e.getErrorResponse() == ErrorResponse.UNKNOWN_USER) {
+                        return Optional.empty(); // member left the guild
+                    }
+                    // For any other error, rethrow so it's caught by reconcileUsers and counted as failed
+                    throw e;
                 }
-                // For any other error, rethrow so it's caught by reconcileUsers and counted as failed
-                throw e;
-            }
-        };
+            };
 
-        List<DiscordUser> linkedUsers = repository.getAllDocuments().stream()
-            .filter(user -> user.getDriveAccess() != null)
-            .toList();
+            // Discover ids via getAllDocuments, but operate on the cache-first instances from findById so
+            // the sweep never clobbers a change another thread wrote to the cache after the bulk read.
+            List<String> allIds = repository.getAllDocuments().stream()
+                .map(DiscordUser::getDiscordId)
+                .toList();
+            List<DiscordUser> linkedUsers = allIds.stream()
+                .map(id -> repository.findById(id).toOptional().orElse(null))
+                .filter(user -> user != null && user.getDriveAccess() != null)
+                .toList();
 
-        Set<String> mappedFolders = new HashSet<>();
-        config.getFolderMappings().forEach(mapping -> mappedFolders.addAll(mapping.getFolderIds()));
-        log.info("Reconcile sweep starting: {} linked member(s), {} mapped folder(s)", linkedUsers.size(), mappedFolders.size());
+            Set<String> mappedFolders = mappedFolderIds(config);
+            log.info("Reconcile sweep starting: {} linked member(s), {} mapped folder(s)", linkedUsers.size(), mappedFolders.size());
 
-        // Wrap the saver with pacing so a large sweep doesn't hammer the API
-        UserSaver saver = user -> {
-            repository.cacheObject(user);
-            repository.saveToDatabaseAsync(user);
-            try {
-                Thread.sleep(PAUSE_BETWEEN_USERS_MS);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        };
+            // Wrap the saver with pacing so a large sweep doesn't hammer the API
+            UserSaver saver = user -> {
+                repository.cacheObject(user);
+                if (user.getDriveAccess() == null) {
+                    // A $set save can't remove a field: the serializer omits nulls and $set leaves absent
+                    // fields alone, so a departed member's driveAccess would silently survive in Mongo.
+                    repository.unsetField(user.getDiscordId(), "driveAccess");
+                } else {
+                    repository.saveToDatabaseAsync(user);
+                }
+                try {
+                    Thread.sleep(PAUSE_BETWEEN_USERS_MS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            };
 
-        Result result = reconcileUsers(linkedUsers, lookup, service.get(), config, saver);
-        log.info("Drive reconcile sweep finished: {}", result.summary());
-        return result;
+            Result result = reconcileUsers(linkedUsers, lookup, service.get(), config, saver,
+                (memberId, granted, revoked) -> DriveLogEmbeds.postAccessChange(service.get(), memberId, granted, revoked));
+            log.info("Drive reconcile sweep finished: {}", result.summary());
+            return result;
+        } finally {
+            SWEEP_RUNNING.set(false);
+        }
     }
 }

--- a/app/src/main/java/net/hypixel/nerdbot/app/feature/DrivePermissionSyncFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/feature/DrivePermissionSyncFeature.java
@@ -33,6 +33,9 @@ public class DrivePermissionSyncFeature extends BotFeature {
         if (SkyBlockNerdsBot.drivePermissionService().isEmpty()) {
             return;
         }
+        if (!SkyBlockNerdsBot.config().getGoogleDriveConfig().isEnabled()) {
+            return;
+        }
         if (!BotEnvironment.getBot().getDatabase().isConnected()) {
             log.error("Skipping Drive permission sweep as the database is not connected!");
             return;

--- a/app/src/main/java/net/hypixel/nerdbot/app/feature/DrivePermissionSyncFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/feature/DrivePermissionSyncFeature.java
@@ -1,0 +1,47 @@
+package net.hypixel.nerdbot.app.feature;
+
+import lombok.extern.slf4j.Slf4j;
+import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
+import net.hypixel.nerdbot.app.drive.DriveSyncSweep;
+import net.hypixel.nerdbot.discord.BotEnvironment;
+import net.hypixel.nerdbot.discord.api.feature.BotFeature;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Hourly Drive permission reconcile: heals role changes missed while offline,
+ * members who left unseen, failed grant/revoke calls, and permissions deleted
+ * by hand in Drive. Event-driven updates (DrivePermissionListener) are the
+ * primary path; this is the safety net. No-ops when the Drive service is
+ * unconfigured.
+ */
+@Slf4j
+public class DrivePermissionSyncFeature extends BotFeature {
+
+    private static final long PERIOD_MS = TimeUnit.HOURS.toMillis(1);
+
+    @Override
+    public void onFeatureStart() {
+        if (BotEnvironment.getBot().isReadOnly()) {
+            log.warn("Bot is in read-only mode, skipping Drive permission sync task!");
+            return;
+        }
+        scheduleAtFixedRate("drive-permission-sync-task", this::sweep, PERIOD_MS, PERIOD_MS);
+    }
+
+    private void sweep() {
+        if (SkyBlockNerdsBot.drivePermissionService().isEmpty()) {
+            return;
+        }
+        if (!BotEnvironment.getBot().getDatabase().isConnected()) {
+            log.error("Skipping Drive permission sweep as the database is not connected!");
+            return;
+        }
+        new DriveSyncSweep().run();
+    }
+
+    @Override
+    public void onFeatureEnd() {
+        stopScheduledTask();
+    }
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/listener/DrivePermissionListener.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/listener/DrivePermissionListener.java
@@ -1,0 +1,80 @@
+package net.hypixel.nerdbot.app.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleAddEvent;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleRemoveEvent;
+import net.dv8tion.jda.api.hooks.SubscribeEvent;
+import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
+import net.hypixel.nerdbot.app.drive.DriveLinkWorkflow;
+import net.hypixel.nerdbot.app.drive.DrivePermissionService;
+import net.hypixel.nerdbot.discord.BotEnvironment;
+import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
+
+import java.util.List;
+
+/**
+ * Mirrors Discord role changes onto shared-Drive folder permissions as they
+ * happen, and revokes + forgets everything when a member leaves (which covers
+ * kicks and bans too). The hourly DrivePermissionSyncFeature is the safety net
+ * for anything this misses while the bot is offline.
+ */
+@Slf4j
+public class DrivePermissionListener {
+
+    @SubscribeEvent
+    public void onRoleAdd(GuildMemberRoleAddEvent event) {
+        resync(event.getMember());
+    }
+
+    @SubscribeEvent
+    public void onRoleRemove(GuildMemberRoleRemoveEvent event) {
+        resync(event.getMember());
+    }
+
+    @SubscribeEvent
+    public void onMemberRemove(GuildMemberRemoveEvent event) {
+        SkyBlockNerdsBot.drivePermissionService().ifPresent(service -> {
+            DiscordUserRepository repository = repository();
+            repository.findByIdAsync(event.getUser().getId()).thenAccept(user -> {
+                if (user == null || user.getDriveAccess() == null) {
+                    return;
+                }
+                new DriveLinkWorkflow(service, SkyBlockNerdsBot.config().getGoogleDriveConfig()).revokeAndForget(user);
+                repository.cacheObject(user);
+                repository.saveToDatabaseAsync(user);
+                log.info("Revoked Drive access for departing member {}", event.getUser().getId());
+            });
+        });
+    }
+
+    private void resync(Member member) {
+        if (member.getUser().isBot()) {
+            return;
+        }
+
+        SkyBlockNerdsBot.drivePermissionService().ifPresent(service -> {
+            DiscordUserRepository repository = repository();
+            repository.findByIdAsync(member.getId()).thenAccept(user -> {
+                if (user == null || user.getDriveAccess() == null) {
+                    return;
+                }
+                List<String> roleIds = member.getRoles().stream().map(Role::getId).toList();
+                DrivePermissionService.SyncOutcome outcome = service.syncGrants(
+                    user.getDriveAccess(), roleIds, SkyBlockNerdsBot.config().getGoogleDriveConfig());
+                repository.cacheObject(user);
+                repository.saveToDatabaseAsync(user);
+                if (!outcome.grantedFolders().isEmpty() || !outcome.revokedFolders().isEmpty() || outcome.hasFailures()) {
+                    log.info("Drive resync for {}: +{} -{} !{}", member.getId(),
+                        outcome.grantedFolders().size(), outcome.revokedFolders().size(), outcome.failedFolders().size());
+                }
+            });
+        });
+    }
+
+    private static DiscordUserRepository repository() {
+        return BotEnvironment.getBot().getDatabase().getRepositoryManager().getRepository(DiscordUserRepository.class);
+    }
+}

--- a/app/src/main/java/net/hypixel/nerdbot/app/listener/DrivePermissionListener.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/listener/DrivePermissionListener.java
@@ -9,7 +9,9 @@ import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleRemoveEvent;
 import net.dv8tion.jda.api.hooks.SubscribeEvent;
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
 import net.hypixel.nerdbot.app.drive.DriveLinkWorkflow;
+import net.hypixel.nerdbot.app.drive.DriveLogEmbeds;
 import net.hypixel.nerdbot.app.drive.DrivePermissionService;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.drive.DriveGrant;
 import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.marmalade.storage.database.repository.DiscordUserRepository;
 
@@ -36,16 +38,27 @@ public class DrivePermissionListener {
 
     @SubscribeEvent
     public void onMemberRemove(GuildMemberRemoveEvent event) {
+        if (!SkyBlockNerdsBot.config().getGoogleDriveConfig().isEnabled()) {
+            return;
+        }
+
         SkyBlockNerdsBot.drivePermissionService().ifPresent(service -> {
             DiscordUserRepository repository = repository();
-            repository.findByIdAsync(event.getUser().getId()).thenAccept(user -> {
+            String memberId = event.getUser().getId();
+            repository.findByIdAsync(memberId).thenAccept(user -> {
                 if (user == null || user.getDriveAccess() == null) {
                     return;
                 }
+                List<String> heldFolders = user.getDriveAccess().getGrants().stream().map(DriveGrant::folderId).toList();
                 new DriveLinkWorkflow(service, SkyBlockNerdsBot.config().getGoogleDriveConfig()).revokeAndForget(user);
                 repository.cacheObject(user);
-                repository.saveToDatabaseAsync(user);
-                log.info("Revoked Drive access for departing member {}", event.getUser().getId());
+                // revokeAndForget always nulls driveAccess here; a $set save can't clear it from Mongo, so unset the field directly.
+                repository.unsetField(memberId, "driveAccess");
+                log.info("Revoked Drive access for departing member {}", memberId);
+                DriveLogEmbeds.postAccessChange(service, memberId, List.of(), heldFolders);
+            }).exceptionally(throwable -> {
+                log.error("Drive permission listener task failed for {}", memberId, throwable);
+                return null;
             });
         });
     }
@@ -55,23 +68,32 @@ public class DrivePermissionListener {
             return;
         }
 
+        if (!SkyBlockNerdsBot.config().getGoogleDriveConfig().isEnabled()) {
+            return;
+        }
+
         SkyBlockNerdsBot.drivePermissionService().ifPresent(service -> {
             DiscordUserRepository repository = repository();
-            repository.findByIdAsync(member.getId()).thenAccept(user -> {
+            String memberId = member.getId();
+            repository.findByIdAsync(memberId).thenAccept(user -> {
                 if (user == null || user.getDriveAccess() == null) {
                     return;
                 }
                 List<String> roleIds = member.getRoles().stream().map(Role::getId).toList();
                 DrivePermissionService.SyncOutcome outcome = service.syncGrants(
-                    member.getId(), user.getDriveAccess(), roleIds, SkyBlockNerdsBot.config().getGoogleDriveConfig());
+                    memberId, user.getDriveAccess(), roleIds, SkyBlockNerdsBot.config().getGoogleDriveConfig());
                 repository.cacheObject(user);
                 repository.saveToDatabaseAsync(user);
                 if (!outcome.grantedFolders().isEmpty() || !outcome.revokedFolders().isEmpty() || outcome.hasFailures()) {
-                    log.info("Drive resync for {}: +{} -{} !{}", member.getId(),
+                    log.info("Drive resync for {}: +{} -{} !{}", memberId,
                         outcome.grantedFolders().size(), outcome.revokedFolders().size(), outcome.failedFolders().size());
+                    DriveLogEmbeds.postAccessChange(service, memberId, outcome.grantedFolders(), outcome.revokedFolders());
                 } else {
-                    log.debug("Drive resync for {}: no changes", member.getId());
+                    log.debug("Drive resync for {}: no changes", memberId);
                 }
+            }).exceptionally(throwable -> {
+                log.error("Drive permission listener task failed for {}", memberId, throwable);
+                return null;
             });
         });
     }

--- a/app/src/main/java/net/hypixel/nerdbot/app/listener/DrivePermissionListener.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/listener/DrivePermissionListener.java
@@ -63,12 +63,14 @@ public class DrivePermissionListener {
                 }
                 List<String> roleIds = member.getRoles().stream().map(Role::getId).toList();
                 DrivePermissionService.SyncOutcome outcome = service.syncGrants(
-                    user.getDriveAccess(), roleIds, SkyBlockNerdsBot.config().getGoogleDriveConfig());
+                    member.getId(), user.getDriveAccess(), roleIds, SkyBlockNerdsBot.config().getGoogleDriveConfig());
                 repository.cacheObject(user);
                 repository.saveToDatabaseAsync(user);
                 if (!outcome.grantedFolders().isEmpty() || !outcome.revokedFolders().isEmpty() || outcome.hasFailures()) {
                     log.info("Drive resync for {}: +{} -{} !{}", member.getId(),
                         outcome.grantedFolders().size(), outcome.revokedFolders().size(), outcome.failedFolders().size());
+                } else {
+                    log.debug("Drive resync for {}: no changes", member.getId());
                 }
             });
         });

--- a/app/src/test/java/net/hypixel/nerdbot/app/config/GoogleDriveConfigTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/config/GoogleDriveConfigTest.java
@@ -1,0 +1,46 @@
+package net.hypixel.nerdbot.app.config;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GoogleDriveConfigTest {
+
+    @Test
+    void parsesFromBotConfigJson() {
+        String json = """
+            {
+              "googleDriveConfig": {
+                "enabled": true,
+                "folderMappings": [
+                  {"roleId": "111", "folderIds": ["fA", "fB"], "accessLevel": "READER"},
+                  {"roleId": "222", "folderIds": ["fA"], "accessLevel": "WRITER"}
+                ]
+              }
+            }
+            """;
+
+        NerdBotConfig config = new Gson().fromJson(json, NerdBotConfig.class);
+        GoogleDriveConfig driveConfig = config.getGoogleDriveConfig();
+
+        assertTrue(driveConfig.isEnabled());
+        assertEquals(2, driveConfig.getFolderMappings().size());
+        assertEquals("111", driveConfig.getFolderMappings().get(0).getRoleId());
+        assertEquals(List.of("fA", "fB"), driveConfig.getFolderMappings().get(0).getFolderIds());
+        assertEquals("WRITER", driveConfig.getFolderMappings().get(1).getAccessLevel());
+    }
+
+    @Test
+    void defaultsToDisabledWhenAbsent() {
+        NerdBotConfig config = new Gson().fromJson("{}", NerdBotConfig.class);
+        assertNotNull(config.getGoogleDriveConfig());
+        assertFalse(config.getGoogleDriveConfig().isEnabled());
+        assertNotNull(config.getGoogleDriveConfig().getFolderMappings());
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/config/GoogleDriveConfigTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/config/GoogleDriveConfigTest.java
@@ -43,4 +43,28 @@ class GoogleDriveConfigTest {
         assertFalse(config.getGoogleDriveConfig().isEnabled());
         assertNotNull(config.getGoogleDriveConfig().getFolderMappings());
     }
+
+    @Test
+    void notificationEmailsDefaultOnAndParseOff() {
+        NerdBotConfig absent = new Gson().fromJson("{}", NerdBotConfig.class);
+        assertTrue(absent.getGoogleDriveConfig().isSendNotificationEmails());
+
+        String json = """
+            {"googleDriveConfig": {"sendNotificationEmails": false}}
+            """;
+        NerdBotConfig explicit = new Gson().fromJson(json, NerdBotConfig.class);
+        assertFalse(explicit.getGoogleDriveConfig().isSendNotificationEmails());
+    }
+
+    @Test
+    void notificationEmailMessageDefaultsAndParses() {
+        NerdBotConfig absent = new Gson().fromJson("{}", NerdBotConfig.class);
+        assertFalse(absent.getGoogleDriveConfig().getNotificationEmailMessage().isBlank());
+
+        String json = """
+            {"googleDriveConfig": {"notificationEmailMessage": "custom text"}}
+            """;
+        NerdBotConfig explicit = new Gson().fromJson(json, NerdBotConfig.class);
+        assertEquals("custom text", explicit.getGoogleDriveConfig().getNotificationEmailMessage());
+    }
 }

--- a/app/src/test/java/net/hypixel/nerdbot/app/drive/DriveLinkWorkflowTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/drive/DriveLinkWorkflowTest.java
@@ -1,0 +1,124 @@
+package net.hypixel.nerdbot.app.drive;
+
+import net.hypixel.nerdbot.app.config.GoogleDriveConfig;
+import net.hypixel.nerdbot.app.config.objects.DriveFolderMapping;
+import net.hypixel.nerdbot.app.drive.DriveLinkWorkflow.LinkResult;
+import net.hypixel.nerdbot.marmalade.security.AesGcmCipher;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DriveLinkWorkflowTest {
+
+    private static final AesGcmCipher CIPHER = new AesGcmCipher("0123456789abcdef0123456789abcdef".getBytes());
+
+    private FakeDrivePermissionClient client;
+    private DrivePermissionService service;
+    private GoogleDriveConfig config;
+    private DriveLinkWorkflow workflow;
+
+    @BeforeEach
+    void setUp() {
+        client = new FakeDrivePermissionClient();
+        service = new DrivePermissionService(CIPHER, client);
+        config = new GoogleDriveConfig();
+        config.setEnabled(true);
+        DriveFolderMapping mapping = new DriveFolderMapping();
+        mapping.setRoleId("111");
+        mapping.setFolderIds(List.of("fA"));
+        mapping.setAccessLevel("READER");
+        config.setFolderMappings(List.of(mapping));
+        workflow = new DriveLinkWorkflow(service, config);
+    }
+
+    @Test
+    void linkEncryptsStoresAndSyncs() {
+        DiscordUser user = new DiscordUser("42");
+
+        LinkResult result = workflow.link(user, "  User@Example.com ", List.of("111"), List.of(user));
+
+        assertEquals(DriveLinkWorkflow.Status.LINKED, result.status());
+        assertNotNull(user.getDriveAccess());
+        assertEquals(CIPHER.hmac("user@example.com"), user.getDriveAccess().getEmailHash());
+        assertFalse(user.getDriveAccess().getEncryptedEmail().contains("example.com"));
+        assertEquals(1, user.getDriveAccess().getGrants().size());
+        assertEquals("user@example.com", client.folders.get("fA").getFirst().emailAddress());
+    }
+
+    @Test
+    void linkRejectsInvalidEmail() {
+        DiscordUser user = new DiscordUser("42");
+        LinkResult result = workflow.link(user, "not-an-email", List.of("111"), List.of(user));
+        assertEquals(DriveLinkWorkflow.Status.INVALID_EMAIL, result.status());
+        assertNull(user.getDriveAccess());
+    }
+
+    @Test
+    void linkRejectsEmailLinkedToAnotherMember() {
+        DiscordUser other = new DiscordUser("99");
+        workflow.link(other, "user@example.com", List.of(), List.of(other));
+
+        DiscordUser user = new DiscordUser("42");
+        LinkResult result = workflow.link(user, "USER@example.com", List.of("111"), List.of(other, user));
+
+        assertEquals(DriveLinkWorkflow.Status.DUPLICATE_EMAIL, result.status());
+        assertNull(user.getDriveAccess());
+    }
+
+    @Test
+    void relinkingSameMemberWithNewEmailRevokesOldGrantsFirst() {
+        DiscordUser user = new DiscordUser("42");
+        workflow.link(user, "old@example.com", List.of("111"), List.of(user));
+        String oldPermissionId = user.getDriveAccess().getGrants().getFirst().permissionId();
+
+        LinkResult result = workflow.link(user, "new@example.com", List.of("111"), List.of(user));
+
+        assertEquals(DriveLinkWorkflow.Status.LINKED, result.status());
+        assertEquals(1, client.folders.get("fA").size());
+        assertEquals("new@example.com", client.folders.get("fA").getFirst().emailAddress());
+        assertFalse(user.getDriveAccess().getGrants().getFirst().permissionId().equals(oldPermissionId));
+    }
+
+    @Test
+    void relinkingSameEmailIsAllowedForSameUser() {
+        DiscordUser user = new DiscordUser("42");
+        workflow.link(user, "user@example.com", List.of("111"), List.of(user));
+        LinkResult result = workflow.link(user, "user@example.com", List.of("111"), List.of(user));
+        assertEquals(DriveLinkWorkflow.Status.LINKED, result.status());
+    }
+
+    @Test
+    void unlinkRevokesAndDeletes() {
+        DiscordUser user = new DiscordUser("42");
+        workflow.link(user, "user@example.com", List.of("111"), List.of(user));
+
+        assertTrue(workflow.unlink(user));
+
+        assertNull(user.getDriveAccess());
+        assertTrue(client.folders.get("fA").isEmpty());
+    }
+
+    @Test
+    void unlinkWhenNotLinkedReturnsFalse() {
+        assertFalse(workflow.unlink(new DiscordUser("42")));
+    }
+
+    @Test
+    void revokeAndForgetAlwaysClearsStateEvenOnRevokeFailure() {
+        DiscordUser user = new DiscordUser("42");
+        workflow.link(user, "user@example.com", List.of("111"), List.of(user));
+        client.failPermanently("fA", 403);
+
+        workflow.revokeAndForget(user);
+
+        assertNull(user.getDriveAccess());
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/drive/DrivePermissionServiceTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/drive/DrivePermissionServiceTest.java
@@ -90,7 +90,7 @@ class DrivePermissionServiceTest {
         FakeDrivePermissionClient client = new FakeDrivePermissionClient();
         DriveAccess access = linkedAccess();
 
-        SyncOutcome outcome = service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
+        SyncOutcome outcome = service(client).syncGrants("42", access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
 
         assertEquals(List.of("fA", "fB"), outcome.grantedFolders().stream().sorted().toList());
         assertEquals(2, access.getGrants().size());
@@ -101,9 +101,9 @@ class DrivePermissionServiceTest {
     void revokesStaleFolders() {
         FakeDrivePermissionClient client = new FakeDrivePermissionClient();
         DriveAccess access = linkedAccess();
-        service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
+        service(client).syncGrants("42", access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
 
-        SyncOutcome outcome = service(client).syncGrants(access, List.of(), config(mapping("111", "READER", "fA", "fB")));
+        SyncOutcome outcome = service(client).syncGrants("42", access, List.of(), config(mapping("111", "READER", "fA", "fB")));
 
         assertEquals(2, outcome.revokedFolders().size());
         assertTrue(access.getGrants().isEmpty());
@@ -114,9 +114,9 @@ class DrivePermissionServiceTest {
     void levelChangeRevokesThenRegrants() {
         FakeDrivePermissionClient client = new FakeDrivePermissionClient();
         DriveAccess access = linkedAccess();
-        service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA")));
+        service(client).syncGrants("42", access, List.of("111"), config(mapping("111", "READER", "fA")));
 
-        service(client).syncGrants(access, List.of("222"), config(mapping("111", "READER", "fA"), mapping("222", "WRITER", "fA")));
+        service(client).syncGrants("42", access, List.of("222"), config(mapping("111", "READER", "fA"), mapping("222", "WRITER", "fA")));
 
         assertEquals(1, access.getGrants().size());
         assertEquals("WRITER", access.getGrants().getFirst().accessLevel());
@@ -130,7 +130,7 @@ class DrivePermissionServiceTest {
         client.failTransiently("fA", 2); // fewer than max attempts
         DriveAccess access = linkedAccess();
 
-        SyncOutcome outcome = service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA")));
+        SyncOutcome outcome = service(client).syncGrants("42", access, List.of("111"), config(mapping("111", "READER", "fA")));
 
         assertEquals(List.of("fA"), outcome.grantedFolders());
         assertTrue(outcome.failedFolders().isEmpty());
@@ -142,7 +142,7 @@ class DrivePermissionServiceTest {
         client.failPermanently("fA", 400);
         DriveAccess access = linkedAccess();
 
-        SyncOutcome outcome = service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
+        SyncOutcome outcome = service(client).syncGrants("42", access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
 
         assertEquals(List.of("fA"), outcome.failedFolders());
         assertEquals(List.of("fB"), outcome.grantedFolders());
@@ -153,10 +153,10 @@ class DrivePermissionServiceTest {
     void failedRevokeKeepsGrantRecordedForReconcile() {
         FakeDrivePermissionClient client = new FakeDrivePermissionClient();
         DriveAccess access = linkedAccess();
-        service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA")));
+        service(client).syncGrants("42", access, List.of("111"), config(mapping("111", "READER", "fA")));
         client.failPermanently("fA", 403);
 
-        SyncOutcome outcome = service(client).syncGrants(access, List.of(), config(mapping("111", "READER", "fA")));
+        SyncOutcome outcome = service(client).syncGrants("42", access, List.of(), config(mapping("111", "READER", "fA")));
 
         assertEquals(List.of("fA"), outcome.failedFolders());
         assertEquals(1, access.getGrants().size());
@@ -167,7 +167,7 @@ class DrivePermissionServiceTest {
         FakeDrivePermissionClient client = new FakeDrivePermissionClient();
         DriveAccess access = new DriveAccess("garbage-not-ciphertext", "hash");
 
-        SyncOutcome outcome = service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA")));
+        SyncOutcome outcome = service(client).syncGrants("42", access, List.of("111"), config(mapping("111", "READER", "fA")));
 
         assertTrue(outcome.grantedFolders().isEmpty());
         assertEquals(List.of("fA"), outcome.failedFolders());
@@ -180,9 +180,9 @@ class DrivePermissionServiceTest {
     void revokeAllClearsEverything() {
         FakeDrivePermissionClient client = new FakeDrivePermissionClient();
         DriveAccess access = linkedAccess();
-        service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
+        service(client).syncGrants("42", access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
 
-        assertTrue(service(client).revokeAll(access));
+        assertTrue(service(client).revokeAll("42", access));
         assertTrue(access.getGrants().isEmpty());
         assertTrue(client.folders.get("fA").isEmpty());
     }
@@ -191,10 +191,10 @@ class DrivePermissionServiceTest {
     void revokeAllReportsFailureButRemovesWhatItCan() {
         FakeDrivePermissionClient client = new FakeDrivePermissionClient();
         DriveAccess access = linkedAccess();
-        service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
+        service(client).syncGrants("42", access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
         client.failPermanently("fA", 403);
 
-        assertFalse(service(client).revokeAll(access));
+        assertFalse(service(client).revokeAll("42", access));
         assertTrue(client.folders.get("fB").isEmpty());
     }
 

--- a/app/src/test/java/net/hypixel/nerdbot/app/drive/DrivePermissionServiceTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/drive/DrivePermissionServiceTest.java
@@ -144,7 +144,8 @@ class DrivePermissionServiceTest {
 
         SyncOutcome outcome = service(client).syncGrants("42", access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
 
-        assertEquals(List.of("fA"), outcome.failedFolders());
+        assertEquals(List.of("fA"), outcome.failedFolders().stream().map(DrivePermissionService.FailedFolder::folderId).toList());
+        assertEquals(400, outcome.failedFolders().getFirst().statusCode());
         assertEquals(List.of("fB"), outcome.grantedFolders());
         assertEquals(1, access.getGrants().size()); // only fB recorded — reconcile will retry fA later
     }
@@ -158,7 +159,8 @@ class DrivePermissionServiceTest {
 
         SyncOutcome outcome = service(client).syncGrants("42", access, List.of(), config(mapping("111", "READER", "fA")));
 
-        assertEquals(List.of("fA"), outcome.failedFolders());
+        assertEquals(List.of("fA"), outcome.failedFolders().stream().map(DrivePermissionService.FailedFolder::folderId).toList());
+        assertEquals(403, outcome.failedFolders().getFirst().statusCode());
         assertEquals(1, access.getGrants().size());
     }
 
@@ -170,7 +172,8 @@ class DrivePermissionServiceTest {
         SyncOutcome outcome = service(client).syncGrants("42", access, List.of("111"), config(mapping("111", "READER", "fA")));
 
         assertTrue(outcome.grantedFolders().isEmpty());
-        assertEquals(List.of("fA"), outcome.failedFolders());
+        assertEquals(List.of("fA"), outcome.failedFolders().stream().map(DrivePermissionService.FailedFolder::folderId).toList());
+        assertEquals(-1, outcome.failedFolders().getFirst().statusCode());
         assertTrue(client.operations.isEmpty());
     }
 

--- a/app/src/test/java/net/hypixel/nerdbot/app/drive/DrivePermissionServiceTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/drive/DrivePermissionServiceTest.java
@@ -1,0 +1,212 @@
+package net.hypixel.nerdbot.app.drive;
+
+import net.hypixel.nerdbot.app.config.GoogleDriveConfig;
+import net.hypixel.nerdbot.app.config.objects.DriveFolderMapping;
+import net.hypixel.nerdbot.app.drive.DrivePermissionService.SyncOutcome;
+import net.hypixel.nerdbot.marmalade.google.drive.DriveAccessLevel;
+import net.hypixel.nerdbot.marmalade.security.AesGcmCipher;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.drive.DriveAccess;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.drive.DriveGrant;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DrivePermissionServiceTest {
+
+    private static final AesGcmCipher CIPHER = new AesGcmCipher("0123456789abcdef0123456789abcdef".getBytes());
+
+    private static GoogleDriveConfig config(DriveFolderMapping... mappings) {
+        GoogleDriveConfig config = new GoogleDriveConfig();
+        config.setEnabled(true);
+        config.setFolderMappings(List.of(mappings));
+        return config;
+    }
+
+    private static DriveFolderMapping mapping(String roleId, String accessLevel, String... folderIds) {
+        DriveFolderMapping mapping = new DriveFolderMapping();
+        mapping.setRoleId(roleId);
+        mapping.setFolderIds(List.of(folderIds));
+        mapping.setAccessLevel(accessLevel);
+        return mapping;
+    }
+
+    private static DriveAccess linkedAccess() {
+        return new DriveAccess(CIPHER.encrypt("user@example.com"), CIPHER.hmac("user@example.com"));
+    }
+
+    private DrivePermissionService service(FakeDrivePermissionClient client) {
+        return new DrivePermissionService(CIPHER, client);
+    }
+
+    // ── computeDesiredGrants ────────────────────────────────────────────
+
+    @Test
+    void noMappedRolesMeansNoGrants() {
+        Map<String, DriveAccessLevel> desired = DrivePermissionService.computeDesiredGrants(
+            List.of("999"), config(mapping("111", "READER", "fA")));
+        assertTrue(desired.isEmpty());
+    }
+
+    @Test
+    void unionsAcrossHeldRoles() {
+        Map<String, DriveAccessLevel> desired = DrivePermissionService.computeDesiredGrants(
+            List.of("111", "222"),
+            config(mapping("111", "READER", "fA", "fB"), mapping("222", "COMMENTER", "fC")));
+        assertEquals(Map.of("fA", DriveAccessLevel.READER, "fB", DriveAccessLevel.READER, "fC", DriveAccessLevel.COMMENTER), desired);
+    }
+
+    @Test
+    void mostPermissiveLevelWinsPerFolder() {
+        Map<String, DriveAccessLevel> desired = DrivePermissionService.computeDesiredGrants(
+            List.of("111", "222"),
+            config(mapping("111", "WRITER", "fA"), mapping("222", "READER", "fA")));
+        assertEquals(Map.of("fA", DriveAccessLevel.WRITER), desired);
+    }
+
+    @Test
+    void invalidAccessLevelInConfigSkipsThatMapping() {
+        Map<String, DriveAccessLevel> desired = DrivePermissionService.computeDesiredGrants(
+            List.of("111", "222"),
+            config(mapping("111", "OWNER", "fA"), mapping("222", "READER", "fB")));
+        assertEquals(Map.of("fB", DriveAccessLevel.READER), desired);
+    }
+
+    @Test
+    void disabledConfigYieldsNothing() {
+        GoogleDriveConfig disabled = config(mapping("111", "READER", "fA"));
+        disabled.setEnabled(false);
+        assertTrue(DrivePermissionService.computeDesiredGrants(List.of("111"), disabled).isEmpty());
+    }
+
+    // ── syncGrants ──────────────────────────────────────────────────────
+
+    @Test
+    void grantsMissingFolders() {
+        FakeDrivePermissionClient client = new FakeDrivePermissionClient();
+        DriveAccess access = linkedAccess();
+
+        SyncOutcome outcome = service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
+
+        assertEquals(List.of("fA", "fB"), outcome.grantedFolders().stream().sorted().toList());
+        assertEquals(2, access.getGrants().size());
+        assertTrue(access.getLastSyncedAt() > 0);
+    }
+
+    @Test
+    void revokesStaleFolders() {
+        FakeDrivePermissionClient client = new FakeDrivePermissionClient();
+        DriveAccess access = linkedAccess();
+        service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
+
+        SyncOutcome outcome = service(client).syncGrants(access, List.of(), config(mapping("111", "READER", "fA", "fB")));
+
+        assertEquals(2, outcome.revokedFolders().size());
+        assertTrue(access.getGrants().isEmpty());
+        assertTrue(client.folders.get("fA").isEmpty());
+    }
+
+    @Test
+    void levelChangeRevokesThenRegrants() {
+        FakeDrivePermissionClient client = new FakeDrivePermissionClient();
+        DriveAccess access = linkedAccess();
+        service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA")));
+
+        service(client).syncGrants(access, List.of("222"), config(mapping("111", "READER", "fA"), mapping("222", "WRITER", "fA")));
+
+        assertEquals(1, access.getGrants().size());
+        assertEquals("WRITER", access.getGrants().getFirst().accessLevel());
+        assertEquals(1, client.folders.get("fA").size());
+        assertEquals("writer", client.folders.get("fA").getFirst().role());
+    }
+
+    @Test
+    void transientFailureIsRetriedThenSucceeds() {
+        FakeDrivePermissionClient client = new FakeDrivePermissionClient();
+        client.failTransiently("fA", 2); // fewer than max attempts
+        DriveAccess access = linkedAccess();
+
+        SyncOutcome outcome = service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA")));
+
+        assertEquals(List.of("fA"), outcome.grantedFolders());
+        assertTrue(outcome.failedFolders().isEmpty());
+    }
+
+    @Test
+    void permanentFailureLandsInFailedWithoutRecordingGrant() {
+        FakeDrivePermissionClient client = new FakeDrivePermissionClient();
+        client.failPermanently("fA", 400);
+        DriveAccess access = linkedAccess();
+
+        SyncOutcome outcome = service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
+
+        assertEquals(List.of("fA"), outcome.failedFolders());
+        assertEquals(List.of("fB"), outcome.grantedFolders());
+        assertEquals(1, access.getGrants().size()); // only fB recorded — reconcile will retry fA later
+    }
+
+    @Test
+    void failedRevokeKeepsGrantRecordedForReconcile() {
+        FakeDrivePermissionClient client = new FakeDrivePermissionClient();
+        DriveAccess access = linkedAccess();
+        service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA")));
+        client.failPermanently("fA", 403);
+
+        SyncOutcome outcome = service(client).syncGrants(access, List.of(), config(mapping("111", "READER", "fA")));
+
+        assertEquals(List.of("fA"), outcome.failedFolders());
+        assertEquals(1, access.getGrants().size());
+    }
+
+    @Test
+    void undecryptableEmailSyncsNothing() {
+        FakeDrivePermissionClient client = new FakeDrivePermissionClient();
+        DriveAccess access = new DriveAccess("garbage-not-ciphertext", "hash");
+
+        SyncOutcome outcome = service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA")));
+
+        assertTrue(outcome.grantedFolders().isEmpty());
+        assertEquals(List.of("fA"), outcome.failedFolders());
+        assertTrue(client.operations.isEmpty());
+    }
+
+    // ── revokeAll ───────────────────────────────────────────────────────
+
+    @Test
+    void revokeAllClearsEverything() {
+        FakeDrivePermissionClient client = new FakeDrivePermissionClient();
+        DriveAccess access = linkedAccess();
+        service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
+
+        assertTrue(service(client).revokeAll(access));
+        assertTrue(access.getGrants().isEmpty());
+        assertTrue(client.folders.get("fA").isEmpty());
+    }
+
+    @Test
+    void revokeAllReportsFailureButRemovesWhatItCan() {
+        FakeDrivePermissionClient client = new FakeDrivePermissionClient();
+        DriveAccess access = linkedAccess();
+        service(client).syncGrants(access, List.of("111"), config(mapping("111", "READER", "fA", "fB")));
+        client.failPermanently("fA", 403);
+
+        assertFalse(service(client).revokeAll(access));
+        assertTrue(client.folders.get("fB").isEmpty());
+    }
+
+    // ── email helpers ───────────────────────────────────────────────────
+
+    @Test
+    void normalizesAndValidatesEmails() {
+        assertEquals("user@example.com", DrivePermissionService.normalizeEmail("  User@Example.COM "));
+        assertTrue(DrivePermissionService.isValidEmail("user@example.com"));
+        assertFalse(DrivePermissionService.isValidEmail("not-an-email"));
+        assertFalse(DrivePermissionService.isValidEmail("a@b"));
+        assertFalse(DrivePermissionService.isValidEmail("two@at@signs.com"));
+        assertFalse(DrivePermissionService.isValidEmail(""));
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/drive/DriveSyncSweepTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/drive/DriveSyncSweepTest.java
@@ -1,0 +1,112 @@
+package net.hypixel.nerdbot.app.drive;
+
+import net.hypixel.nerdbot.app.config.GoogleDriveConfig;
+import net.hypixel.nerdbot.app.config.objects.DriveFolderMapping;
+import net.hypixel.nerdbot.marmalade.security.AesGcmCipher;
+import net.hypixel.nerdbot.marmalade.storage.database.model.user.DiscordUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DriveSyncSweepTest {
+
+    private static final AesGcmCipher CIPHER = new AesGcmCipher("0123456789abcdef0123456789abcdef".getBytes());
+
+    private FakeDrivePermissionClient client;
+    private DrivePermissionService service;
+    private GoogleDriveConfig config;
+    private List<DiscordUser> saved;
+
+    @BeforeEach
+    void setUp() {
+        client = new FakeDrivePermissionClient();
+        service = new DrivePermissionService(CIPHER, client);
+        config = new GoogleDriveConfig();
+        config.setEnabled(true);
+        DriveFolderMapping mapping = new DriveFolderMapping();
+        mapping.setRoleId("111");
+        mapping.setFolderIds(List.of("fA"));
+        mapping.setAccessLevel("READER");
+        config.setFolderMappings(List.of(mapping));
+        saved = new ArrayList<>();
+    }
+
+    private DiscordUser linkedUser(String id) {
+        DiscordUser user = new DiscordUser(id);
+        DriveLinkWorkflow workflow = new DriveLinkWorkflow(service, config);
+        workflow.link(user, id + "@example.com", List.of(), List.of(user));
+        return user;
+    }
+
+    @Test
+    void syncsLinkedMembersAgainstLiveRoles() {
+        DiscordUser user = linkedUser("42");
+        Map<String, List<String>> guildRoles = Map.of("42", List.of("111"));
+
+        DriveSyncSweep.Result result = DriveSyncSweep.reconcileUsers(
+            List.of(user), id -> Optional.ofNullable(guildRoles.get(id)), service, config, saved::add);
+
+        assertEquals(1, result.synced());
+        assertEquals(1, user.getDriveAccess().getGrants().size());
+        assertEquals(List.of(user), saved);
+    }
+
+    @Test
+    void revokesAndForgetsDepartedMembers() {
+        DiscordUser user = linkedUser("42");
+        DriveSyncSweep.Result result = DriveSyncSweep.reconcileUsers(
+            List.of(user), id -> Optional.empty(), service, config, saved::add);
+
+        assertEquals(1, result.departed());
+        assertNull(user.getDriveAccess());
+        assertEquals(List.of(user), saved);
+    }
+
+    @Test
+    void skipsUnlinkedUsersEntirely() {
+        DiscordUser user = new DiscordUser("42");
+        DriveSyncSweep.Result result = DriveSyncSweep.reconcileUsers(
+            List.of(user), id -> Optional.of(List.of("111")), service, config, saved::add);
+
+        assertEquals(0, result.synced());
+        assertTrue(saved.isEmpty());
+    }
+
+    @Test
+    void healsGrantDeletedManuallyInDrive() {
+        DiscordUser user = linkedUser("42");
+        DriveSyncSweep.Result first = DriveSyncSweep.reconcileUsers(
+            List.of(user), id -> Optional.of(List.of("111")), service, config, saved::add);
+        assertEquals(1, first.synced());
+
+        // Someone deletes the permission directly in Drive; our stored id now dangles
+        client.folders.get("fA").clear();
+
+        DriveSyncSweep.Result second = DriveSyncSweep.reconcileUsers(
+            List.of(user), id -> Optional.of(List.of("111")), service, config, saved::add);
+
+        assertEquals(1, second.synced());
+        assertEquals(1, client.folders.get("fA").size()); // regranted
+    }
+
+    @Test
+    void countsFailuresWithoutAborting() {
+        DiscordUser userA = linkedUser("1");
+        DiscordUser userB = linkedUser("2");
+        client.failPermanently("fA", 403);
+
+        DriveSyncSweep.Result result = DriveSyncSweep.reconcileUsers(
+            List.of(userA, userB), id -> Optional.of(List.of("111")), service, config, saved::add);
+
+        assertEquals(2, result.failed());
+        assertEquals(2, saved.size()); // state still persisted for both
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/drive/DriveSyncSweepTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/drive/DriveSyncSweepTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -108,5 +109,32 @@ class DriveSyncSweepTest {
 
         assertEquals(2, result.failed());
         assertEquals(2, saved.size()); // state still persisted for both
+    }
+
+    @Test
+    void lookupFailureLeavesUserUntouched() {
+        // Link with the mapped role so we get a grant
+        DiscordUser user = new DiscordUser("42");
+        DriveLinkWorkflow workflow = new DriveLinkWorkflow(service, config);
+        workflow.link(user, "42@example.com", List.of("111"), List.of(user));
+
+        // Verify user is linked and has a grant stored
+        assertNotNull(user.getDriveAccess());
+        assertTrue(user.getDriveAccess().getGrants().size() > 0);
+        int initialGrantCount = user.getDriveAccess().getGrants().size();
+
+        DriveSyncSweep.Result result = DriveSyncSweep.reconcileUsers(
+            List.of(user), id -> {
+                throw new RuntimeException("discord hiccup");
+            }, service, config, saved::add);
+
+        // Failed lookup must not revoke or forget
+        assertEquals(0, result.departed());
+        assertEquals(1, result.failed());
+        // User's drive access must be intact (not null, grants untouched in count)
+        assertNotNull(user.getDriveAccess());
+        assertEquals(initialGrantCount, user.getDriveAccess().getGrants().size());
+        // Saver must not have been called
+        assertTrue(saved.isEmpty());
     }
 }

--- a/app/src/test/java/net/hypixel/nerdbot/app/drive/FakeDrivePermissionClient.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/drive/FakeDrivePermissionClient.java
@@ -1,0 +1,68 @@
+package net.hypixel.nerdbot.app.drive;
+
+import net.hypixel.nerdbot.marmalade.google.drive.DriveAccessLevel;
+import net.hypixel.nerdbot.marmalade.google.drive.DriveApiException;
+import net.hypixel.nerdbot.marmalade.google.drive.DrivePermission;
+import net.hypixel.nerdbot.marmalade.google.drive.DrivePermissionClient;
+import net.hypixel.nerdbot.marmalade.google.drive.TransientDriveApiException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * In-memory Drive: tracks permissions per folder, hands out sequential ids, and
+ * can be programmed to fail specific folders permanently or transiently-N-times.
+ */
+public class FakeDrivePermissionClient implements DrivePermissionClient {
+
+    public final Map<String, List<DrivePermission>> folders = new HashMap<>();
+    public final List<String> operations = new ArrayList<>();
+    private final Map<String, Integer> transientFailuresRemaining = new HashMap<>();
+    private final Map<String, Integer> permanentFailureStatus = new HashMap<>();
+    private int nextId = 1;
+
+    public void failTransiently(String folderId, int times) {
+        transientFailuresRemaining.put(folderId, times);
+    }
+
+    public void failPermanently(String folderId, int status) {
+        permanentFailureStatus.put(folderId, status);
+    }
+
+    private void maybeFail(String folderId) throws DriveApiException {
+        Integer remaining = transientFailuresRemaining.get(folderId);
+        if (remaining != null && remaining > 0) {
+            transientFailuresRemaining.put(folderId, remaining - 1);
+            throw new TransientDriveApiException(503, "scripted transient failure for {}", folderId);
+        }
+        Integer status = permanentFailureStatus.get(folderId);
+        if (status != null) {
+            throw new DriveApiException(status, "scripted permanent failure for {}", folderId);
+        }
+    }
+
+    @Override
+    public String grantPermission(String folderId, String email, DriveAccessLevel level) throws DriveApiException {
+        maybeFail(folderId);
+        String id = "perm-" + nextId++;
+        folders.computeIfAbsent(folderId, k -> new ArrayList<>()).add(new DrivePermission(id, email, level.getApiRole()));
+        operations.add("grant:" + folderId + ":" + email + ":" + level);
+        return id;
+    }
+
+    @Override
+    public void revokePermission(String folderId, String permissionId) throws DriveApiException {
+        maybeFail(folderId);
+        folders.getOrDefault(folderId, new ArrayList<>()).removeIf(p -> p.id().equals(permissionId));
+        operations.add("revoke:" + folderId + ":" + permissionId);
+    }
+
+    @Override
+    public List<DrivePermission> listPermissions(String folderId) throws DriveApiException {
+        maybeFail(folderId);
+        operations.add("list:" + folderId);
+        return List.copyOf(folders.getOrDefault(folderId, new ArrayList<>()));
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/drive/FakeDrivePermissionClient.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/drive/FakeDrivePermissionClient.java
@@ -17,6 +17,14 @@ import java.util.Map;
  */
 public class FakeDrivePermissionClient implements DrivePermissionClient {
 
+    /** Optional folder-name overrides for getFileName; unset ids echo a stub name. */
+    public final Map<String, String> fileNames = new HashMap<>();
+
+    @Override
+    public String getFileName(String fileId) {
+        return fileNames.getOrDefault(fileId, "Folder " + fileId);
+    }
+
     public final Map<String, List<DrivePermission>> folders = new HashMap<>();
     public final List<String> operations = new ArrayList<>();
     private final Map<String, Integer> transientFailuresRemaining = new HashMap<>();

--- a/example-config.json
+++ b/example-config.json
@@ -108,6 +108,19 @@
       "defaultPack": "example_value"
     }
   },
+  "googleDriveConfig": {
+    "enabled": false,
+    "folderMappings": [
+      {
+        "roleId": "1234567890123456789",
+        "folderIds": [
+          "example_folder_id_1",
+          "example_folder_id_2"
+        ],
+        "accessLevel": "READER"
+      }
+    ]
+  },
   "messageLimit": 1,
   "mojangUsernameCacheTTL": 1,
   "mojangForceNicknameUpdate": true,

--- a/example-config.json
+++ b/example-config.json
@@ -114,12 +114,13 @@
       {
         "roleId": "1234567890123456789",
         "folderIds": [
-          "example_folder_id_1",
-          "example_folder_id_2"
+          "1234567890123456789"
         ],
         "accessLevel": "READER"
       }
-    ]
+    ],
+    "sendNotificationEmails": true,
+    "notificationEmailMessage": "This folder was shared automatically by the SkyBlock Nerds bot based on your Discord roles."
   },
   "messageLimit": 1,
   "mojangUsernameCacheTTL": 1,

--- a/tooling/src/main/java/net/hypixel/nerdbot/tooling/config/ConfigGenerator.java
+++ b/tooling/src/main/java/net/hypixel/nerdbot/tooling/config/ConfigGenerator.java
@@ -2,6 +2,7 @@ package net.hypixel.nerdbot.tooling.config;
 
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
+import net.hypixel.nerdbot.app.config.ExampleValue;
 import net.hypixel.nerdbot.app.config.NerdBotConfig;
 import net.hypixel.nerdbot.marmalade.json.DataSerialization;
 
@@ -203,6 +204,10 @@ public class ConfigGenerator {
     }
 
     private Object generateValueForField(Field field, int depth) {
+        if (field.isAnnotationPresent(ExampleValue.class)) {
+            return parseExampleValue(field, field.getAnnotation(ExampleValue.class).value());
+        }
+
         Class<?> type = field.getType();
         Type genericType = field.getGenericType();
         String fieldName = field.getName().toLowerCase();
@@ -210,6 +215,20 @@ public class ConfigGenerator {
         boolean isDiscordId = fieldName.endsWith("id") || fieldName.endsWith("ids");
 
         return generateValue(type, genericType, fieldName, isDiscordId, depth);
+    }
+
+    /**
+     * Honors an {@link ExampleValue} override: booleans are parsed, everything
+     * else (currently just strings) is emitted as the raw annotation value.
+     */
+    private Object parseExampleValue(Field field, String rawValue) {
+        Class<?> type = field.getType();
+
+        if (type == boolean.class || type == Boolean.class) {
+            return Boolean.parseBoolean(rawValue);
+        }
+
+        return rawValue;
     }
 
     private Object generateValue(Class<?> type, Type genericType, String fieldName, boolean isDiscordId, int depth) {


### PR DESCRIPTION
Members link their Google email with /drive link (a modal, so the address never hits chat) and the bot keeps their shared-Drive folder access in line with their roles: gaining a mapped role grants access, losing it revokes, and leaving or getting banned revokes everything and deletes the stored email. Relinking with a new address revokes the old one's grants first.

Emails are AES-256-GCM encrypted at rest with the key supplied via system property, and a keyed hash handles duplicate detection without decryption. Event listeners do the instant updates; an hourly sweep heals whatever they miss, including permissions someone deleted by hand in Drive and members who left while the bot was offline. Every grant and revoke is logged with member, folder, and permission ids for auditability. The whole subsystem is inert unless googleDriveConfig.enabled is true and the two secret properties are set.

Depends on the Marmalade Drive/cipher work merged in SkyBlock-Nerds/Marmalade#42. Setup and deployment are documented in the new README section.