### PR TITLE
Make periodMs the only curate schedule setting

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/SkyBlockNerdsBot.java
@@ -155,23 +155,15 @@ public class SkyBlockNerdsBot extends AbstractDiscordBot {
                     log.info("Added feature from config: {}", featureConfig.getClassName());
 
                     if (feature instanceof SchedulableFeature schedulable) {
-                        long defaultInitial = schedulable.defaultInitialDelayMs(config);
-                        long defaultPeriod = schedulable.defaultPeriodMs(config);
-
-                        Long overrideInitial = featureConfig.getInitialDelayMs();
-                        Long overridePeriod = featureConfig.getPeriodMs();
-                        long effectiveInitial = overrideInitial != null ? overrideInitial : defaultInitial;
-                        long effectivePeriod = overridePeriod != null ? overridePeriod : defaultPeriod;
-
-                        if (overrideInitial != null || overridePeriod != null) {
-                            log.info(
-                                "Applying schedule override for {}: initialDelayMs={} (default {}), periodMs={} (default {})",
-                                feature.getClass().getName(), effectiveInitial, defaultInitial, effectivePeriod, defaultPeriod
-                            );
-                        }
-
+                        // Override precedence lives in BotFeature.scheduleAtFixedRate, which also logs
+                        // the resolved schedule. Don't duplicate that logic here.
                         String taskName = feature.getClass().getSimpleName() + "-task";
-                        feature.scheduleAtFixedRate(taskName, schedulable::executeTask, defaultInitial, defaultPeriod);
+                        feature.scheduleAtFixedRate(
+                            taskName,
+                            schedulable::executeTask,
+                            schedulable.defaultInitialDelayMs(config),
+                            schedulable.defaultPeriodMs(config)
+                        );
                     }
 
                     return null;

--- a/app/src/main/java/net/hypixel/nerdbot/app/config/NerdBotConfig.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/config/NerdBotConfig.java
@@ -70,12 +70,6 @@ public class NerdBotConfig extends DiscordBotConfig {
     private long voiceThreshold = 60;
 
     /**
-     * The interval between each curate cycle in milliseconds
-     * Default value is 43200000 (12 hours)
-     */
-    private long interval = 43_200_000;
-
-    /**
      * Whether nominations to the next role are enabled
      * Default value is true
      */

--- a/app/src/main/java/net/hypixel/nerdbot/app/feature/CurateFeature.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/feature/CurateFeature.java
@@ -9,7 +9,6 @@ import net.hypixel.nerdbot.discord.BotEnvironment;
 import net.hypixel.nerdbot.discord.api.feature.BotFeature;
 import net.hypixel.nerdbot.discord.api.feature.SchedulableFeature;
 import net.hypixel.nerdbot.discord.cache.ChannelCache;
-import net.hypixel.nerdbot.app.config.NerdBotConfig;
 import net.hypixel.nerdbot.discord.config.DiscordBotConfig;
 import net.hypixel.nerdbot.app.config.SuggestionConfig;
 import net.hypixel.nerdbot.app.curator.Curator;
@@ -18,11 +17,17 @@ import net.hypixel.nerdbot.marmalade.storage.database.model.greenlit.GreenlitMes
 import net.hypixel.nerdbot.marmalade.storage.database.repository.GreenlitMessageRepository;
 import net.hypixel.nerdbot.app.SkyBlockNerdsBot;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
 @Slf4j
 public class CurateFeature extends BotFeature implements SchedulableFeature {
+
+    /**
+     * Fallback curate cadence, used when the feature's config entry omits {@code periodMs}.
+     */
+    private static final long DEFAULT_PERIOD_MS = Duration.ofHours(12).toMillis();
 
     @Override
     public void onFeatureStart() {
@@ -73,7 +78,7 @@ public class CurateFeature extends BotFeature implements SchedulableFeature {
 
     @Override
     public long defaultPeriodMs(DiscordBotConfig config) {
-        return ((NerdBotConfig) config).getInterval();
+        return DEFAULT_PERIOD_MS;
     }
 
     @Override

--- a/discord-framework/src/main/java/net/hypixel/nerdbot/discord/api/feature/BotFeature.java
+++ b/discord-framework/src/main/java/net/hypixel/nerdbot/discord/api/feature/BotFeature.java
@@ -1,10 +1,12 @@
 package net.hypixel.nerdbot.discord.api.feature;
 
+import lombok.extern.slf4j.Slf4j;
 import net.hypixel.nerdbot.marmalade.concurrent.ScheduledTask;
 import net.hypixel.nerdbot.marmalade.functional.ThrowingRunnable;
 
 import java.time.Duration;
 
+@Slf4j
 public abstract class BotFeature {
 
     protected ScheduledTask scheduledTask;
@@ -33,8 +35,22 @@ public abstract class BotFeature {
     public void scheduleAtFixedRate(String name, ThrowingRunnable<?> task, long defaultInitialDelayMs, long defaultPeriodMs) {
         long initialDelay = scheduleInitialDelayOverrideMs != null ? scheduleInitialDelayOverrideMs : defaultInitialDelayMs;
         long period = schedulePeriodOverrideMs != null ? schedulePeriodOverrideMs : defaultPeriodMs;
+
+        // Logged unconditionally: a config override silently shadows the feature's default, so the
+        // resolved values are the only reliable record of what the bot is actually running.
+        log.info(
+            "Scheduling task '{}': initialDelayMs={} ({}), periodMs={} ({})",
+            name,
+            initialDelay, describeSource(scheduleInitialDelayOverrideMs, defaultInitialDelayMs),
+            period, describeSource(schedulePeriodOverrideMs, defaultPeriodMs)
+        );
+
         this.scheduledTask = ScheduledTask.create(name, ThrowingRunnable.sneaky(task), Duration.ofMillis(initialDelay), Duration.ofMillis(period));
         this.scheduledTask.start();
+    }
+
+    private static String describeSource(Long override, long defaultValue) {
+        return override != null ? "config override, feature default " + defaultValue : "feature default";
     }
 
     public void stopScheduledTask() {

--- a/example-config.json
+++ b/example-config.json
@@ -112,7 +112,6 @@
   "mojangUsernameCacheTTL": 1,
   "mojangForceNicknameUpdate": true,
   "voiceThreshold": 1,
-  "interval": 1,
   "nominationsEnabled": true,
   "inactivityCheckEnabled": true,
   "inactivityDays": 1,


### PR DESCRIPTION
## What happened

Production was greenlighting every 10 minutes despite the config reading `"interval": 43200000`. The cause was `"periodMs": 600000` on the `CurateFeature` entry in `features[]`, which silently shadows `interval` — `interval` is only ever passed along as a *default*, and `BotFeature.scheduleAtFixedRate` prefers the override whenever one is present.

So the config had two keys controlling one schedule, the losing one failed silently, and the boot log said nothing useful unless an override happened to exist.

## Changes

**`interval` is gone.** `features[].periodMs` is now the single source of truth for every schedulable feature. `CurateFeature` keeps a 12 hour fallback constant for configs that omit it, so behaviour is unchanged for anyone who was relying on the old default.

**Schedule resolution is logged for every feature at boot**, whether or not an override exists, and whether or not the feature is listed in the config:

```
Scheduling task 'CurateFeature-task': initialDelayMs=10000 (config override, feature default 30000), periodMs=43200000 (config override, feature default 43200000)
Scheduling task 'RoleReconcileFeature-task': initialDelayMs=3600000 (feature default), periodMs=3600000 (feature default)
```

The always-on features (`RepositoryAutosaveFeature`, `RoleReconcileFeature`) previously logged nothing at all about their cadence.

**The duplicated precedence logic in `SkyBlockNerdsBot.createFeatures()` is removed.** It was computing `effectiveInitial`/`effectivePeriod` only to build a log message, then passing the *defaults* into `scheduleAtFixedRate` and letting `BotFeature` re-derive the same values. Correct, but two independent copies of one rule. Precedence and its logging now live together in `BotFeature`.

## Deploying this

`production.config.json` needs `interval` removed and `periodMs` set to `43200000` on the `CurateFeature` entry. This is already done on the box.

Worth knowing: **`/config reload` does not reschedule running tasks.** It swaps the config object and refreshes presence and metrics, but the `ScheduledTask` instances are created once in `onStart()`. Any schedule change needs a full restart, and a reload will make the config *look* right while the old timer keeps running.

## Notes

- One behaviour change to watch for: the log line identifies tasks by `CurateFeature-task` rather than the old fully-qualified class name, so anything grepping logs for the FQN won't match.
- After this ships, `43200000` appears twice in the curate log line — once as the override, once as the feature default. They agree; that's expected.
- No tests added. The precedence rule is a two-line ternary and we opted not to pin it.

`mvn verify` passes — 150 tests, no failures.
